### PR TITLE
🐛(frontend) prevent side panel and chat from opening simultaneously

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useWidgetInteraction.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useWidgetInteraction.ts
@@ -19,7 +19,7 @@ export const useWidgetInteraction = () => {
   }
 
   const toggleChat = () => {
-    if (isParticipantsOpen) {
+    if (isParticipantsOpen || isEffectsOpen) {
       layoutStore.sidePanel = null
     }
     if (dispatch) {


### PR DESCRIPTION
Fixed issue where side panel could open while chat was already open. Resolved recent bug introduced in a previous commit.