### PR TITLE
Poc e2ee

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -130,16 +130,16 @@ class RoomSerializer(serializers.ModelSerializer):
             del output["configuration"]
 
         if role is not None or instance.is_public:
-            slug = f"{instance.id!s}"
+            room_id = f"{instance.id!s}"
             username = request.query_params.get("username", None)
 
             output["livekit"] = {
                 "url": settings.LIVEKIT_CONFIGURATION["url"],
-                "room": slug,
+                "room": room_id,
                 "token": utils.generate_token(
-                    room=slug, user=request.user, username=username
+                    room=room_id, user=request.user, username=username
                 ),
-                "passphrase": utils.get_cached_passphrase(slug)
+                "passphrase": utils.get_cached_passphrase(room_id)
             }
             
         output["is_administrable"] = is_admin

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -143,6 +143,8 @@ class RoomSerializer(serializers.ModelSerializer):
 
         output["is_administrable"] = is_admin
 
+        output['passphrase'] = "thisisapassphrase"
+
         return output
 
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -139,11 +139,10 @@ class RoomSerializer(serializers.ModelSerializer):
                 "token": utils.generate_token(
                     room=slug, user=request.user, username=username
                 ),
+                "passphrase": utils.get_cached_passphrase(slug)
             }
-
+            
         output["is_administrable"] = is_admin
-
-        output['passphrase'] = "thisisapassphrase"
 
         return output
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -210,6 +210,10 @@ class RoomViewSet(
         Allow unregistered rooms when activated.
         For unregistered rooms we only return a null id and the livekit room and token.
         """
+
+        # todo - determine whether encryption is needed store a shared secret in memory or in redis
+        # todo - check if a secret already exists, else create one.
+
         try:
             instance = self.get_object()
         except Http404:
@@ -342,6 +346,8 @@ class RoomViewSet(
         return drf_response.Response(
             {"message": f"Recording stopped for room {room.slug}."}
         )
+
+    # todo - support a callback endpoint when a room is finished, to invalidate cached key
 
 
 class ResourceAccessListModelMixin:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -47,6 +47,8 @@ from core.recording.worker.mediator import (
 
 from . import permissions, serializers
 
+from livekit import api as livekit_api
+
 # pylint: disable=too-many-ancestors
 
 logger = getLogger(__name__)
@@ -347,7 +349,35 @@ class RoomViewSet(
             {"message": f"Recording stopped for room {room.slug}."}
         )
 
-    # todo - support a callback endpoint when a room is finished, to invalidate cached key
+    @decorators.action(
+        detail=False,
+        methods=["post"],
+        url_path="livekit-webhook",
+        permission_classes=[],
+        authentication_classes=[],
+    )
+    def handle_livekit_webhook(self, request, pk=None):  # pylint: disable=unused-argument
+        """Handle LiveKit webhook events."""
+        auth_token = request.headers.get("Authorization")
+        if not auth_token:
+            return drf_response.Response(
+                {"error": "Missing LiveKit authentication token"},
+                status=drf_status.HTTP_401_UNAUTHORIZED
+            )
+
+        token_verifier = livekit_api.TokenVerifier()
+        webhook_receiver = livekit_api.WebhookReceiver(token_verifier)
+
+        webhook_data = webhook_receiver.receive(request.body.decode("utf-8"), auth_token)
+
+        # Todo - livekit triggers a webhook for all events, see if we can restrict webhook to a limited number of events.
+        # Todo - handle Egress stopped / aborted events.
+
+        if webhook_data.event == "room_finished":
+            room_id = webhook_data.room.name
+            utils.clear_cache_passphrase(room_id)
+
+        return drf_response.Response({"message": f"Event processed"})
 
 
 class ResourceAccessListModelMixin:

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -14,6 +14,21 @@ from django.conf import settings
 
 from livekit.api import AccessToken, VideoGrants
 
+from functools import lru_cache
+import secrets
+import string
+
+
+def generate_random_passphrase(length=26):
+    """Generate a random passphrase using letters and digits"""
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+@lru_cache()
+def get_cached_passphrase(room_slug):
+    """Get or generate a cached passphrase for a room slug"""
+    return generate_random_passphrase()
+
 
 def generate_color(identity: str) -> str:
     """Generates a consistent HSL color based on a given identity string.

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -483,6 +483,8 @@ class Base(Configuration):
     )
     BREVO_API_CONTACT_ATTRIBUTES = values.DictValue({"VISIO_USER": True})
 
+    PASSPHRASE_ENCRYPTION_KEY = values.Value(environ_name="PASSPHRASE_ENCRYPTION_KEY", environ_prefix=None)
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/src/frontend/src/features/rooms/api/ApiRoom.ts
+++ b/src/frontend/src/features/rooms/api/ApiRoom.ts
@@ -4,11 +4,11 @@ export type ApiRoom = {
   slug: string
   is_public: boolean
   is_administrable: boolean
-  passphrase: string
   livekit?: {
     url: string
     room: string
     token: string
+    passphrase: string
   }
   configuration?: {
     [key: string]: string | number | boolean

--- a/src/frontend/src/features/rooms/api/ApiRoom.ts
+++ b/src/frontend/src/features/rooms/api/ApiRoom.ts
@@ -4,6 +4,7 @@ export type ApiRoom = {
   slug: string
   is_public: boolean
   is_administrable: boolean
+  passphrase: string
   livekit?: {
     url: string
     room: string

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -110,7 +110,7 @@ export const Conference = ({
     }
     if (e2eeEnabled) {
       keyProvider
-        .setKey(data.passphrase)
+        .setKey(data.livekit?.passphrase)
         .then(() => {
           room.setE2EEEnabled(true).catch((e) => {
             if (e instanceof DeviceUnsupportedError) {

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -68,14 +68,11 @@ export const Conference = ({
     retry: false,
   })
 
-  const e2eePassphrase = typeof window !== 'undefined' && 'thisisapassphrase'
-
   const worker =
     typeof window !== 'undefined' &&
-    e2eePassphrase &&
     new Worker(new URL('livekit-client/e2ee-worker', import.meta.url))
 
-  const e2eeEnabled = !!(e2eePassphrase && worker)
+  const e2eeEnabled = !!worker
   const keyProvider = new ExternalE2EEKeyProvider()
 
   const [e2eeSetupComplete, setE2eeSetupComplete] = useState(false)
@@ -108,9 +105,12 @@ export const Conference = ({
   const room = useMemo(() => new Room(roomOptions), [roomOptions])
 
   useEffect(() => {
+    if (!data) {
+      return
+    }
     if (e2eeEnabled) {
       keyProvider
-        .setKey('thisisapassphrase')
+        .setKey(data.passphrase)
         .then(() => {
           room.setE2EEEnabled(true).catch((e) => {
             if (e instanceof DeviceUnsupportedError) {
@@ -127,7 +127,7 @@ export const Conference = ({
     } else {
       setE2eeSetupComplete(true)
     }
-  }, [e2eeEnabled, room, e2eePassphrase])
+  }, [e2eeEnabled, room, data])
 
   const [showInviteDialog, setShowInviteDialog] = useState(mode === 'create')
 

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -15,8 +15,9 @@ import {
   VideoTrack,
   TrackRefContext,
   ParticipantContextIfNeeded,
+  useIsSpeaking,
 } from '@livekit/components-react'
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   isTrackReference,
   isTrackReferencePinned,

--- a/src/helm/env.d/dev/values.livekit.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.livekit.yaml.gotmpl
@@ -17,6 +17,10 @@ livekit:
     udp_port: 443
     domain: livekit.127.0.0.1.nip.io
     loadBalancerAnnotations: {}
+  webhook:
+    api_key: devkey
+    urls:
+      - https://meet.127.0.0.1.nip.io/api/v1.0/rooms/livekit-webhook/
 
 
 loadBalancer:

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -61,6 +61,7 @@ backend:
     RECORDING_STORAGE_EVENT_TOKEN: password
     SUMMARY_SERVICE_ENDPOINT: http://meet-summary:80/api/v1/tasks/
     SUMMARY_SERVICE_API_TOKEN: password
+    PASSPHRASE_ENCRYPTION_KEY: lT3cX5dzFhCe-9xNjXUiTCX00r2ZgHgGUJKO66x-QIo=
 
 
   migrate:


### PR DESCRIPTION
## Purpose

This PR implements end-to-end encryption (E2EE) capabilities for LiveKit rooms using WebRTC's Frame Encryption API. The implementation ensures that media streams are encrypted on the sender's side and can only be decrypted by authorized participants, maintaining confidentiality even from the LiveKit server.

It's a proof of concept, not intended to be merged.

According to LiveKit documentation : 

> Connections are established using 256-bit TLS encryption and media streams are encrypted with AES-128. All data at rest is encrypted with AES-256

E2EE adds an extra layer of security features, when you cannot trust the LiveKit server.


## Proposal

During room access token generation, the first participant triggers the creation of a room passphrase, which is encrypted using Fernet symmetric encryption and stored in Redis. Subsequent participants retrieve this encrypted passphrase from the cache. When the room ends, LiveKit's webhook notifies the backend to invalidate the cached passphrase.

Using Fernet symmetric encryption is fine for short-term storage. 

It's a naive approach, but yet simple.

All participants share an encryption key that remains constant throughout the meeting session, without rotation.


## Technical Limitations

Current E2EE feature isn't perfect yet, for a few reasons: 

**Codec Compatibility**

Limited to VP8 video and Opus audio
VP9/AV1 incompatible due to lack of encrypted backup codec support
Required for backwards compatibility with non-VP9 clients

→ doesn't support most recent and optimized Media codec.

**Audio Processing**

RED (Redundant Encoding) unsupported
Server cannot strip RED packets when E2EE enabled

→ Cannot enable this optimization.

**Browser Support**

Requires Firefox 117+ for compatibility
Chrome/Edge: 86+
Safari: 15.4+

→ Not available for our FF 115 users

**Performance Considerations**

Increased CPU usage on resource-constrained devices
Web Worker implementation mitigates main thread impact

**AI or recording**

E2EE disables Egress functionality, preventing AI features that require room audio recording and processing.

→ Disable a differentiating feature

**Documentation**

I haven't found any documentation on LiveKit website.

**Algorithm**

Yet supports only AES-GCM 128, no 256.

## Source code

[FrameCryptor](https://github.com/livekit/client-sdk-js/blob/d6d03ee6844ef49edd5d5783e436a94e53a5390c/src/e2ee/worker/FrameCryptor.ts) is responsible for en-/decrypting media frames.

[KeyProvider](https://github.com/livekit/client-sdk-js/blob/d6d03ee6844ef49edd5d5783e436a94e53a5390c/src/e2ee/KeyProvider.ts#L12) is responsible for key lifecycle.


## Future Enhancements

**Dynamic Encryption**

- Investigation needed: Enable/disable encryption mid-session
- Requires careful key distribution and participant synchronization


**Passphrase Requirements**

- Define secure passphrase format
- verify the passphrase generation is totally secure


**Room Configuration**

- Make encryption opt-in rather than default
- Provide admin controls for encryption settings

## My 2cts

E2EE should be disabled by default for several reasons:

- Not all meetings require the additional security layer and computational overhead
- Enables broader codec support (VP9, AV1) for standard meetings
- Maintains compatibility with features like audio RED and egress
- Not supported on our targeted FF version


End-to-end encryption becomes critical in scenarios where:

- The LiveKit infrastructure might be compromised
- Meeting content is highly sensitive (e.g., "Diffusion Restreinte" discussions, medical data)
- Zero-trust security model is mandated


