### PR TITLE
🔧(helm) configuration

### DIFF
--- a/src/helm/env.d/preprod/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/preprod/values.meet.yaml.gotmpl
@@ -92,7 +92,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
-    LIVEKIT_API_URL: https://livekit-docker-1.beta.numerique.gouv.fr
+    LIVEKIT_API_URL: https://livekit-preprod.beta.numerique.gouv.fr
 
   createsuperuser:
     command:

--- a/src/helm/env.d/production/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/production/values.meet.yaml.gotmpl
@@ -92,7 +92,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
-    LIVEKIT_API_URL: https://livekit-docker-1.beta.numerique.gouv.fr
+    LIVEKIT_API_URL: https://livekit-preprod.beta.numerique.gouv.fr
 
   createsuperuser:
     command:

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -92,7 +92,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
-    LIVEKIT_API_URL: https://livekit-docker-1.beta.numerique.gouv.fr
+    LIVEKIT_API_URL: https://livekit-preprod.beta.numerique.gouv.fr
 
   createsuperuser:
     command:


### PR DESCRIPTION
Change configuration to use livekit-preprod.beta.numerique.gouv.fr instead of the docker test vm
