### PR TITLE
🩹(frontend) avoid franglish copywritting

### DIFF
--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -123,7 +123,7 @@
     "skip": "Passer"
   },
   "confirmationMessage": {
-    "heading": "Merci pour votre submission",
+    "heading": "Merci pour votre retour",
     "body": "Notre équipe produit prend le temps d'analyser attentivement vos réponses. Nous reviendrons vers vous dans les plus brefs délais."
   },
   "participants": {


### PR DESCRIPTION
My bad, few english terms were mixed in some french ones. Fixed it.

