### PR TITLE
⚰️(backend) remove unused cold storage configurations

### DIFF
--- a/.github/workflows/meet.yml
+++ b/.github/workflows/meet.yml
@@ -122,9 +122,6 @@ jobs:
       DB_PASSWORD: pass
       DB_PORT: 5432
       STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
-      AWS_S3_ENDPOINT_URL: http://localhost:9000
-      AWS_S3_ACCESS_KEY_ID: impress
-      AWS_S3_SECRET_ACCESS_KEY: password
       LIVEKIT_API_SECRET: secret
       LIVEKIT_API_KEY: devkey
 

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -18,9 +18,6 @@ MEET_BASE_URL="http://localhost:8072"
 
 # Media
 STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStorage
-AWS_S3_ENDPOINT_URL=http://minio:9000
-AWS_S3_ACCESS_KEY_ID=meet
-AWS_S3_SECRET_ACCESS_KEY=password
 
 # OIDC
 OIDC_OP_JWKS_ENDPOINT=http://nginx:8083/realms/meet/protocol/openid-connect/certs


### PR DESCRIPTION
Minio was removed from our stack, because it wasn't used.
Cleaned up some environment variables.
