### PR TITLE
🐛(frontend) remove excessive z-index from screenshare warning overlay

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
@@ -71,7 +71,6 @@ export const FullScreenShareWarning = ({
     <div
       className={css({
         position: 'absolute',
-        zIndex: '1000',
         height: '100%',
         width: '100%',
       })}
@@ -81,7 +80,6 @@ export const FullScreenShareWarning = ({
         <div
           className={css({
             position: 'absolute',
-            zIndex: '1000',
             height: '100%',
             width: '100%',
             backgroundColor: 'rgba(22, 22, 34, 0.9)',


### PR DESCRIPTION
Remove 1000 z-index from screenshare warning that was causing conflicts with reaction menu and reaction displays, retaining only necessary layering to hide participant metadata underneath.