### PR TITLE
Use our self-deployed models

### DIFF
--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -125,6 +125,9 @@ summary:
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     OPENAI_API_KEY: password
+    OPENAI_BASE_URL: https://albertine.beta.numerique.gouv.fr:32222/v1
+    OPENAI_ASR_MODEL: openai/whisper-large-v3
+    OPENAI_LLM_MODEL: meta-llama/Llama-3.1-8B-Instruct
     AWS_S3_SECURE_ACCESS: False
     WEBHOOK_API_TOKEN: password
     WEBHOOK_URL: https://www.mock-impress.com/webhook/
@@ -155,6 +158,9 @@ celery:
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     OPENAI_API_KEY: password
+    OPENAI_BASE_URL: https://albertine.beta.numerique.gouv.fr:32222/v1
+    OPENAI_ASR_MODEL: openai/whisper-large-v3
+    OPENAI_LLM_MODEL: meta-llama/Llama-3.1-8B-Instruct
     AWS_S3_SECURE_ACCESS: False
     WEBHOOK_API_TOKEN: password
     WEBHOOK_URL: https://www.mock-impress.com/webhook/

--- a/src/helm/env.d/staging/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/staging/values.meet.yaml.gotmpl
@@ -216,6 +216,9 @@ summary:
       secretKeyRef:
         name: summary
         key: OPENAI_API_KEY
+    OPENAI_BASE_URL: https://albertine.beta.numerique.gouv.fr:32222/v1
+    OPENAI_ASR_MODEL: openai/whisper-large-v3
+    OPENAI_LLM_MODEL: meta-llama/Llama-3.1-8B-Instruct
     WEBHOOK_API_TOKEN:
       secretKeyRef:
         name: summary


### PR DESCRIPTION
Switch from OpenAI to our own self-hosted models.
