### PR TITLE
🩹(frontend) avoid duplicating Grist form's URL

### DIFF
--- a/src/frontend/src/components/FeedbackBanner.tsx
+++ b/src/frontend/src/components/FeedbackBanner.tsx
@@ -2,9 +2,7 @@ import { css } from '@/styled-system/css'
 import { RiErrorWarningLine, RiExternalLinkLine } from '@remixicon/react'
 import { useTranslation } from 'react-i18next'
 import { Text, A } from '@/primitives'
-
-const GRIST_FORM =
-  'https://grist.numerique.gouv.fr/o/docs/forms/1YrfNP1QSSy8p2gCxMFnSf/4'
+import { GRIST_FORM } from '@/utils/constants'
 
 export const FeedbackBanner = () => {
   const { t } = useTranslation()

--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/OptionsMenuItems.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/OptionsMenuItems.tsx
@@ -9,6 +9,7 @@ import { Separator } from '@/primitives/Separator'
 import { useSidePanel } from '../../../hooks/useSidePanel'
 import { menuRecipe } from '@/primitives/menuRecipe.ts'
 import { useSettingsDialog } from '../SettingsDialogContext'
+import { GRIST_FORM } from '@/utils/constants'
 
 // @todo try refactoring it to use MenuList component
 export const OptionsMenuItems = () => {
@@ -34,7 +35,7 @@ export const OptionsMenuItems = () => {
       <Separator />
       <Section>
         <MenuItem
-          href="https://grist.incubateur.net/o/docs/forms/1YrfNP1QSSy8p2gCxMFnSf/4"
+          href={GRIST_FORM}
           target="_blank"
           className={menuRecipe({ icon: true }).item}
         >

--- a/src/frontend/src/utils/constants.ts
+++ b/src/frontend/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const GRIST_FORM =
+  'https://grist.numerique.gouv.fr/o/docs/forms/1YrfNP1QSSy8p2gCxMFnSf/4' as const


### PR DESCRIPTION
It led to an error, with two occurrences of the form's URL being desynchronized. Fix this minor issue, and refactor the constant in a constant file to be shared across the app.
