### PR TITLE
🚸(frontend) replace effects icons in menu option

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/Options/EffectsMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Options/EffectsMenuItem.tsx
@@ -1,4 +1,4 @@
-import { RiAccountBoxLine } from '@remixicon/react'
+import { RiImageCircleAiFill } from '@remixicon/react'
 import { MenuItem } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 import { menuRecipe } from '@/primitives/menuRecipe'
@@ -13,7 +13,7 @@ export const EffectsMenuItem = () => {
       onAction={() => toggleEffects()}
       className={menuRecipe({ icon: true, variant: 'dark' }).item}
     >
-      <RiAccountBoxLine size={20} />
+      <RiImageCircleAiFill size={20} />
       {t('effects')}
     </MenuItem>
   )


### PR DESCRIPTION
Align effects icon with the one from the newly refactored pre-join screen. This new icon is stylish.

To be merged after #309 