### PR TITLE
🚸(frontend) generate shorter room IDs making URLs easier to share

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { useLang } from 'hoofd'
 import { Route, Switch } from 'wouter'
 import { HomeRoute } from '@/features/home'
 import { NotFound } from './routes/NotFound'
-import { RoomRoute } from '@/features/rooms'
+import { RoomRoute, roomIdRegex } from '@/features/rooms'
 import './i18n/init'
 
 const queryClient = new QueryClient()
@@ -19,7 +19,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <Switch>
         <Route path="/" component={HomeRoute} />
-        <Route path="/:roomId" component={RoomRoute} />
+        <Route path={roomIdRegex} component={RoomRoute} />
         <Route component={NotFound} />
       </Switch>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/frontend/src/features/rooms/index.ts
+++ b/src/frontend/src/features/rooms/index.ts
@@ -1,2 +1,3 @@
 export { navigateToNewRoom } from './navigation/navigateToNewRoom'
 export { Room as RoomRoute } from './routes/Room'
+export { roomIdRegex } from './utils/generateRoomId'

--- a/src/frontend/src/features/rooms/utils/generateRoomId.ts
+++ b/src/frontend/src/features/rooms/utils/generateRoomId.ts
@@ -25,3 +25,6 @@ export const generateRoomId = () => {
   ];
   return parts.join('-');
 }
+
+export const roomIdRegex = /^[/](?<roomId>[a-z]{3}-[a-z]{4}-[a-z]{3})$/;
+

--- a/src/frontend/src/features/rooms/utils/generateRoomId.ts
+++ b/src/frontend/src/features/rooms/utils/generateRoomId.ts
@@ -1,5 +1,27 @@
-import { slugify } from '@/utils/slugify'
+
+const getRandomChar = () => {
+  // Google Meet uses only letters in a room identifier
+  const characters = 'abcdefghijklmnopqrstuvwxyz';
+  const charactersLength = characters.length;
+  return characters.charAt(Math.floor(Math.random() * charactersLength))
+}
+
+const generateSegment = (length: number): string => {
+  let segment = '';
+  for (let i = 0; i < length; i++) {
+    segment += getRandomChar();
+  }
+  return segment;
+};
 
 export const generateRoomId = () => {
-  return slugify(crypto.randomUUID())
+  // Generates a unique room identifier following the Google Meet format
+  const shortLength = 3;
+  const longLength = 4;
+  const parts = [
+    generateSegment(shortLength),
+    generateSegment(longLength),
+    generateSegment(shortLength)
+  ];
+  return parts.join('-');
 }

--- a/src/frontend/src/features/rooms/utils/generateRoomId.ts
+++ b/src/frontend/src/features/rooms/utils/generateRoomId.ts
@@ -1,30 +1,16 @@
+// Google Meet uses only letters in a room identifier
+const ROOM_ID_ALLOWED_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz'
 
-const getRandomChar = () => {
-  // Google Meet uses only letters in a room identifier
-  const characters = 'abcdefghijklmnopqrstuvwxyz';
-  const charactersLength = characters.length;
-  return characters.charAt(Math.floor(Math.random() * charactersLength))
-}
+const getRandomChar = () =>
+  ROOM_ID_ALLOWED_CHARACTERS[
+    Math.floor(Math.random() * ROOM_ID_ALLOWED_CHARACTERS.length)
+  ]
 
-const generateSegment = (length: number): string => {
-  let segment = '';
-  for (let i = 0; i < length; i++) {
-    segment += getRandomChar();
-  }
-  return segment;
-};
+const generateSegment = (length: number): string =>
+  Array.from(Array(length), getRandomChar).join('')
 
-export const generateRoomId = () => {
-  // Generates a unique room identifier following the Google Meet format
-  const shortLength = 3;
-  const longLength = 4;
-  const parts = [
-    generateSegment(shortLength),
-    generateSegment(longLength),
-    generateSegment(shortLength)
-  ];
-  return parts.join('-');
-}
+// Generates a unique room identifier following the Google Meet format
+export const generateRoomId = () =>
+  [generateSegment(3), generateSegment(4), generateSegment(3)].join('-')
 
-export const roomIdRegex = /^[/](?<roomId>[a-z]{3}-[a-z]{4}-[a-z]{3})$/;
-
+export const roomIdRegex = /^[/](?<roomId>[a-z]{3}-[a-z]{4}-[a-z]{3})$/


### PR DESCRIPTION
## Proposition

Simplify room's name (ID).

## Proposal

Please refer to the issue #41 which explains why simplifying room IDs could be beneficial in terms of user experience (UX).
It closes #41.
