### PR TITLE
🔐(helm) configure Brevo marketing tool

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -460,7 +460,7 @@ class Base(Configuration):
     # Marketing and communication settings
     SIGNUP_NEW_USER_TO_MARKETING_EMAIL = values.BooleanValue(
         False,
-        environ_name="SIGNUP_NEW_USERS_TO_NEWSLETTER",
+        environ_name="SIGNUP_NEW_USER_TO_MARKETING_EMAIL",
         environ_prefix=None,
         help_text=(
             "When enabled, new users are automatically added to mailing list "

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -459,13 +459,9 @@ class Base(Configuration):
 
     # Marketing and communication settings
     SIGNUP_NEW_USER_TO_MARKETING_EMAIL = values.BooleanValue(
-        False,
+        False,  # When enabled, new users are automatically added to mailing list.
         environ_name="SIGNUP_NEW_USER_TO_MARKETING_EMAIL",
         environ_prefix=None,
-        help_text=(
-            "When enabled, new users are automatically added to mailing list "
-            "for product updates, marketing communications, and customized emails. "
-        ),
     )
     MARKETING_SERVICE_CLASS = values.Value(
         "core.services.marketing_service.BrevoMarketingService",

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -9,6 +9,11 @@ secrets:
     field: password
     podVariable: OIDC_RP_CLIENT_SECRET
     clusterSecretStore: bitwarden-login-meet
+  - name: brevoApiKey
+    itemId: 99107889-6124-4436-97cc-a5193f28443f
+    field: password
+    podVariable: BREVO_API_KEY
+    clusterSecretStore: bitwarden-login-meet
 image:
   repository: localhost:5001/meet-backend
   pullPolicy: Always
@@ -78,6 +83,12 @@ backend:
     RECORDING_STORAGE_EVENT_TOKEN: password
     SUMMARY_SERVICE_ENDPOINT: http://meet-summary:80/api/v1/tasks/
     SUMMARY_SERVICE_API_TOKEN: password
+    SIGNUP_NEW_USER_TO_MARKETING_EMAIL: True
+    BREVO_API_KEY:
+      secretKeyRef:
+        name: backend
+        key: BREVO_API_KEY
+    BREVO_API_CONTACT_LIST_IDS: 8
 
 
   migrate:


### PR DESCRIPTION
Using VaultWarden, added a dev Brevo API key.
In the "dev" stack, enable Brevo to validate new users are signed-up to the marketing emails.

Can be merged after #299 