### PR TITLE
🐛(frontend) fix missing user label in prejoin screen

### DIFF
--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -19,7 +19,7 @@ export const Join = ({
           micLabel={t('join.audioinput.label')}
           camLabel={t('join.videoinput.label')}
           joinLabel={t('join.joinLabel')}
-          userLabel={t('join.userLabel')}
+          userLabel={t('join.usernameLabel')}
         />
       </CenteredContent>
     </Screen>

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -22,7 +22,6 @@
     "joinMeeting": "",
     "toggleOff": "",
     "toggleOn": "",
-    "userLabel": "",
     "usernameHint": "",
     "usernameLabel": ""
   },

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -22,7 +22,6 @@
     "joinMeeting": "Join meeting",
     "toggleOff": "Click to turn off",
     "toggleOn": "Click to turn on",
-    "userLabel": "",
     "usernameHint": "Shown to other participants",
     "usernameLabel": "Your name"
   },

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -22,7 +22,6 @@
     "joinMeeting": "Rejoindre la réjoindre",
     "toggleOff": "Cliquez pour désactiver",
     "toggleOn": "Cliquez pour activer",
-    "userLabel": "",
     "usernameHint": "Affiché aux autres participants",
     "usernameLabel": "Votre nom"
   },


### PR DESCRIPTION
Add missing hint to guide user entering their name while joining a room.