### PR TITLE
🐛(frontend) fix wrong feature flag for noise reduction

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useNoiseReductionAvailable.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useNoiseReductionAvailable.ts
@@ -4,7 +4,7 @@ import { useIsAnalyticsEnabled } from '@/features/analytics/hooks/useIsAnalytics
 import { isMobileBrowser } from '@livekit/components-core'
 
 export const useNoiseReductionAvailable = () => {
-  const featureEnabled = useFeatureFlagEnabled(FeatureFlags.faceLandmarks)
+  const featureEnabled = useFeatureFlagEnabled(FeatureFlags.noiseReduction)
   const isAnalyticsEnabled = useIsAnalyticsEnabled()
 
   const isMobile = isMobileBrowser()


### PR DESCRIPTION
Replace incorrect faceLandmarks flag with proper noiseReduction flag to ensure correct feature availability checking.
