### PR TITLE
🔖(minor) bump release to 0.1.27

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meet"
-version = "0.1.26"
+version = "0.1.27"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meet",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meet",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@livekit/components-react": "2.9.12",
         "@livekit/components-styles": "1.1.6",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meet",
   "private": true,
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "dev": "panda codegen && vite",

--- a/src/mail/package-lock.json
+++ b/src/mail/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mail_mjml",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mail_mjml",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "MIT",
       "dependencies": {
         "@html-to/text-cli": "0.5.4",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {

--- a/src/sdk/package-lock.json
+++ b/src/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sdk",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sdk",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "ISC",
       "workspaces": [
         "./library",

--- a/src/sdk/package.json
+++ b/src/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "author": "",
   "license": "ISC",
   "description": "",

--- a/src/summary/pyproject.toml
+++ b/src/summary/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "summary"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
     "fastapi[standard]>=0.105.0",
     "uvicorn>=0.24.0",


### PR DESCRIPTION
White label frontend. Docs are missing, will be
written shortly after the v0.1.27 release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers across backend, frontend, mail, sdk, and summary projects to 0.1.27. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->