### PR TITLE
🐛(backend) filter LiveKit webhook events by room name regex to exclude Tchap

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -517,6 +517,10 @@ class Base(Configuration):
     LIVEKIT_VERIFY_SSL = values.BooleanValue(
         True, environ_name="LIVEKIT_VERIFY_SSL", environ_prefix=None
     )
+    # Regex to filter webhook events by room name. Only matching events are processed.
+    LIVEKIT_WEBHOOK_EVENTS_FILTER_REGEX = values.Value(
+        None, environ_name="LIVEKIT_WEBHOOK_EVENTS_FILTER_REGEX", environ_prefix=None
+    )
     RESOURCE_DEFAULT_ACCESS_LEVEL = values.Value(
         "public", environ_name="RESOURCE_DEFAULT_ACCESS_LEVEL", environ_prefix=None
     )


### PR DESCRIPTION
Add configurable room name regex filtering to exclude Tchap events from shared LiveKit server webhooks, preventing backend spam from unrelated application events while maintaining UUID-based room processing for visio.

Those unrelated application events are spamming the sentry.

Acknowledges this is a pragmatic solution trading proper namespace prefixing for immediate spam reduction with minimal refactoring impact leaving prefix-based approach for future improvement.