### PR TITLE
Enable recording

### DIFF
--- a/src/backend/core/recording/event/authentication.py
+++ b/src/backend/core/recording/event/authentication.py
@@ -47,8 +47,6 @@ class StorageEventAuthentication(BaseAuthentication):
 
     def authenticate(self, request):
         """Validate the Bearer token from the Authorization header."""
-        if not settings.RECORDING_ENABLE_STORAGE_EVENT_AUTH:
-            return MachineUser(), None
 
         if not settings.RECORDING_ENABLE_STORAGE_EVENT_AUTH:
             return MachineUser(), None

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -446,7 +446,7 @@ class Base(Configuration):
         False, environ_name="RECORDING_STORAGE_EVENT_ENABLE", environ_prefix=None
     )
     RECORDING_STORAGE_EVENT_TOKEN = values.Value(
-        None, environ_name="RECORDING_STORAGE_HOOK_TOKEN", environ_prefix=None
+        None, environ_name="RECORDING_STORAGE_EVENT_TOKEN", environ_prefix=None
     )
 
     # pylint: disable=invalid-name

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -1,12 +1,7 @@
 import { fetchApi } from './fetchApi'
 import { keys } from './queryKeys'
 import { useQuery } from '@tanstack/react-query'
-
-// todo - refactor it in a proper place
-export enum RecordingMode {
-  Transcript = 'transcript',
-  ScreenRecording = 'screen_recording',
-}
+import { RecordingMode } from '@/features/rooms/api/startRecording'
 
 export interface ApiConfig {
   analytics?: {

--- a/src/frontend/src/features/rooms/api/ApiRoom.ts
+++ b/src/frontend/src/features/rooms/api/ApiRoom.ts
@@ -3,6 +3,7 @@ export type ApiRoom = {
   name: string
   slug: string
   is_public: boolean
+  is_administrable: boolean
   livekit?: {
     url: string
     room: string

--- a/src/frontend/src/features/rooms/api/startRecording.ts
+++ b/src/frontend/src/features/rooms/api/startRecording.ts
@@ -1,0 +1,35 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { fetchApi } from '@/api/fetchApi'
+import { ApiError } from '@/api/ApiError'
+import { ApiRoom } from './ApiRoom'
+
+export enum RecordingMode {
+  Transcript = 'transcript',
+  ScreenRecording = 'screen_recording',
+}
+
+export interface StartRecordingParams {
+  id: string
+  mode?: RecordingMode
+}
+
+const startRecording = ({
+  id,
+  mode = RecordingMode.Transcript,
+}: StartRecordingParams): Promise<ApiRoom> => {
+  return fetchApi(`rooms/${id}/start-recording/`, {
+    method: 'POST',
+    body: JSON.stringify({
+      mode: mode,
+    }),
+  })
+}
+
+export function useStartRecording(
+  options?: UseMutationOptions<ApiRoom, ApiError, StartRecordingParams>
+) {
+  return useMutation<ApiRoom, ApiError, StartRecordingParams>({
+    mutationFn: startRecording,
+    onSuccess: options?.onSuccess,
+  })
+}

--- a/src/frontend/src/features/rooms/api/stopRecording.ts
+++ b/src/frontend/src/features/rooms/api/stopRecording.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { fetchApi } from '@/api/fetchApi'
+import { ApiError } from '@/api/ApiError'
+import { ApiRoom } from './ApiRoom'
+
+export interface StopRecordingParams {
+  id: string
+}
+
+const stopRecording = ({ id }: StopRecordingParams): Promise<ApiRoom> => {
+  return fetchApi(`rooms/${id}/stop-recording/`, {
+    method: 'POST',
+  })
+}
+
+export function useStopRecording(
+  options?: UseMutationOptions<ApiRoom, ApiError, StopRecordingParams>
+) {
+  return useMutation<ApiRoom, ApiError, StopRecordingParams>({
+    mutationFn: stopRecording,
+    onSuccess: options?.onSuccess,
+  })
+}

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/OptionsMenuItems.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/OptionsMenuItems.tsx
@@ -10,6 +10,7 @@ import { DialogState } from './OptionsButton'
 import { Separator } from '@/primitives/Separator'
 import { useSidePanel } from '../../../hooks/useSidePanel'
 import { menuRecipe } from '@/primitives/menuRecipe.ts'
+import { TranscriptMenuItem } from './TranscriptMenuItem'
 
 // @todo try refactoring it to use MenuList component
 export const OptionsMenuItems = ({
@@ -34,6 +35,7 @@ export const OptionsMenuItems = ({
           <RiAccountBoxLine size={20} />
           {t('effects')}
         </MenuItem>
+        <TranscriptMenuItem />
       </Section>
       <Separator />
       <Section>

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
@@ -14,17 +14,17 @@ import { useConfig } from '@/api/useConfig'
 export const TranscriptMenuItem = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'options.items' })
 
-  const data = useRoomData()
+  const apiRoomData = useRoomData()
 
   const { mutateAsync: startRecordingRoom } = useStartRecording()
   const { mutateAsync: stopRecordingRoom } = useStopRecording()
 
-  const { data: apiConfig } = useConfig()
+  const { data } = useConfig()
 
   const room = useRoomContext()
 
   const handleTranscript = async () => {
-    const roomId = data?.livekit?.room
+    const roomId = apiRoomData?.livekit?.room
 
     if (!roomId) {
       console.warn('No room ID found')
@@ -43,9 +43,9 @@ export const TranscriptMenuItem = () => {
   }
 
   if (
-    !apiConfig.recording?.is_enabled ||
-    !apiConfig.recording?.available_modes?.includes(RecordingMode.Transcript) ||
-    !data.is_administrable
+    !data?.recording?.is_enabled ||
+    !data?.recording?.available_modes?.includes(RecordingMode.Transcript) ||
+    !apiRoomData?.is_administrable
   ) {
     return
   }

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
@@ -1,0 +1,60 @@
+import { RiRecordCircleLine, RiStopCircleLine } from '@remixicon/react'
+import { useTranslation } from 'react-i18next'
+import { menuRecipe } from '@/primitives/menuRecipe'
+import { MenuItem } from 'react-aria-components'
+import {
+  RecordingMode,
+  useStartRecording,
+} from '@/features/rooms/api/startRecording'
+import { useStopRecording } from '@/features/rooms/api/stopRecording'
+import { useRoomContext } from '@livekit/components-react'
+import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+
+export const TranscriptMenuItem = () => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'options.items' })
+
+  const data = useRoomData()
+
+  const { mutateAsync: startRecordingRoom } = useStartRecording()
+  const { mutateAsync: stopRecordingRoom } = useStopRecording()
+
+  const room = useRoomContext()
+
+  const handleTranscript = async () => {
+    const roomId = data?.livekit?.room
+
+    if (!roomId) {
+      console.warn('No room ID found')
+      return
+    }
+
+    try {
+      if (room.isRecording) {
+        await stopRecordingRoom({ id: roomId })
+      } else {
+        await startRecordingRoom({ id: roomId, mode: RecordingMode.Transcript })
+      }
+    } catch (error) {
+      console.error('Failed to handle transcript:', error)
+    }
+  }
+
+  return (
+    <MenuItem
+      className={menuRecipe({ icon: true }).item}
+      onAction={async () => await handleTranscript()}
+    >
+      {room.isRecording ? (
+        <>
+          <RiRecordCircleLine size={20} />
+          {t('transcript.stop')}
+        </>
+      ) : (
+        <>
+          <RiStopCircleLine size={20} />
+          {t('transcript.start')}
+        </>
+      )}
+    </MenuItem>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
@@ -9,6 +9,7 @@ import {
 import { useStopRecording } from '@/features/rooms/api/stopRecording'
 import { useRoomContext } from '@livekit/components-react'
 import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+import { useConfig } from '@/api/useConfig'
 
 export const TranscriptMenuItem = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'options.items' })
@@ -17,6 +18,8 @@ export const TranscriptMenuItem = () => {
 
   const { mutateAsync: startRecordingRoom } = useStartRecording()
   const { mutateAsync: stopRecordingRoom } = useStopRecording()
+
+  const { data: apiConfig } = useConfig()
 
   const room = useRoomContext()
 
@@ -37,6 +40,13 @@ export const TranscriptMenuItem = () => {
     } catch (error) {
       console.error('Failed to handle transcript:', error)
     }
+  }
+
+  if (
+    !apiConfig.recording?.is_enabled ||
+    !apiConfig.recording?.available_modes?.includes(RecordingMode.Transcript)
+  ) {
+    return
   }
 
   return (

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/TranscriptMenuItem.tsx
@@ -44,7 +44,8 @@ export const TranscriptMenuItem = () => {
 
   if (
     !apiConfig.recording?.is_enabled ||
-    !apiConfig.recording?.available_modes?.includes(RecordingMode.Transcript)
+    !apiConfig.recording?.available_modes?.includes(RecordingMode.Transcript) ||
+    !data.is_administrable
   ) {
     return
   }

--- a/src/frontend/src/features/rooms/livekit/prefabs/ControlBar.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/ControlBar.tsx
@@ -3,13 +3,9 @@ import * as React from 'react'
 
 import { supportsScreenSharing } from '@livekit/components-core'
 
-import {
-  useMaybeLayoutContext,
-  usePersistentUserChoices,
-} from '@livekit/components-react'
+import { usePersistentUserChoices } from '@livekit/components-react'
 
 import { StartMediaButton } from '../components/controls/StartMediaButton'
-import { useMediaQuery } from '../hooks/useMediaQuery'
 import { OptionsButton } from '../components/controls/Options/OptionsButton'
 import { ParticipantsToggle } from '../components/controls/Participants/ParticipantsToggle'
 import { ChatToggle } from '../components/controls/ChatToggle'
@@ -60,25 +56,9 @@ export interface ControlBarProps extends React.HTMLAttributes<HTMLDivElement> {
  * @public
  */
 export function ControlBar({
-  variation,
   saveUserChoices = true,
   onDeviceError,
 }: ControlBarProps) {
-  const [isChatOpen, setIsChatOpen] = React.useState(false)
-  const layoutContext = useMaybeLayoutContext()
-  React.useEffect(() => {
-    if (layoutContext?.widget.state?.showChat !== undefined) {
-      setIsChatOpen(layoutContext?.widget.state?.showChat)
-    }
-  }, [layoutContext?.widget.state?.showChat])
-
-  const isTooLittleSpace = useMediaQuery(
-    `(max-width: ${isChatOpen ? 1000 : 760}px)`
-  )
-
-  const defaultVariation = isTooLittleSpace ? 'minimal' : 'verbose'
-  variation ??= defaultVariation
-
   const browserSupportsScreenSharing = supportsScreenSharing()
 
   const {

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -79,7 +79,11 @@
       "support": "",
       "settings": "",
       "username": "",
-      "effects": ""
+      "effects": "",
+      "transcript": {
+        "start": "",
+        "stop": ""
+      }
     }
   },
   "effects": {

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -78,7 +78,11 @@
       "support": "Get Help on Tchap",
       "settings": "Settings",
       "username": "Update Your Name",
-      "effects": "Apply effects"
+      "effects": "Apply effects",
+      "transcript": {
+        "start": "Start meeting transcription",
+        "stop": "Stop ongoing transcription"
+      }
     }
   },
   "effects": {

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -78,7 +78,11 @@
       "support": "Obtenir de l'aide sur Tchap",
       "settings": "Paramètres",
       "username": "Choisir votre nom",
-      "effects": "Appliquer des effets"
+      "effects": "Appliquer des effets",
+      "transcript": {
+        "start": "Démarrer la transcription",
+        "stop": "Arrêter la transcription en cours"
+      }
     }
   },
   "effects": {

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -54,6 +54,11 @@ backend:
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     AWS_STORAGE_BUCKET_NAME: meet-media-storage
+    AWS_S3_REGION_NAME: local
+    RECORDING_ENABLE: True
+    RECORDING_VERIFY_SSL: False
+    RECORDING_STORAGE_EVENT_ENABLE: True
+    RECORDING_STORAGE_EVENT_TOKEN: password
 
 
   migrate:

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -113,6 +113,12 @@ backend:
         name: meet-media-storage.bucket.libre.sh
         key: bucket
     AWS_S3_REGION_NAME: local
+    RECORDING_ENABLE: True
+    RECORDING_STORAGE_EVENT_ENABLE: True
+    RECORDING_STORAGE_EVENT_TOKEN:
+        secretKeyRef:
+            name: backend
+            key: RECORDING_STORAGE_EVENT_TOKEN
 
   createsuperuser:
     command:

--- a/src/helm/meet/templates/secrets.yaml
+++ b/src/helm/meet/templates/secrets.yaml
@@ -15,3 +15,4 @@ stringData:
   OIDC_RP_CLIENT_SECRET: {{ .Values.oidc.clientSecret }}
   LIVEKIT_API_SECRET: {{ .Values.livekitApi.secret }}
   LIVEKIT_API_KEY: {{ .Values.livekitApi.key }}
+  RECORDING_STORAGE_EVENT_TOKEN: {{ .Values.recordingStorageEventToken }}


### PR DESCRIPTION
## Description 

The recording feature needs to be enabled in the dev and staging environments. 

Currently, the MinIO webhook is broken. When using the nip.io address, while the MinIO post the webhook, it results in certificate errors, preventing MinIO from posting to the webhook ofc. 

I've tried to read MinIO config documentation. Other type of notification seems to offer a `skip_ssl_verification` which is not supported for the webhook type.

My goal is to add a bucket event notification on `Put` on our bucket. I would like to configure everything in the helmfile, so any dev starting the project has no configuration to do. 

### TODO  

- [x] Fix MinIO webhook certificate errors in the dev environment.  
- [ ] Add a secret for the webhook password and sync secrets.
- [x] Commit frontend code to enable recording (planned for tomorrow morning) to allow Jacques test it.