### PR TITLE
🚨(backend) fix Django UnorderedObjectListWarning on User and ResourceAccess

### DIFF
--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -189,6 +189,7 @@ class User(AbstractBaseUser, BaseModel, auth_models.PermissionsMixin):
 
     class Meta:
         db_table = "meet_user"
+        ordering = ("-created_at",)
         verbose_name = _("user")
         verbose_name_plural = _("users")
 
@@ -304,6 +305,7 @@ class ResourceAccess(BaseModel):
 
     class Meta:
         db_table = "meet_resource_access"
+        ordering = ("-created_at",)
         verbose_name = _("Resource access")
         verbose_name_plural = _("Resource accesses")
         constraints = [

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -66,7 +66,7 @@ def test_api_users_list_query_email():
 
     assert response.status_code == 200
     user_ids = [user["id"] for user in response.json()["results"]]
-    assert user_ids == [str(nicole.id), str(frank.id)]
+    assert user_ids == [str(frank.id), str(nicole.id)]
 
 
 def test_api_users_retrieve_me_anonymous():


### PR DESCRIPTION
Found this solution googling on Stack Overflow.

Without a default ordering on a model, Django raises a warning, that pagination may yield inconsistent results.
