### PR TITLE
🩹(frontend) prevent runtime error when Crisp is not initialized

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
@@ -7,7 +7,9 @@ import { ToggleButtonProps } from '@/primitives/ToggleButton'
 
 export const SupportToggle = ({ onPress, ...props }: ToggleButtonProps) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls' })
-  const [isOpened, setIsOpened] = useState($crisp.is('chat:opened'))
+  const [isOpened, setIsOpened] = useState(() => {
+    return window?.$crisp?.is?.('chat:opened') || false
+  })
 
   useEffect(() => {
     if (!Crisp) {

--- a/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/SupportToggle.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { Crisp } from 'crisp-sdk-web'
 import { useEffect, useState } from 'react'
 import { ToggleButtonProps } from '@/primitives/ToggleButton'
+import { useIsSupportEnabled } from '@/features/support/hooks/useSupport'
 
 export const SupportToggle = ({ onPress, ...props }: ToggleButtonProps) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls' })
+
   const [isOpened, setIsOpened] = useState(() => {
     return window?.$crisp?.is?.('chat:opened') || false
   })
@@ -27,6 +29,12 @@ export const SupportToggle = ({ onPress, ...props }: ToggleButtonProps) => {
       Crisp.chat.offChatClosed()
     }
   }, [])
+
+  const isSupportEnabled = useIsSupportEnabled()
+
+  if (!isSupportEnabled) {
+    return
+  }
 
   return (
     <ToggleButton

--- a/src/frontend/src/features/support/hooks/useSupport.tsx
+++ b/src/frontend/src/features/support/hooks/useSupport.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Crisp } from 'crisp-sdk-web'
 import { ApiUser } from '@/features/auth/api/ApiUser'
+import { useConfig } from '@/api/useConfig'
 
 export const initializeSupportSession = (user: ApiUser) => {
   if (!Crisp.isCrispInjected()) return
@@ -28,4 +29,9 @@ export const useSupport = ({ id }: useSupportProps) => {
   }, [id])
 
   return null
+}
+
+export const useIsSupportEnabled = () => {
+  const { data } = useConfig()
+  return !!data?.support?.id
 }


### PR DESCRIPTION
Prevents runtime error when Crisp chat hasn't initialized before component mount Previously caused crash since we assumed $crisp global was always available.
