### PR TITLE
🔒️(helm) configure staging to use livekit-staging

### DIFF
--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -92,7 +92,7 @@ backend:
       secretKeyRef:
         name: backend
         key: LIVEKIT_API_KEY
-    LIVEKIT_API_URL: https://livekit-preprod.beta.numerique.gouv.fr
+    LIVEKIT_API_URL: https://livekit-staging.beta.numerique.gouv.fr
     ANALYTICS_KEY: Roi1k6IAc2DEqHB0
     ALLOW_UNREGISTERED_ROOMS: False
 


### PR DESCRIPTION
Reconfigure staging environment to use livekit-staging.beta.numerique.gouv.fr
