### PR TITLE
Prepare deployment

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -43,3 +43,4 @@ OIDC_AUTH_REQUEST_EXTRA_PARAMS={"acr_values": "eidas1"}
 # Livekit Token settings
 LIVEKIT_API_SECRET="secret"
 LIVEKIT_API_KEY="devkey"
+LIVEKIT_API_URL=http://localhost:7880

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -1,4 +1,5 @@
 """Client serializers for the Meet core app."""
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -122,6 +123,7 @@ class RoomSerializer(serializers.ModelSerializer):
             slug = f"{instance.id!s}".replace("-", "")
 
             output["livekit"] = {
+                "url": settings.LIVEKIT_CONFIGURATION["url"],
                 "room": slug,
                 "token": utils.generate_token(room=slug, user=request.user),
             }

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -191,6 +191,7 @@ class RoomViewSet(
             data = {
                 "id": None,
                 "livekit": {
+                    "url": settings.LIVEKIT_CONFIGURATION["url"],
                     "room": slug,
                     "token": utils.generate_token(room=slug, user=request.user),
                 },

--- a/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
@@ -85,6 +85,13 @@ def test_api_rooms_retrieve_anonymous_private_slug_not_normalized():
 
 
 @override_settings(ALLOW_UNREGISTERED_ROOMS=True)
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 @mock.patch("core.utils.generate_token", return_value="foo")
 def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
     """
@@ -98,6 +105,7 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
     assert response.json() == {
         "id": None,
         "livekit": {
+            "url": "test_url_value",
             "room": "unregistered-room",
             "token": "foo",
         },
@@ -107,6 +115,13 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
 
 
 @override_settings(ALLOW_UNREGISTERED_ROOMS=True)
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 @mock.patch("core.utils.generate_token", return_value="foo")
 def test_api_rooms_retrieve_anonymous_unregistered_allowed_not_normalized(mock_token):
     """
@@ -120,6 +135,7 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed_not_normalized(mock_t
     assert response.json() == {
         "id": None,
         "livekit": {
+            "url": "test_url_value",
             "room": "reunion",
             "token": "foo",
         },
@@ -141,6 +157,13 @@ def test_api_rooms_retrieve_anonymous_unregistered_not_allowed():
 
 
 @mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 def test_api_rooms_retrieve_anonymous_public(mock_token):
     """
     Anonymous users should be able to retrieve a room with a token provided it is public.
@@ -156,6 +179,7 @@ def test_api_rooms_retrieve_anonymous_public(mock_token):
         "is_administrable": False,
         "is_public": True,
         "livekit": {
+            "url": "test_url_value",
             "room": expected_name,
             "token": "foo",
         },
@@ -167,6 +191,13 @@ def test_api_rooms_retrieve_anonymous_public(mock_token):
 
 
 @mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 def test_api_rooms_retrieve_authenticated_public(mock_token):
     """
     Authenticated users should be allowed to retrieve a room and get a token for a room to
@@ -190,6 +221,7 @@ def test_api_rooms_retrieve_authenticated_public(mock_token):
         "is_administrable": False,
         "is_public": True,
         "livekit": {
+            "url": "test_url_value",
             "room": expected_name,
             "token": "foo",
         },
@@ -226,6 +258,13 @@ def test_api_rooms_retrieve_authenticated():
 
 
 @mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 def test_api_rooms_retrieve_members(mock_token, django_assert_num_queries):
     """
     Users who are members of a room should be allowed to see related users.
@@ -280,6 +319,7 @@ def test_api_rooms_retrieve_members(mock_token, django_assert_num_queries):
         "is_administrable": False,
         "is_public": room.is_public,
         "livekit": {
+            "url": "test_url_value",
             "room": expected_name,
             "token": "foo",
         },
@@ -291,6 +331,13 @@ def test_api_rooms_retrieve_members(mock_token, django_assert_num_queries):
 
 
 @mock.patch("core.utils.generate_token", return_value="foo")
+@override_settings(
+    LIVEKIT_CONFIGURATION={
+        "api_key": "key",
+        "api_secret": "secret",
+        "url": "test_url_value",
+    }
+)
 def test_api_rooms_retrieve_administrators(mock_token, django_assert_num_queries):
     """
     A user who is an administrator or owner of a room should be allowed
@@ -345,6 +392,7 @@ def test_api_rooms_retrieve_administrators(mock_token, django_assert_num_queries
         "is_public": room.is_public,
         "configuration": {},
         "livekit": {
+            "url": "test_url_value",
             "room": expected_name,
             "token": "foo",
         },

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -536,7 +536,6 @@ class Production(Base):
     # - Your proxy sets the X-Forwarded-Proto header and sends it to Django
     #
     # In other cases, you should comment the following line to avoid security issues.
-    # SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
     # Modern browsers require to have the `secure` attribute on cookies with `Samesite=none`

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -116,27 +116,6 @@ class Base(Configuration):
         },
     }
 
-    # Media
-    AWS_S3_ENDPOINT_URL = values.Value(
-        environ_name="AWS_S3_ENDPOINT_URL", environ_prefix=None
-    )
-    AWS_S3_ACCESS_KEY_ID = values.Value(
-        environ_name="AWS_S3_ACCESS_KEY_ID", environ_prefix=None
-    )
-    AWS_S3_SECRET_ACCESS_KEY = values.Value(
-        environ_name="AWS_S3_SECRET_ACCESS_KEY", environ_prefix=None
-    )
-    AWS_S3_REGION_NAME = values.Value(
-        environ_name="AWS_S3_REGION_NAME", environ_prefix=None
-    )
-    AWS_STORAGE_BUCKET_NAME = values.Value(
-        "meet-media-storage",
-        environ_name="AWS_STORAGE_BUCKET_NAME",
-        environ_prefix=None,
-    )
-
-    S3_VERSIONS_PAGE_SIZE = 50
-
     # Internationalization
     # https://docs.djangoproject.com/en/3.1/topics/i18n/
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -372,6 +372,7 @@ class Base(Configuration):
         "api_secret": values.Value(
             environ_name="LIVEKIT_API_SECRET", environ_prefix=None
         ),
+        "url": values.Value(environ_name="LIVEKIT_API_URL", environ_prefix=None),
     }
     DEFAULT_ROOM_IS_PUBLIC = values.BooleanValue(
         True, environ_name="DEFAULT_ROOM_IS_PUBLIC", environ_prefix=None

--- a/src/frontend/.env.development
+++ b/src/frontend/.env.development
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://localhost:8071/api/v1.0/
+VITE_API_BASE_URL=http://localhost:8071/
 VITE_LIVEKIT_SERVER_URL=http://localhost:7880

--- a/src/frontend/.env.development
+++ b/src/frontend/.env.development
@@ -1,2 +1,1 @@
 VITE_API_BASE_URL=http://localhost:8071/
-VITE_LIVEKIT_SERVER_URL=http://localhost:7880

--- a/src/frontend/.eslintrc.cjs
+++ b/src/frontend/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     'plugin:@tanstack/eslint-plugin-query/recommended',
     'plugin:jsx-a11y/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'styled-system'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {

--- a/src/frontend/src/api/ApiRoom.ts
+++ b/src/frontend/src/api/ApiRoom.ts
@@ -4,6 +4,7 @@ export type ApiRoom = {
   slug: string
   is_public: boolean
   livekit?: {
+    url: string
     room: string
     token: string
   }

--- a/src/frontend/src/api/apiUrl.ts
+++ b/src/frontend/src/api/apiUrl.ts
@@ -1,3 +1,12 @@
-export const apiUrl = (path: string) => {
-  return `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, '')}${path}`
+export const apiUrl = (path: string, apiVersion = '1.0') => {
+  
+  const origin =
+    import.meta.env.VITE_API_BASE_URL
+    || (typeof window !== 'undefined' ? window.location.origin : '');
+
+  // Remove leading/trailing slashes from origin/path if it exists
+  const sanitizedOrigin = origin.replace(/\/$/, '')
+  const sanitizedPath = path.replace(/^\//, '');
+
+  return `${sanitizedOrigin}/api/v${apiVersion}/${sanitizedPath}`;
 }

--- a/src/frontend/src/routes/Conference.tsx
+++ b/src/frontend/src/routes/Conference.tsx
@@ -54,11 +54,11 @@ export const Conference = () => {
     return <ForbiddenScreen />
   }
 
-  if (data?.livekit?.token) {
+  if (data?.livekit?.token && data?.livekit?.url) {
     return (
       <Screen>
         <LiveKitRoom
-          serverUrl={import.meta.env.VITE_LIVEKIT_SERVER_URL}
+          serverUrl={data?.livekit?.url}
           token={data?.livekit?.token}
           connect={true}
           audio={{

--- a/src/frontend/src/vite-env.d.ts
+++ b/src/frontend/src/vite-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string
-  readonly VITE_LIVEKIT_SERVER_URL: string
 }
 
 interface ImportMeta {

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -79,7 +79,7 @@ frontend:
   envVars:
     VITE_PORT: 8080
     VITE_HOST: 0.0.0.0
-    VITE_API_BASE_URL: https://meet.127.0.0.1.nip.io/api/v1.0/
+    VITE_API_BASE_URL: https://meet.127.0.0.1.nip.io/
     VITE_LIVEKIT_SERVER_URL: https://livekit.127.0.0.1.nip.io/
 
   replicas: 1

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -49,6 +49,7 @@ backend:
     LIVEKIT_API_KEY: {{ $key }}
     {{- end }}
     {{- end }}
+    LIVEKIT_API_URL: https://livekit.127.0.0.1.nip.io/
 
 
   migrate:
@@ -80,7 +81,6 @@ frontend:
     VITE_PORT: 8080
     VITE_HOST: 0.0.0.0
     VITE_API_BASE_URL: https://meet.127.0.0.1.nip.io/
-    VITE_LIVEKIT_SERVER_URL: https://livekit.127.0.0.1.nip.io/
 
   replicas: 1
 

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -38,10 +38,6 @@ backend:
     POSTGRES_USER: dinum
     POSTGRES_PASSWORD: pass
     REDIS_URL: redis://default:pass@redis-master:6379/1
-    AWS_S3_ENDPOINT_URL: http://minio.meet.svc.cluster.local:9000
-    AWS_S3_ACCESS_KEY_ID: meet
-    AWS_S3_SECRET_ACCESS_KEY: password
-    AWS_STORAGE_BUCKET_NAME: meet-media-storage
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     {{- with .Values.livekit.keys }}
     {{- range $key, $value := . }}

--- a/src/helm/env.d/preprod/secrets.enc.yaml
+++ b/src/helm/env.d/preprod/secrets.enc.yaml
@@ -1,1 +1,0 @@
-../../../../secrets/numerique-gouv/impress/env/preprod/secrets.enc.yaml

--- a/src/helm/env.d/preprod/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.meet.yaml.gotmpl
@@ -83,23 +83,6 @@ backend:
       secretKeyRef:
         name: redis.redis.libre.sh
         key: url
-    AWS_S3_ENDPOINT_URL:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: url
-    AWS_S3_ACCESS_KEY_ID:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: accessKey
-    AWS_S3_SECRET_ACCESS_KEY:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: secretKey
-    AWS_STORAGE_BUCKET_NAME:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: bucket
-    AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     LIVEKIT_API_SECRET:
       secretKeyRef:

--- a/src/helm/env.d/preprod/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.meet.yaml.gotmpl
@@ -101,6 +101,14 @@ backend:
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+    LIVEKIT_API_SECRET:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_SECRET
+    LIVEKIT_API_KEY:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_KEY
 
   createsuperuser:
     command:

--- a/src/helm/env.d/preprod/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.meet.yaml.gotmpl
@@ -1,25 +1,25 @@
 image:
   repository: lasuite/meet-backend
   pullPolicy: Always
-  tag: "main"
+  tag: "v0.1.0"
 
 backend:
   migrateJobAnnotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   envVars:
-    DJANGO_CSRF_TRUSTED_ORIGINS: http://impress-staging.beta.numerique.gouv.fr,https://impress-staging.beta.numerique.gouv.fr
+    DJANGO_CSRF_TRUSTED_ORIGINS: http://meet-preprod.beta.numerique.gouv.fr,https://meet-preprod.beta.numerique.gouv.fr
     DJANGO_CONFIGURATION: Production
     DJANGO_ALLOWED_HOSTS: "*"
-    DJANGO_SECRET_KEY:
-      secretKeyRef:
-        name: backend
-        key: DJANGO_SECRET_KEY
-    DJANGO_SETTINGS_MODULE: impress.settings
     DJANGO_SUPERUSER_EMAIL:
       secretKeyRef:
         name: backend
         key: DJANGO_SUPERUSER_EMAIL
+    DJANGO_SECRET_KEY:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_SECRET_KEY
+    DJANGO_SETTINGS_MODULE: meet.settings
     DJANGO_SUPERUSER_PASSWORD:
       secretKeyRef:
         name: backend
@@ -27,7 +27,6 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
-    DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
     OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
     OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token
@@ -43,11 +42,11 @@ backend:
         key: OIDC_RP_CLIENT_SECRET
     OIDC_RP_SIGN_ALGO: RS256
     OIDC_RP_SCOPES: "openid email"
-    OIDC_REDIRECT_ALLOWED_HOSTS: https://impress-staging.beta.numerique.gouv.fr
+    OIDC_REDIRECT_ALLOWED_HOSTS: https://meet-preprod.beta.numerique.gouv.fr
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    LOGIN_REDIRECT_URL: https://impress-staging.beta.numerique.gouv.fr
-    LOGIN_REDIRECT_URL_FAILURE: https://impress-staging.beta.numerique.gouv.fr
-    LOGOUT_REDIRECT_URL: https://impress-staging.beta.numerique.gouv.fr
+    LOGIN_REDIRECT_URL: https://meet-preprod.beta.numerique.gouv.fr
+    LOGIN_REDIRECT_URL_FAILURE: https://meet-preprod.beta.numerique.gouv.fr
+    LOGOUT_REDIRECT_URL: https://meet-preprod.beta.numerique.gouv.fr
     DB_HOST:
       secretKeyRef:
         name: postgresql.postgres.libre.sh
@@ -86,19 +85,19 @@ backend:
         key: url
     AWS_S3_ENDPOINT_URL:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: url
     AWS_S3_ACCESS_KEY_ID:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: accessKey
     AWS_S3_SECRET_ACCESS_KEY:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: secretKey
     AWS_STORAGE_BUCKET_NAME:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
@@ -115,31 +114,18 @@ frontend:
   image:
     repository: lasuite/meet-frontend
     pullPolicy: Always
-    tag: "main"
-
-webrtc:
-  image:
-    repository: lasuite/impress-y-webrtc-signaling
-    pullPolicy: Always
-    tag: "main"
+    tag: "v0.1.0"
 
 ingress:
   enabled: true
-  host: impress-staging.beta.numerique.gouv.fr
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-
-ingressWS:
-  enabled: true
-  host: impress-staging.beta.numerique.gouv.fr
+  host: meet-preprod.beta.numerique.gouv.fr
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
 
 ingressAdmin:
   enabled: true
-  host: impress-staging.beta.numerique.gouv.fr
+  host: meet-preprod.beta.numerique.gouv.fr
   className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/src/helm/env.d/preprod/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.meet.yaml.gotmpl
@@ -109,6 +109,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
+    LIVEKIT_API_URL: https://livekit.beta.numerique.gouv.fr
 
   createsuperuser:
     command:

--- a/src/helm/env.d/production/secrets.enc.yaml
+++ b/src/helm/env.d/production/secrets.enc.yaml
@@ -1,1 +1,1 @@
-../../../../secrets/numerique-gouv/impress/env/production/secrets.enc.yaml
+../../../../secrets/numerique-gouv/meet/env/production/secrets.enc.yaml

--- a/src/helm/env.d/production/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/production/values.meet.yaml.gotmpl
@@ -83,23 +83,6 @@ backend:
       secretKeyRef:
         name: redis.redis.libre.sh
         key: url
-    AWS_S3_ENDPOINT_URL:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: url
-    AWS_S3_ACCESS_KEY_ID:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: accessKey
-    AWS_S3_SECRET_ACCESS_KEY:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: secretKey
-    AWS_STORAGE_BUCKET_NAME:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: bucket
-    AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     LIVEKIT_API_SECRET:
       secretKeyRef:

--- a/src/helm/env.d/production/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/production/values.meet.yaml.gotmpl
@@ -101,6 +101,14 @@ backend:
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+    LIVEKIT_API_SECRET:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_SECRET
+    LIVEKIT_API_KEY:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_KEY
 
   createsuperuser:
     command:

--- a/src/helm/env.d/production/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/production/values.meet.yaml.gotmpl
@@ -109,6 +109,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
+    LIVEKIT_API_URL: https://livekit.beta.numerique.gouv.fr
 
   createsuperuser:
     command:

--- a/src/helm/env.d/production/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/production/values.meet.yaml.gotmpl
@@ -5,21 +5,21 @@ image:
 
 backend:
   migrateJobAnnotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   envVars:
-    DJANGO_CSRF_TRUSTED_ORIGINS: http://impress-preprod.beta.numerique.gouv.fr,https://impress-preprod.beta.numerique.gouv.fr
+    DJANGO_CSRF_TRUSTED_ORIGINS: https://meet.numerique.gouv.fr
     DJANGO_CONFIGURATION: Production
     DJANGO_ALLOWED_HOSTS: "*"
-    DJANGO_SUPERUSER_EMAIL:
-      secretKeyRef:
-        name: backend
-        key: DJANGO_SUPERUSER_EMAIL
     DJANGO_SECRET_KEY:
       secretKeyRef:
         name: backend
         key: DJANGO_SECRET_KEY
-    DJANGO_SETTINGS_MODULE: impress.settings
+    DJANGO_SETTINGS_MODULE: meet.settings
+    DJANGO_SUPERUSER_EMAIL:
+      secretKeyRef:
+        name: backend
+        key: DJANGO_SUPERUSER_EMAIL
     DJANGO_SUPERUSER_PASSWORD:
       secretKeyRef:
         name: backend
@@ -27,12 +27,11 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
-    DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
-    OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
-    OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
-    OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token
-    OIDC_OP_USER_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/userinfo
-    OIDC_OP_LOGOUT_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/session/end
+    OIDC_OP_JWKS_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/jwks
+    OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/authorize
+    OIDC_OP_TOKEN_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/token
+    OIDC_OP_USER_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/userinfo
+    OIDC_OP_LOGOUT_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/session/end
     OIDC_RP_CLIENT_ID:
       secretKeyRef:
         name: backend
@@ -43,11 +42,11 @@ backend:
         key: OIDC_RP_CLIENT_SECRET
     OIDC_RP_SIGN_ALGO: RS256
     OIDC_RP_SCOPES: "openid email"
-    OIDC_REDIRECT_ALLOWED_HOSTS: https://impress-preprod.beta.numerique.gouv.fr
+    OIDC_REDIRECT_ALLOWED_HOSTS: https://meet.numerique.gouv.fr
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    LOGIN_REDIRECT_URL: https://impress-preprod.beta.numerique.gouv.fr
-    LOGIN_REDIRECT_URL_FAILURE: https://impress-preprod.beta.numerique.gouv.fr
-    LOGOUT_REDIRECT_URL: https://impress-preprod.beta.numerique.gouv.fr
+    LOGIN_REDIRECT_URL: https://meet.numerique.gouv.fr
+    LOGIN_REDIRECT_URL_FAILURE: https://meet.numerique.gouv.fr
+    LOGOUT_REDIRECT_URL: https://meet.numerique.gouv.fr
     DB_HOST:
       secretKeyRef:
         name: postgresql.postgres.libre.sh
@@ -86,19 +85,19 @@ backend:
         key: url
     AWS_S3_ENDPOINT_URL:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: url
     AWS_S3_ACCESS_KEY_ID:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: accessKey
     AWS_S3_SECRET_ACCESS_KEY:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: secretKey
     AWS_STORAGE_BUCKET_NAME:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
@@ -117,31 +116,18 @@ frontend:
     pullPolicy: Always
     tag: "v0.1.0"
 
-webrtc:
-  image:
-    repository: lasuite/impress-y-webrtc-signaling
-    pullPolicy: Always
-    tag: "v0.1.0"
-
 ingress:
   enabled: true
-  host: impress-preprod.beta.numerique.gouv.fr
+  host: meet.numerique.gouv.fr
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-
-ingressWS:
-  enabled: true
-  host: impress-preprod.beta.numerique.gouv.fr
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt
 
 ingressAdmin:
   enabled: true
-  host: impress-preprod.beta.numerique.gouv.fr
+  host: meet.numerique.gouv.fr
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/start
-    nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/auth
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/start
+    nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/auth

--- a/src/helm/env.d/staging/secrets.enc.yaml
+++ b/src/helm/env.d/staging/secrets.enc.yaml
@@ -1,1 +1,1 @@
-../../../../secrets/numerique-gouv/impress/env/staging/secrets.enc.yaml
+../../../../secrets/numerique-gouv/meet/env/staging/secrets.enc.yaml

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -83,23 +83,6 @@ backend:
       secretKeyRef:
         name: redis.redis.libre.sh
         key: url
-    AWS_S3_ENDPOINT_URL:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: url
-    AWS_S3_ACCESS_KEY_ID:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: accessKey
-    AWS_S3_SECRET_ACCESS_KEY:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: secretKey
-    AWS_STORAGE_BUCKET_NAME:
-      secretKeyRef:
-        name: meet-media-storage.bucket.libre.sh
-        key: bucket
-    AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     LIVEKIT_API_SECRET:
       secretKeyRef:

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -101,6 +101,14 @@ backend:
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+    LIVEKIT_API_SECRET:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_SECRET
+    LIVEKIT_API_KEY:
+      secretKeyRef:
+        name: backend
+        key: LIVEKIT_API_KEY
 
   createsuperuser:
     command:

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -1,21 +1,21 @@
 image:
   repository: lasuite/meet-backend
   pullPolicy: Always
-  tag: "v0.1.0"
+  tag: "main"
 
 backend:
   migrateJobAnnotations:
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   envVars:
-    DJANGO_CSRF_TRUSTED_ORIGINS: https://docs.numerique.gouv.fr
+    DJANGO_CSRF_TRUSTED_ORIGINS: http://meet-staging.beta.numerique.gouv.fr,https://meet-staging.beta.numerique.gouv.fr
     DJANGO_CONFIGURATION: Production
     DJANGO_ALLOWED_HOSTS: "*"
     DJANGO_SECRET_KEY:
       secretKeyRef:
         name: backend
         key: DJANGO_SECRET_KEY
-    DJANGO_SETTINGS_MODULE: impress.settings
+    DJANGO_SETTINGS_MODULE: meet.settings
     DJANGO_SUPERUSER_EMAIL:
       secretKeyRef:
         name: backend
@@ -27,12 +27,11 @@ backend:
     DJANGO_EMAIL_HOST: "snap-mail.numerique.gouv.fr"
     DJANGO_EMAIL_PORT: 465
     DJANGO_EMAIL_USE_SSL: True
-    DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
-    OIDC_OP_JWKS_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/jwks
-    OIDC_OP_AUTHORIZATION_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/authorize
-    OIDC_OP_TOKEN_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/token
-    OIDC_OP_USER_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/userinfo
-    OIDC_OP_LOGOUT_ENDPOINT: https://auth.agentconnect.gouv.fr/api/v2/session/end
+    OIDC_OP_JWKS_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
+    OIDC_OP_AUTHORIZATION_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
+    OIDC_OP_TOKEN_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/token
+    OIDC_OP_USER_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/userinfo
+    OIDC_OP_LOGOUT_ENDPOINT: https://fca.integ01.dev-agentconnect.fr/api/v2/session/end
     OIDC_RP_CLIENT_ID:
       secretKeyRef:
         name: backend
@@ -43,11 +42,11 @@ backend:
         key: OIDC_RP_CLIENT_SECRET
     OIDC_RP_SIGN_ALGO: RS256
     OIDC_RP_SCOPES: "openid email"
-    OIDC_REDIRECT_ALLOWED_HOSTS: https://docs.numerique.gouv.fr
+    OIDC_REDIRECT_ALLOWED_HOSTS: https://meet-staging.beta.numerique.gouv.fr
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
-    LOGIN_REDIRECT_URL: https://docs.numerique.gouv.fr
-    LOGIN_REDIRECT_URL_FAILURE: https://docs.numerique.gouv.fr
-    LOGOUT_REDIRECT_URL: https://docs.numerique.gouv.fr
+    LOGIN_REDIRECT_URL: https://meet-staging.beta.numerique.gouv.fr
+    LOGIN_REDIRECT_URL_FAILURE: https://meet-staging.beta.numerique.gouv.fr
+    LOGOUT_REDIRECT_URL: https://meet-staging.beta.numerique.gouv.fr
     DB_HOST:
       secretKeyRef:
         name: postgresql.postgres.libre.sh
@@ -86,19 +85,19 @@ backend:
         key: url
     AWS_S3_ENDPOINT_URL:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: url
     AWS_S3_ACCESS_KEY_ID:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: accessKey
     AWS_S3_SECRET_ACCESS_KEY:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: secretKey
     AWS_STORAGE_BUCKET_NAME:
       secretKeyRef:
-        name: impress-media-storage.bucket.libre.sh
+        name: meet-media-storage.bucket.libre.sh
         key: bucket
     AWS_S3_REGION_NAME: local
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
@@ -115,33 +114,20 @@ frontend:
   image:
     repository: lasuite/meet-frontend
     pullPolicy: Always
-    tag: "v0.1.0"
-
-webrtc:
-  image:
-    repository: lasuite/impress-y-webrtc-signaling
-    pullPolicy: Always
-    tag: "v0.1.0"
+    tag: "main"
 
 ingress:
   enabled: true
-  host: docs.numerique.gouv.fr
+  host: meet-staging.beta.numerique.gouv.fr
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-
-ingressWS:
-  enabled: true
-  host: docs.numerique.gouv.fr
-  className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 
 ingressAdmin:
   enabled: true
-  host: docs.numerique.gouv.fr
+  host: meet-staging.beta.numerique.gouv.fr
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-    nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/start
-    nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy.beta.numerique.gouv.fr/oauth2/auth
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/start
+    nginx.ingress.kubernetes.io/auth-url: https://oauth2-proxy-preprod.beta.numerique.gouv.fr/oauth2/auth

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -109,6 +109,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
+    LIVEKIT_API_URL: https://livekit.beta.numerique.gouv.fr
 
   createsuperuser:
     command:

--- a/src/helm/extra/templates/secrets.yaml
+++ b/src/helm/extra/templates/secrets.yaml
@@ -8,3 +8,5 @@ stringData:
   DJANGO_SECRET_KEY: {{ .Values.djangoSecretKey }}
   OIDC_RP_CLIENT_ID: {{ .Values.oidc.clientId }}
   OIDC_RP_CLIENT_SECRET: {{ .Values.oidc.clientSecret }}
+  LIVEKIT_API_SECRET: {{ .Values.livekitApi.secret }}
+  LIVEKIT_API_KEY: {{ .Values.livekitApi.key }}


### PR DESCRIPTION
## Purpose

Prepare deployment in staging, and production.

## Proposal

Setting up the CI/CD as soon as possible is crucial for iteration. It's also essential to start getting user feedback next week. Therefore, having an MVP in users' hands is a must.

A pre-production environment can be prepared, but it won't be useful for the MVP. The pre-production environment will be necessary once we can no longer afford to risk breaking the production environment. Early user testers will be aware that the product is in beta version.

Deploying a first version based on Indie Hoster and Google infrastructure is okay for the early user testers. We cannot block deployment until @rouja deployed an enhanced and totally sovereign version of LiveKit.

Deploying LiveKit on a Kubernetes cluster managed by private cloud providers is challenging because some ports and IPs need to be static and public, which contradicts the principles of Kubernetes.

