### PR TITLE
♿️(frontend) add missing aria-label to screenshare button

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/ScreenShareToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ScreenShareToggle.tsx
@@ -40,6 +40,7 @@ export const ScreenShareToggle = ({
       isDisabled={!canShareScreen}
       square
       variant={variant}
+      aria-label={t(tooltipLabel)}
       tooltip={t(tooltipLabel)}
       onPress={(e) => {
         buttonProps.onClick?.(


### PR DESCRIPTION
Add accessibility label to screenshare control button to ensure screen readers can properly announce the button's function to users with visual impairments.
