### PR TITLE
🔊(backend) update production logger

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -557,6 +557,26 @@ class Production(Base):
         },
     }
 
+    LOGGING = {
+        "version": 1,
+        "formatters": {
+            "json": {"()": "dockerflow.logging.JsonLogFormatter", "logger_name": "meet"}
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+            },
+        },
+        "loggers": {
+            "request.summary": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+        },
+    }
+
 
 class Feature(Production):
     """


### PR DESCRIPTION
Configure probes logs as recommended by the Django `dockerflow` [documentation](https://python-dockerflow.readthedocs.io/en/main/django.html#logging).

Updating logger's config, fixed another minor issue, silenced system warnings were still logged when calling the `__lbheartbeat__` probe. These warnings are now properly silenced.

It closes #84 

Incoming requests are now logged in Json. Wdyt @rouja?



**Before**
```
10.42.1.218 - - [29/Aug/2024:16:23:16 +0000] "GET /__heartbeat__ HTTP/1.1" 200 21 "-" "kube-probe/1.27"
10.42.2.252 - - [29/Aug/2024:16:23:25 +0000] "GET /__lbheartbeat__ HTTP/1.1" 200 0 "-" "kube-probe/1.27"
security.W008: Your SECURE_SSL_REDIRECT setting is not set to True. Unless your site should be available over both SSL and non-SSL connections, you may want to either set this setting True or configure a load balancer or reverse-proxy server to redirect all connections to HTTPS.
security.W004: You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
```


**After**:

```
{"Timestamp": 1724948569546892032, "Type": "request.summary", "Logger": "meet", "Hostname": "meet-backend-58bf856b74-djbrw", "EnvVersion": "2.0", "Severity": 6, "Pid": 50, "Fields": {"errno": 0, "agent": "kube-probe/1.27", "lang": "", "method": "GET", "path": "/__lbheartbeat__", "uid": "", "rid": null}}
{"Timestamp": 1724948569710832384, "Type": "request.summary", "Logger": "meet", "Hostname": "meet-backend-58bf856b74-djbrw", "EnvVersion": "2.0", "Severity": 6, "Pid": 51, "Fields": {"errno": 0, "agent": "kube-probe/1.27", "lang": "", "method": "GET", "path": "/__heartbeat__", "uid": "", "rid": null}}
```

