### PR TITLE
⬆️(frontend) manually upgrade Alpine dependencies to fix libexpat vulnerability

### DIFF
--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -42,7 +42,7 @@ COPY ./docker/dinum-frontend/fonts/ \
 FROM nginxinc/nginx-unprivileged:alpine3.21 AS frontend-production
 
 USER root
-RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2 libxslt>=1.1.39-r2
+RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2 libxslt>=1.1.39-r2 libexpat>=2.7.2-r0
 
 USER nginx
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -38,7 +38,7 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:alpine3.21 AS frontend-production
 
 USER root
-RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2 libxslt>=1.1.39-r2
+RUN apk update && apk upgrade libssl3 libcrypto3 libxml2>=2.12.7-r2 libxslt>=1.1.39-r2 libexpat>=2.7.2-r0
 
 USER nginx
 


### PR DESCRIPTION
Manually update libexpat to 2.7.2-r0 in Alpine 3.21.3 base image to address CVE-2025-59375 high-severity vulnerability until newer Alpine base image becomes available, ensuring Trivy security scans pass.