### PR TITLE
Optimizations

### DIFF
--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -65,6 +65,9 @@ export const Conference = ({
 
   const roomOptions = useMemo((): RoomOptions => {
     return {
+      publishDefaults: {
+        videoCodec: 'vp9',
+      },
       videoCaptureDefaults: {
         deviceId: userConfig.videoDeviceId ?? undefined,
       },

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -66,6 +66,7 @@ export const Conference = ({
   const roomOptions = useMemo((): RoomOptions => {
     return {
       adaptiveStream: true,
+      dynacast: true,
       publishDefaults: {
         videoCodec: 'vp9',
       },

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -65,6 +65,7 @@ export const Conference = ({
 
   const roomOptions = useMemo((): RoomOptions => {
     return {
+      adaptiveStream: true,
       publishDefaults: {
         videoCodec: 'vp9',
       },


### PR DESCRIPTION
## Purpose

Address #237 and in general optimize bandwidth usage for large room. 

## Proposition

I've enabled several key optimizations from LiveKit, including Adaptive Stream, Dynacast, and modern video codecs. I’m not sure why we didn’t enable these earlier—my mistake.

I spent a significant amount of time reviewing LiveKit’s code, exploring other projects that use it, viewing conferences, and reading the official WebRTC documentation. Based on that, I believe the changes in my commit are optimal.

Locally, I tested it by creating a room and joining with Chrome on one side and Firefox on the other. VP9 decoding works on Firefox, while the Firefox client sends VP8.

Using `about:webrtc`, I confirmed that Dynacast and Adaptive Stream were enabled. For example, when the other participant is on a different tab, my video track stops sending bytes, which helps with bandwidth. Similarly, if I switch to another tab, I stop receiving data from the peer. These optimizations take effect after a few seconds of changing or hiding the tab.

When I return to the Visio conference room, the video resumes in less than a second.

Please have a look at my commits, I detail everything in it.
