### PR TITLE
🚑️(frontend) fix posthog user's ID

### DIFF
--- a/src/frontend/src/features/auth/api/useUser.tsx
+++ b/src/frontend/src/features/auth/api/useUser.tsx
@@ -19,7 +19,7 @@ export const useUser = () => {
 
   useEffect(() => {
     if (query.data && query.data.id && !posthog._isIdentified()) {
-      posthog.identify('query.data.id', { email: query.data.email })
+      posthog.identify(query.data.id, { email: query.data.email })
     }
   }, [query.data])
 


### PR DESCRIPTION
Oupsie… quotes were misplaced, and led to having the exact same ID for every user. Fixed them. Trivial error.
