### PR TITLE
🐛(celery) fix metadata manager task_args order broken by signal sender argument

### DIFF
--- a/src/summary/summary/core/analytics.py
+++ b/src/summary/summary/core/analytics.py
@@ -123,7 +123,7 @@ class MetadataManager:
             logger.error("Invalid number of arguments to enable metadata manager.")
             return
 
-        filename, email, _, received_at, *_ = task_args
+        _, filename, email, _, received_at, *_ = task_args
 
         initial_metadata = {
             **initial_metadata,


### PR DESCRIPTION
Restore correct task_args ordering in metadata manager after commit f0939b6f added sender argument to Celery signals for transcription task scoping, unexpectedly shifting positional arguments and breaking metadata creation.

Issue went undetected due to missing staging analytics deployment, silently losing production observability on microservice without blocking transcription job execution, highlighting need for staging analytics activation.
