### PR TITLE
🐛(backend) add missing Django settings

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -258,6 +258,7 @@ class Base(Configuration):
     EMAIL_HOST_PASSWORD = values.Value(None)
     EMAIL_PORT = values.PositiveIntegerValue(None)
     EMAIL_USE_TLS = values.BooleanValue(False)
+    EMAIL_USE_SSL = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@example.com")
 
     AUTH_USER_MODEL = "core.User"


### PR DESCRIPTION
Fixed an issue where a setting cloned from Joanie was missing in the  Django configuration. Although its value was provided, it was not applied due to the missing reference in the settings file.
