### PR TITLE
📱(front) improve control bar responsive

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
               <Route component={NotFoundScreen} />
             </Switch>
           </Layout>
-          <ReactQueryDevtools initialIsOpen={false} />
+          <ReactQueryDevtools initialIsOpen={false} buttonPosition="top-left" />
         </I18nProvider>
       </Suspense>
     </QueryClientProvider>

--- a/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
@@ -1,0 +1,37 @@
+import { ToggleButton } from '@/primitives'
+import { RiQuestionLine } from '@remixicon/react'
+import { useTranslation } from 'react-i18next'
+import { Crisp } from 'crisp-sdk-web'
+import { useEffect, useState } from 'react'
+
+export const SupportToggle = () => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'controls' })
+  const [isOpened, setIsOpened] = useState($crisp.is('chat:opened'))
+
+  useEffect(() => {
+    Crisp.chat.onChatOpened(() => {
+      setIsOpened(true)
+    })
+    Crisp.chat.onChatClosed(() => {
+      setIsOpened(false)
+    })
+    return () => {
+      Crisp.chat.offChatOpened()
+      Crisp.chat.offChatClosed()
+    }
+  }, [])
+
+  return (
+    <ToggleButton
+      square
+      variant="primaryTextDark"
+      tooltip={t('support')}
+      aria-label={t('support')}
+      isSelected={isOpened}
+      onPress={() => (isOpened ? Crisp.chat.close() : Crisp.chat.open())}
+      data-attr="controls-support"
+    >
+      <RiQuestionLine />
+    </ToggleButton>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/prefabs/ControlBar.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/ControlBar.tsx
@@ -18,6 +18,7 @@ import { SelectToggleDevice } from '../components/controls/SelectToggleDevice'
 import { LeaveButton } from '../components/controls/LeaveButton'
 import { ScreenShareToggle } from '../components/controls/ScreenShareToggle'
 import { css } from '@/styled-system/css'
+import { SupportToggle } from '@/features/rooms/livekit/components/controls/SupportToggle.tsx'
 
 /** @public */
 export type ControlBarControls = {
@@ -103,28 +104,32 @@ export function ControlBar({
   return (
     <div
       className={css({
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '.75rem',
-        maxHeight: 'var(--lk-control-bar-height)',
-        height: '80px',
+        width: '100vw',
+        display: 'flex',
         position: 'absolute',
+        padding: '1.125rem',
         bottom: 0,
         left: 0,
         right: 0,
-        display: 'flex',
       })}
     >
       <div
         className={css({
           display: 'flex',
-          gap: '.5rem',
+          justifyContent: 'flex-start',
+          flex: '1 1 33%',
           alignItems: 'center',
-          lg: {
-            position: 'absolute',
-            left: '50%',
-            transform: 'translateX(-50%)',
-          },
+          gap: '0.5rem',
+          marginLeft: '0.5rem',
+        })}
+      ></div>
+      <div
+        className={css({
+          flex: '1 1 33%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          display: 'flex',
+          gap: '0.65rem',
         })}
       >
         <SelectToggleDevice
@@ -162,17 +167,16 @@ export function ControlBar({
       <div
         className={css({
           display: 'flex',
-          gap: '.5rem',
+          justifyContent: 'flex-end',
+          flex: '1 1 33%',
           alignItems: 'center',
-          marginRight: '6.25rem',
-          lg: {
-            position: 'absolute',
-            right: 0,
-          },
+          gap: '0.5rem',
+          paddingRight: '0.25rem',
         })}
       >
         <ChatToggle />
         <ParticipantsToggle />
+        <SupportToggle />
       </div>
     </div>
   )

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -77,7 +77,6 @@
     "buttonLabel": "",
     "items": {
       "feedbacks": "",
-      "support": "",
       "settings": "",
       "username": "",
       "effects": ""

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -70,7 +70,8 @@
     "participants": {
       "open": "",
       "closed": ""
-    }
+    },
+    "support": ""
   },
   "options": {
     "buttonLabel": "",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -69,7 +69,8 @@
     "participants": {
       "open": "Hide everyone",
       "closed": "See everyone"
-    }
+    },
+    "support": "Support"
   },
   "options": {
     "buttonLabel": "More Options",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -76,7 +76,6 @@
     "buttonLabel": "More Options",
     "items": {
       "feedbacks": "Give us feedbacks",
-      "support": "Get Help on Tchap",
       "settings": "Settings",
       "username": "Update Your Name",
       "effects": "Apply effects"

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -76,7 +76,6 @@
     "buttonLabel": "Plus d'options",
     "items": {
       "feedbacks": "Partager votre avis",
-      "support": "Obtenir de l'aide sur Tchap",
       "settings": "Paramètres",
       "username": "Choisir votre nom",
       "effects": "Appliquer des effets"

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -69,7 +69,8 @@
     "participants": {
       "open": "Masquer les participants",
       "closed": "Afficher les participants"
-    }
+    },
+    "support": "Support"
   },
   "options": {
     "buttonLabel": "Plus d'options",

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -25,3 +25,7 @@ body,
     transition: none !important;
   }
 }
+
+body:has(.lk-video-conference) #crisp-chatbox > div > a {
+  display: none !important;
+}


### PR DESCRIPTION
We want the bottom bar to stay at the center of the screen + I also added a bit of vertical spacing around the control bar @lebaudantoine .

# Before
<img width="765" alt="Capture d’écran 2024-11-29 à 11 35 51" src="https://github.com/user-attachments/assets/9aa04e21-cc3f-463b-8932-29667ec19a19">

# After
<img width="756" alt="Capture d’écran 2024-11-29 à 11 35 47" src="https://github.com/user-attachments/assets/57005bae-4199-4fc2-b315-da98cc7099bf">


