### PR TITLE
Handle username in the API

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -134,6 +134,4 @@ class RoomSerializer(serializers.ModelSerializer):
 
         output["is_administrable"] = is_admin
 
-        # todo - pass properly livekit configuration
-
         return output

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -122,10 +122,14 @@ class RoomSerializer(serializers.ModelSerializer):
         if role is not None or instance.is_public:
             slug = f"{instance.id!s}".replace("-", "")
 
+            username = request.GET.get("username", None)
+
             output["livekit"] = {
                 "url": settings.LIVEKIT_CONFIGURATION["url"],
                 "room": slug,
-                "token": utils.generate_token(room=slug, user=request.user),
+                "token": utils.generate_token(
+                    room=slug, user=request.user, username=username
+                ),
             }
 
         output["is_administrable"] = is_admin

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -188,12 +188,15 @@ class RoomViewSet(
             if not settings.ALLOW_UNREGISTERED_ROOMS:
                 raise
             slug = slugify(self.kwargs["pk"])
+            username = request.query_params.get("username", None)
             data = {
                 "id": None,
                 "livekit": {
                     "url": settings.LIVEKIT_CONFIGURATION["url"],
                     "room": slug,
-                    "token": utils.generate_token(room=slug, user=request.user),
+                    "token": utils.generate_token(
+                        room=slug, user=request.user, username=username
+                    ),
                 },
             }
         else:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -209,7 +209,6 @@ class RoomViewSet(
         user = self.request.user
 
         if user.is_authenticated:
-            # todo - simplify this queryset
             queryset = (
                 self.filter_queryset(self.get_queryset())
                 .filter(Q(users=user))

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -210,9 +210,7 @@ class RoomViewSet(
 
         if user.is_authenticated:
             queryset = (
-                self.filter_queryset(self.get_queryset())
-                .filter(Q(users=user))
-                .distinct()
+                self.filter_queryset(self.get_queryset()).filter(users=user).distinct()
             )
         else:
             queryset = self.get_queryset().none()

--- a/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
@@ -111,7 +111,9 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
         },
     }
 
-    mock_token.assert_called_once_with(room="unregistered-room", user=AnonymousUser())
+    mock_token.assert_called_once_with(
+        room="unregistered-room", user=AnonymousUser(), username=None
+    )
 
 
 @override_settings(ALLOW_UNREGISTERED_ROOMS=True)
@@ -141,7 +143,9 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed_not_normalized(mock_t
         },
     }
 
-    mock_token.assert_called_once_with(room="reunion", user=AnonymousUser())
+    mock_token.assert_called_once_with(
+        room="reunion", user=AnonymousUser(), username=None
+    )
 
 
 @override_settings(ALLOW_UNREGISTERED_ROOMS=False)
@@ -229,7 +233,7 @@ def test_api_rooms_retrieve_authenticated_public(mock_token):
         "slug": room.slug,
     }
 
-    mock_token.assert_called_once_with(room=expected_name, user=user)
+    mock_token.assert_called_once_with(room=expected_name, user=user, username=None)
 
 
 def test_api_rooms_retrieve_authenticated():
@@ -327,7 +331,7 @@ def test_api_rooms_retrieve_members(mock_token, django_assert_num_queries):
         "slug": room.slug,
     }
 
-    mock_token.assert_called_once_with(room=expected_name, user=user)
+    mock_token.assert_called_once_with(room=expected_name, user=user, username=None)
 
 
 @mock.patch("core.utils.generate_token", return_value="foo")
@@ -400,4 +404,4 @@ def test_api_rooms_retrieve_administrators(mock_token, django_assert_num_queries
         "slug": room.slug,
     }
 
-    mock_token.assert_called_once_with(room=expected_name, user=user)
+    mock_token.assert_called_once_with(room=expected_name, user=user, username=None)

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -1,7 +1,7 @@
 """
 Utils functions used in the core app
 """
-import string
+from typing import Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -9,12 +9,14 @@ from django.conf import settings
 from livekit.api import AccessToken, VideoGrants
 
 
-def generate_token(room: string, user) -> str:
+def generate_token(room: str, user, username: Optional[str] = None) -> str:
     """Generate a Livekit access token for a user in a specific room.
 
     Args:
         room (str): The name of the room.
         user (User): The user which request the access token.
+        username (Optional[str]): The username to be displayed in the room.
+                         If none, a default value will be used.
 
     Returns:
         str: The LiveKit JWT access token.
@@ -38,10 +40,12 @@ def generate_token(room: string, user) -> str:
     ).with_grants(video_grants)
 
     if user.is_anonymous:
-        # todo - allow passing a proper name for not logged-in user
         token.with_identity(str(uuid4()))
+        default_username = "Anonymous"
     else:
-        # todo - use user's fullname instead of its email for the displayed name
-        token.with_identity(user.sub).with_name(f"{user!s}")
+        token.with_identity(user.sub)
+        default_username = str(user)
+
+    token.with_name(username or default_username)
 
     return token.to_jwt()

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -22,7 +22,6 @@ def generate_token(room: str, user, username: Optional[str] = None) -> str:
         str: The LiveKit JWT access token.
     """
 
-    # todo - define the video grants properly based on user and room.
     video_grants = VideoGrants(
         room=room,
         room_join=True,


### PR DESCRIPTION
## Purpose

Display the username typed by user.

## Proposal

The frontend was ready. I've added a new query parameter `username` to the `/room` route in the API. We moved away from email/UUID-v4 usernames, which were totally ugly.

I haven't thoroughly tested all corner cases when passing the string yet. Also, the `generate_token` function lacks unit tests; I will address this asap.

If we're not planning to use named/persistent rooms soon, I propose extracting the LiveKit token generation into a dedicated endpoint. We could take inspiration from the LiveKit demo app, like `https://meet.livekit.io/api/token?identity=Antoine&name=Antoine&roomName=guj4-212l`.

I'm concerned about updating code that might not be used. Before adding complexity to the existing viewset and serializer, I'd prefer to ensure we're heading in the right direction. It might be great to wait for @sampaccoud to initiate architecture discussions.

It closes #29 

![Capture d’écran 2024-07-17 à 17 48 02](https://github.com/user-attachments/assets/080f4009-2647-47df-9c2f-f7ab3b97468f)
