### PR TITLE
🩹(doc) fix wrong endpoint path

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7,7 +7,7 @@ info:
     
     #### Authentication Flow
     
-    1. Exchange application credentials for a JWT token via `/external-api/v1.0/applications/token`.
+    1. Exchange application credentials for a JWT token via `/external-api/v1.0/application/token`.
     2. Use the JWT token in the `Authorization: Bearer <token>` header for all subsequent requests.
     3. Tokens are scoped and allow applications to act on behalf of specific users.
     
@@ -40,7 +40,7 @@ tags:
     description: Room management operations
 
 paths:
-  /applications/token:
+  /application/token:
     post:
       tags:
         - Authentication
@@ -283,7 +283,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: |
-        JWT token obtained from the `/applications/token` endpoint.
+        JWT token obtained from the `/application/token` endpoint.
         Include in requests as: `Authorization: Bearer <token>`
 
   schemas:


### PR DESCRIPTION
Applications to application in the application/token endpoint. Spotted by external contributor.