### PR TITLE
Setting dialog audio v2

### DIFF
--- a/src/frontend/src/components/SoundTester.tsx
+++ b/src/frontend/src/components/SoundTester.tsx
@@ -27,12 +27,17 @@ export const SoundTester = () => {
   return (
     <>
       <Button
+        invisible
         onPress={() => {
           audioRef?.current?.play()
           setIsPlaying(true)
         }}
         size="sm"
         isDisabled={isPlaying}
+        fullWidth
+        style={{
+          color: isPlaying ? 'var(--colors-primary)' : undefined,
+        }}
       >
         {isPlaying ? t('audio.speakers.ongoingTest') : t('audio.speakers.test')}
       </Button>

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -36,6 +36,7 @@ const tabPanelContainerStyle = css({
   display: 'flex',
   flexGrow: '1',
   marginTop: '3.5rem',
+  minWidth: 0,
 })
 
 export type SettingsDialogExtended = Pick<

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -12,6 +12,8 @@ import {
 import { AccountTab } from './tabs/AccountTab'
 import { GeneralTab } from '@/features/settings/components/tabs/GeneralTab.tsx'
 import { AudioTab } from '@/features/settings/components/tabs/AudioTab.tsx'
+import { useSize } from '@/features/rooms/livekit/hooks/useResizeObserver'
+import { useRef } from 'react'
 
 const tabsStyle = css({
   maxHeight: '40.625rem', // fixme size copied from meet settings modal
@@ -28,7 +30,6 @@ const tabListContainerStyle = css({
   borderRight: '1px solid lightGray', // fixme poor color management
   paddingY: '1rem',
   paddingRight: '1.5rem',
-  flex: '0 0 16rem', // fixme size copied from meet settings modal
 })
 
 const tabPanelContainerStyle = css({
@@ -45,25 +46,39 @@ export type SettingsDialogExtended = Pick<
 export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
   // display only icon on small screen
   const { t } = useTranslation('settings')
+
+  const dialogEl = useRef<HTMLDivElement>(null)
+  const { width } = useSize(dialogEl)
+  const isWideScreen = !width || width >= 800 // fixme - hardcoded 50rem in pixel
+
   return (
-    <Dialog {...props} role="dialog" type="flex">
+    <Dialog innerRef={dialogEl} {...props} role="dialog" type="flex">
       <Tabs orientation="vertical" className={tabsStyle}>
-        <div className={tabListContainerStyle}>
-          <Heading slot="title" level={1} className={text({ variant: 'h1' })}>
-            {t('dialog.heading')}
-          </Heading>
+        <div
+          className={tabListContainerStyle}
+          style={{
+            flex: isWideScreen ? '0 0 16rem' : undefined,
+            paddingTop: !isWideScreen ? '64px' : undefined,
+            paddingRight: !isWideScreen ? '1rem' : undefined,
+          }}
+        >
+          {isWideScreen && (
+            <Heading slot="title" level={1} className={text({ variant: 'h1' })}>
+              {t('dialog.heading')}
+            </Heading>
+          )}
           <TabList border={false} aria-label="Chat log orientation example">
             <Tab icon highlight id="1">
               <RiAccountCircleLine />
-              {t('tabs.account')}
+              {isWideScreen && t('tabs.account')}
             </Tab>
             <Tab icon highlight id="2">
               <RiSpeakerLine />
-              {t('tabs.audio')}
+              {isWideScreen && t('tabs.audio')}
             </Tab>
             <Tab icon highlight id="3">
               <RiSettings3Line />
-              {t('tabs.general')}
+              {isWideScreen && t('tabs.general')}
             </Tab>
           </TabList>
         </div>

--- a/src/frontend/src/primitives/Dialog.tsx
+++ b/src/frontend/src/primitives/Dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-aria-components'
 import { Div, Button, Box, VerticallyOffCenter } from '@/primitives'
 import { text } from './Text'
+import { MutableRefObject } from 'react'
 
 const StyledModalOverlay = styled(ModalOverlay, {
   base: {
@@ -61,6 +62,7 @@ export type DialogProps = RACDialogProps & {
    */
   onOpenChange?: (isOpen: boolean) => void
   type?: 'flex'
+  innerRef?: MutableRefObject<HTMLDivElement | null>
 }
 
 export const Dialog = ({
@@ -69,6 +71,7 @@ export const Dialog = ({
   onClose,
   isOpen,
   onOpenChange,
+  innerRef,
   ...dialogProps
 }: DialogProps) => {
   const isAlert = dialogProps['role'] === 'alertdialog'
@@ -93,7 +96,7 @@ export const Dialog = ({
             <VerticallyOffCenter>
               <Div margin="auto" width="fit-content" maxWidth="full">
                 <Div margin="1rem" pointerEvents="auto">
-                  <Box size="sm" type={boxType}>
+                  <Box size="sm" type={boxType} ref={innerRef}>
                     {!!title && (
                       <Heading
                         slot="title"

--- a/src/frontend/src/primitives/Field.tsx
+++ b/src/frontend/src/primitives/Field.tsx
@@ -23,6 +23,7 @@ import { Div } from './Div'
 const FieldWrapper = styled('div', {
   base: {
     marginBottom: 'textfield',
+    minWidth: 0,
   },
 })
 

--- a/src/frontend/src/primitives/Select.tsx
+++ b/src/frontend/src/primitives/Select.tsx
@@ -43,6 +43,9 @@ const StyledButton = styled(Button, {
 
 const StyledSelectValue = styled(SelectValue, {
   base: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    textWrap: 'nowrap',
     '&[data-placeholder]': {
       color: 'default.subtle-text',
       fontStyle: 'italic',


### PR DESCRIPTION
## Purpose

Second iteration on the Audio tab under settings

## Proposal

Added the active speaker indicator to help users easily determine if their mic is active. Refactored the layout to match Gmeet's design and improved the responsiveness of several elements.

<img width="661" alt="Capture d’écran 2024-08-30 à 15 58 09" src="https://github.com/user-attachments/assets/599e9059-55d0-4a5c-a8ab-da2261f4517d">

