### PR TITLE
🩹(frontend) prevent support toggle when Crisp chat is blocked by browsers

### DIFF
--- a/src/frontend/src/features/support/hooks/useSupport.tsx
+++ b/src/frontend/src/features/support/hooks/useSupport.tsx
@@ -31,7 +31,17 @@ export const useSupport = ({ id }: useSupportProps) => {
   return null
 }
 
+// Some users may block Crisp chat widget with browser ad blockers or anti-tracking plugins
+// So we need to safely check if Crisp is available and not blocked
+const isCrispAvailable = () => {
+  try {
+    return !!window?.$crisp?.is
+  } catch {
+    return false
+  }
+}
+
 export const useIsSupportEnabled = () => {
   const { data } = useConfig()
-  return !!data?.support?.id
+  return !!data?.support?.id && isCrispAvailable()
 }


### PR DESCRIPTION
Some users have ad-blockers or privacy extensions that prevent the Crisp chat widget script from loading properly. This was causing the support toggle to still display in rooms, but clicking it had no effect since Crisp was blocked.

This ensures users don't see an inactive support button when their browser is blocking Crisp functionality.

Issue reported by @felhix 