### PR TITLE
⬆️(ci) update checkout actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           repositories: "meet,secrets"
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -28,7 +28,7 @@ jobs:
           repositories: "meet,secrets"
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
@@ -72,7 +72,7 @@ jobs:
           repositories: "meet,secrets"
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}
@@ -122,7 +122,7 @@ jobs:
           repositories: "meet,secrets"
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install development dependencies
@@ -145,7 +145,7 @@ jobs:
           key: mail-templates-${{ hashFiles('src/mail/mjml') }}
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -193,7 +193,7 @@ jobs:
           sudo apt-get install -y gettext
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'pull_request' # Makes sense only for pull requests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: show
@@ -77,7 +77,7 @@ jobs:
         working-directory: src/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Python
         uses: actions/setup-python@v3
         with:
@@ -176,7 +176,7 @@ jobs:
           repositories: "infrastructure,secrets"
       -
         name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
It closes #60 

checkout@v2 uses `node12` which will be deprecated soon. I've aligned CI configurations to use a more recent action, already in-use in the 'meet.yml' flow.
