### PR TITLE
🐛(helm) rename bucket

### DIFF
--- a/src/helm/extra/templates/s3.yaml
+++ b/src/helm/extra/templates/s3.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.libre.sh/v1alpha1
 kind: Bucket
 metadata:
-  name: impress-media-storage
+  name: meet-media-storage
   namespace: {{ .Release.Namespace | quote }}
 spec:
   provider: data


### PR DESCRIPTION
Wrong copy and paste. My bad, bucket's name wasn't matching our project.