### PR TITLE
🐛(backend) fix KeyError crash when role is undefined in request data

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -37,7 +37,7 @@ class ResourceAccessSerializerMixin:
             # Update
             self.instance
             and (
-                data["role"] == models.RoleChoices.OWNER
+                data.get("role") == models.RoleChoices.OWNER
                 and not self.instance.resource.is_owner(user)
                 or self.instance.role == models.RoleChoices.OWNER
                 and not self.instance.user == user


### PR DESCRIPTION
Use dict.get() instead of direct key access to prevent server crashes when role field is missing. Fix inherited from magnify project codebase.
