### PR TITLE
🩹(frontend) fix allowed hosts by Vite using the Tilt stack

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig(({ mode }) => {
     server: {
       port: parseInt(env.VITE_PORT) || 3000,
       host: env.VITE_HOST || 'localhost',
+      allowedHosts: ['.nip.io'],
     },
   }
 })


### PR DESCRIPTION
I recently got the error:

> Blocked request. This host ("meet.127.0.0.1.nip.io") is not allowed.
> To allow this host, add "meet.127.0.0.1.nip.io" to server.allowedHosts in vite.config.js.

We apparently need to explicitly allow these domains in Vite's server configuration to prevent host security violations.
This check should be ignored when using HTTPS.

I've made local config changes that might create this issue. @NathanVss, can you reproduce? 
