### PR TITLE
🐛(frontend) fix inverted keyboard shortcuts for video and microphone

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useDeviceShortcut.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useDeviceShortcut.ts
@@ -6,12 +6,12 @@ export const useDeviceShortcut = (kind: MediaDeviceKind) => {
     switch (kind) {
       case 'audioinput':
         return {
-          key: 'e',
+          key: 'd',
           ctrlKey: true,
         }
       case 'videoinput':
         return {
-          key: 'd',
+          key: 'e',
           ctrlKey: true,
         }
       default:


### PR DESCRIPTION
Correct accidentally swapped keyboard shortcuts between video and microphone toggle controls introduced during device component refactoring, restoring expected shortcut behavior reported by users.
