### PR TITLE
🐛(frontend) tune connection parameters for low bandwidth clients

### DIFF
--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -89,6 +89,13 @@ export const Conference = ({
     )
   }
 
+  // Some clients (like DINUM) operate in bandwidth-constrained environments
+  // These settings help ensure successful connections in poor network conditions
+  const connectOptions = {
+    maxRetries: 5, // Default: 1. Only for unreachable server scenarios
+    peerConnectionTimeout: 60, // Default: 15s. Extended for slow TURN/TLS negotiation
+  }
+
   return (
     <QueryAware status={isFetchError ? createStatus : fetchStatus}>
       <Screen header={false}>
@@ -99,6 +106,7 @@ export const Conference = ({
           connect={true}
           audio={userConfig.audioEnabled}
           video={userConfig.videoEnabled}
+          connectOptions={connectOptions}
         >
           <VideoConference />
           {showInviteDialog && (


### PR DESCRIPTION
Context: DINUM users face connection issues in bandwidth-constrained environments. They cannot reach their room, the peer connection timeouts while negotiating TURN/TLS handshake (from our current understanding).

I am not sure this issue is linked to those parameters, at least try something.