### PR TITLE
🩹(frontend) use browser language if no localStorage for detection

### DIFF
--- a/src/frontend/src/i18n/init.ts
+++ b/src/frontend/src/i18n/init.ts
@@ -13,11 +13,14 @@ i18n
   )
   .use(initReactI18next)
   .use(LanguageDetector)
-i18n.init({
-  supportedLngs: ['en', 'fr'],
-  fallbackLng: 'en',
-  ns: i18nDefaultNamespace,
-  interpolation: {
-    escapeValue: false,
-  },
-})
+  .init({
+    supportedLngs: ['en', 'fr'],
+    fallbackLng: 'fr',
+    ns: i18nDefaultNamespace,
+    detection: {
+      order: ['localStorage', 'navigator'],
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+  })


### PR DESCRIPTION
Previously, language detection was failing to read browser settings correctly. Added explicit detection order to ensure  localStorage preferences are checked before falling back to browser language.