### PR TITLE
🚧(backend) document a resource server integration

### DIFF
--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -65,6 +65,19 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         - Exception: Raised when user creation is not allowed and no existing user is found.
         """
 
+        try:
+            response = requests.get(
+                "https://desk-staging.beta.numerique.gouv.fr/api/v1.0/users/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            response.raise_for_status()
+            api_data = response.json()
+
+            print(api_data)  # Process the Regie data as needed
+
+        except requests.exceptions.RequestException as e:
+            print(f"API request failed: {e}")
+
         user_info = self.get_userinfo(access_token, id_token, payload)
         sub = user_info.get("sub")
 

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -24,7 +24,7 @@ backend:
     OIDC_RP_CLIENT_ID: {{ .Values.oidc.clientId }}
     OIDC_RP_CLIENT_SECRET: {{ .Values.oidc.clientSecret }}
     OIDC_RP_SIGN_ALGO: RS256
-    OIDC_RP_SCOPES: "openid email"
+    OIDC_RP_SCOPES: "openid email groups"
     OIDC_REDIRECT_ALLOWED_HOSTS: https://meet.127.0.0.1.nip.io
     OIDC_AUTH_REQUEST_EXTRA_PARAMS: "{'acr_values': 'eidas1'}"
     LOGIN_REDIRECT_URL: https://meet.127.0.0.1.nip.io


### PR DESCRIPTION
/!\ Not for merging

Meet is calling Regie during user authentication, passing the access token from AgentConnect to the resource server.

/!\ The access token is valid for 60s. After this time, you won't be able to inspect it, neither get data from the resource server.

Why do you need to update scopes?

When introspecting an access token with AgentConnect, it verifies that the relevant scopes were requested during authentication. Users need the "groups" scope to access the Regie resource server.

Note: AgentConnect controls which FS has access to which scopes. A FS cannot request the "groups" scope without approval from AC. Contact Benoit to add the "groups" scope to your client.

In this example, I query a random endpoint (/users/me), but the entire Regie API is accessible using the AC access token. This is temporary. Once we have built something useful with a few FS, I'll restrict the resource server to fewer endpoints, focusing on those related to groups.