### PR TITLE
🔒️(helm) fix secret sync precedence

### DIFF
--- a/src/helm/meet/templates/secrets.yaml
+++ b/src/helm/meet/templates/secrets.yaml
@@ -3,6 +3,10 @@ kind: Secret
 metadata:
   name: backend
   namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 stringData:
   DJANGO_SUPERUSER_EMAIL: {{ .Values.djangoSuperUserEmail }}
   DJANGO_SUPERUSER_PASSWORD: {{ .Values.djangoSuperUserPass }}


### PR DESCRIPTION
When new secret is added to backend secret, it's not sync at the beginning of argocd synchronisation and jobs are blocked. Theses new annotations fix this issue.