### PR TITLE
🔊(summary) add Celery exporter configuration for monitoring

### DIFF
--- a/src/summary/summary/core/celery_config.py
+++ b/src/summary/summary/core/celery_config.py
@@ -1,0 +1,11 @@
+
+# https://github.com/danihodovic/celery-exporter
+# Enable task events for Prometheus monitoring via celery-exporter.
+
+# worker_send_task_events: Sends task lifecycle events (e.g., started, succeeded, failed),
+# allowing the exporter to track task execution metrics and durations.
+worker_send_task_events = True
+
+# task_send_sent_event: Sends an event when a task is dispatched to the broker,
+# enabling full lifecycle tracking from submission to completion (including queue time).
+task_send_sent_event = True

--- a/src/summary/summary/core/celery_worker.py
+++ b/src/summary/summary/core/celery_worker.py
@@ -37,6 +37,8 @@ celery = Celery(
     broker_connection_retry_on_startup=True,
 )
 
+celery.config_from_object('summary.core.celery_config')
+
 if settings.sentry_dsn and settings.sentry_is_enabled:
 
     @signals.celeryd_init.connect


### PR DESCRIPTION
Enable Celery task lifecycle events and broker dispatch events per @rouja's exporter requirements. Basic configuration following documentation without parameterization.
