### PR TITLE
🔧(backend) fix sentry deprecated scope

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -503,9 +503,10 @@ class Base(Configuration):
                 release=get_release(),
                 integrations=[DjangoIntegration()],
             )
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_extra("application", "backend")
 
+            # Add the application name to the Sentry scope
+            scope = sentry_sdk.get_global_scope()
+            scope.set_tag("application", "backend")
 
 class Build(Base):
     """Settings used when the application is built.


### PR DESCRIPTION
`sentry_sdk.configure_scope` is deprecated and will be removed in the next major version.

(commit taken from people by @qbey)