### PR TITLE
🐛(frontend) prevent displaying audio output selector to Safari users

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/AudioDevicesControl.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/AudioDevicesControl.tsx
@@ -15,6 +15,7 @@ import { SettingsButton } from './SettingsButton'
 import { SettingsDialogExtendedKey } from '@/features/settings/type'
 import { TrackSource } from '@livekit/protocol'
 import Source = Track.Source
+import { isSafari } from '@/utils/livekit'
 
 type AudioDevicesControlProps = Omit<
   UseTrackToggleProps<Source.Microphone>,
@@ -111,19 +112,21 @@ export const AudioDevicesControl = ({
                   onSubmit={saveAudioInputDeviceId}
                 />
               </div>
-              <div
-                style={{
-                  flex: '1 1 0',
-                  minWidth: 0,
-                }}
-              >
-                <SelectDevice
-                  context="room"
-                  kind="audiooutput"
-                  id={audioOutputDeviceId}
-                  onSubmit={saveAudioOutputDeviceId}
-                />
-              </div>
+              {!isSafari() && (
+                <div
+                  style={{
+                    flex: '1 1 0',
+                    minWidth: 0,
+                  }}
+                >
+                  <SelectDevice
+                    context="room"
+                    kind="audiooutput"
+                    id={audioOutputDeviceId}
+                    onSubmit={saveAudioOutputDeviceId}
+                  />
+                </div>
+              )}
               <SettingsButton
                 settingTab={SettingsDialogExtendedKey.AUDIO}
                 onPress={close}


### PR DESCRIPTION
Hide audio output selector component for Safari browsers due to lack of native support for audio output device selection APIs. This prevents user confusion and improves browser compatibility.

Spotted thanks to PostHog error tracking.
