### PR TITLE
♻️(frontend) refactor useConnectionObserver to track session time

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
@@ -18,6 +18,7 @@ export const useConnectionObserver = () => {
       // total session duration from first connect to final disconnect.
       if (connectionStartTimeRef.current != null) return
       connectionStartTimeRef.current = Date.now()
+      posthog.capture('connection-event')
     }
 
     const handleReconnect = () => {


### PR DESCRIPTION
Add session duration tracking and consolidate all disconnect events (including client-initiated) with timing data for comprehensive connection analytics.