### PR TITLE
🌐(frontend) fix wrong plural in footer

### DIFF
--- a/src/frontend/src/locales/fr/global.json
+++ b/src/frontend/src/locales/fr/global.json
@@ -34,7 +34,7 @@
       "datagouv": "data.gouv.fr",
       "legalsTerms": "Mentions légales",
       "data": "Données personnelles et cookie",
-      "accessibility": "Accessibilités : non conforme",
+      "accessibility": "Accessibilité : non conforme",
       "ariaLabel": "nouvelle fenêtre",
       "codeAnnotation": "Notre code est ouvert et disponible sur ce",
       "code": "dépôt de code Open Source",


### PR DESCRIPTION
Accessibility should be singular.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the French footer link text for accessibility to use the singular form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->