### PR TITLE
FIX: issue #753

### DIFF
--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -232,7 +232,17 @@ export const Conference = ({
             }
           }}
           onMediaDeviceFailure={(e, kind) => {
-            if (e == MediaDeviceFailure.DeviceInUse && !!kind) {
+            // Avoid showing a likely false 'DeviceInUse' alert on Firefox in
+            // certain proxy / driver setups. Suppression can be enabled from
+            // the server config under `livekit.suppress_firefox_deviceinuse_alert`.
+            const suppressOnFirefox = !!apiConfig?.livekit
+              ?.suppress_firefox_deviceinuse_alert
+
+            if (
+              e == MediaDeviceFailure.DeviceInUse &&
+              !!kind &&
+              !(isFireFox() && suppressOnFirefox)
+            ) {
               setMediaDeviceError({ error: e, kind })
             }
           }}


### PR DESCRIPTION
## Purpose
Reg issue : "Your camera is in use in another tab" 

Description...
Firefox can show a false "Your camera is in use in another tab" alert and block camera activation.


## Proposal
Add an opt‑in Firefox suppression flag.

Description...
- Neutralize locale copy for camera DeviceInUse.
- Add opt-in suppression: when [apiConfig.livekit.suppress_firefox_deviceinuse_alert] is true and client is Firefox, do not show the DeviceInUse dialog.