### PR TITLE
🩹(frontend) fix ignored pre-join options

### DIFF
--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react";
 import { useQuery } from '@tanstack/react-query'
 import {
   LiveKitRoom,
   VideoConference,
   type LocalUserChoices,
 } from '@livekit/components-react'
+import { Room, RoomOptions } from "livekit-client";
 import { keys } from '@/api/queryKeys'
 import { QueryAware } from '@/layout/QueryAware'
 import { navigateToHome } from '@/features/home'
@@ -25,18 +27,28 @@ export const Conference = ({
       }),
   })
 
+  const roomOptions = useMemo((): RoomOptions => {
+    return {
+      videoCaptureDefaults: {
+        deviceId: userConfig.videoDeviceId ?? undefined,
+      },
+      audioCaptureDefaults: {
+        deviceId: userConfig.audioDeviceId ?? undefined,
+      },
+    };
+  }, [userConfig]);
+
+  const room = useMemo(() => new Room(roomOptions), [roomOptions]);
+
   return (
     <QueryAware status={status}>
       <LiveKitRoom
+        room={room}
         serverUrl={data?.livekit?.url}
         token={data?.livekit?.token}
         connect={true}
-        audio={{
-          deviceId: userConfig.audioDeviceId,
-        }}
-        video={{
-          deviceId: userConfig.videoDeviceId,
-        }}
+        audio={userConfig.audioEnabled}
+        video={userConfig.videoEnabled}
         onDisconnected={() => {
           navigateToHome()
         }}


### PR DESCRIPTION
It closes #50 
Adopted LiveKit demo app approach for passing configuration to `LiveKitRoom`. Introduced `roomOptions` for future customizations (e.g., quality, codec).

DeviceId is persisted in local storage despite the boolean flag.
We ended up passing the DeviceId without ever setting the boolean flag to false when any parameter was disabled.

I might have missed smth, please feel free to add any commits.