### PR TITLE
🐛(backend) fix dependencies conflicts

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -275,6 +275,7 @@ class Base(Configuration):
     # Easy thumbnails
     THUMBNAIL_EXTENSION = "webp"
     THUMBNAIL_TRANSPARENCY_EXTENSION = "webp"
+    THUMBNAIL_DEFAULT_STORAGE_ALIAS = "default"
     THUMBNAIL_ALIASES = {}
 
     # Celery


### PR DESCRIPTION
Upgrading Django to 5.1 created a severe issue.
Migrate and create-superuser jobs were failing.

The issue originated from the third party `easy_thumbnail`. Please refer to the issue #641 on their repo.

This is the suggested workaround by @Miketsukami.
