### PR TITLE
✨ Add multilingual support for real-time subtitles

### DIFF
--- a/src/helm/meet/values.yaml
+++ b/src/helm/meet/values.yaml
@@ -788,9 +788,21 @@ agents:
   ## @extra agents.envVars.FROM_CONFIGMAP.configMapKeyRef.key Key within a ConfigMap when configuring env vars from a ConfigMap
   ## @extra agents.envVars.FROM_SECRET.secretKeyRef.name Name of a Secret when configuring env vars from a Secret
   ## @extra agents.envVars.FROM_SECRET.secretKeyRef.key Key within a Secret when configuring env vars from a Secret
+  ## @extra agents.envVars.DEEPGRAM_STT_MODEL Deepgram model to use for speech-to-text (default: nova-3)
+  ## @extra agents.envVars.DEEPGRAM_STT_LANGUAGE Language code for transcription or 'multi' for automatic multilingual support with real-time code-switching (default: multi, supports: en, es, fr, de, hi, ru, pt, ja, it, nl)
   ## @skip agents.envVars
   envVars:
     <<: *commonEnvVars
+    # Deepgram Speech-to-Text configuration for real-time streaming
+    # Only 'model' and 'language' parameters are supported by the LiveKit plugin
+    #
+    # DEEPGRAM_STT_MODEL: "nova-3"              # Model selection (default)
+    # DEEPGRAM_STT_LANGUAGE: "multi"            # Multilingual mode with auto-detection (default)
+    # DEEPGRAM_STT_LANGUAGE: "fr"               # Force French only
+    #
+    # Note: Advanced features (diarization, smart_format, punctuate, detect_language)
+    # are NOT supported by the LiveKit Deepgram plugin in streaming mode.
+    # Use language="multi" for automatic multilingual support (10 languages).
 
   ## @param agents.podAnnotations Annotations to add to the agents Pod
   podAnnotations: {}


### PR DESCRIPTION
### 📋 Summary

This PR enables multilingual support for real-time subtitles (STT) in the agents service using Deepgram's Nova-3 model with automatic language detection across 10 languages.

### 🎯 Problem

Currently, real-time subtitles only work in English (`deepgram.STT()` is called without parameters). Users need multilingual support with automatic language detection for international meetings.

### ✅ Solution

Implement dynamic configuration for Deepgram STT via environment variables:
- Add `DEEPGRAM_STT_*` pattern to configure STT parameters
- Set default to `model=nova-3` and `language=multi`
- Add validation to filter unsupported parameters (LiveKit plugin limitations)
- Log warnings for unsupported parameters (diarization, smart_format, etc.)

### 🌍 Supported Languages

Automatic detection and code-switching for 10 languages:
- English (en)
- Spanish (es)
- French (fr)
- German (de)
- Hindi (hi)
- Russian (ru)
- Portuguese (pt)
- Japanese (ja)
- Italian (it)
- Dutch (nl)

### 🔧 Configuration

**Default (no configuration needed):**
```yaml
# Multilingual mode active by default
# DEEPGRAM_STT_MODEL: "nova-3"
# DEEPGRAM_STT_LANGUAGE: "multi"
```

**Force specific language:**
```yaml
agents:
  envVars:
    DEEPGRAM_STT_LANGUAGE: "fr"  # French only
```

### 📝 Changes

**Python (`multi-user-transcriber.py`):**
- Add `_build_deepgram_stt_kwargs()` function to scan `DEEPGRAM_STT_*` env vars
- Add whitelist of supported parameters (`model`, `language`)
- Add automatic type parsing (boolean, integer, string)
- Add warning logging for unsupported parameters
- Add configuration logging for debugging

**Helm (`values.yaml`):**
- Document `DEEPGRAM_STT_MODEL` and `DEEPGRAM_STT_LANGUAGE` parameters
- Add usage examples and configuration notes
- Document LiveKit plugin limitations

### ⚠️ Limitations

The LiveKit Deepgram plugin only supports:
- ✅ `model` - Deepgram model selection
- ✅ `language` - Language code or 'multi'
- ❌ `detect_language` - Not supported in streaming mode
- ❌ `diarize` - Not supported by plugin
- ❌ `smart_format` - Not supported by plugin
- ❌ `punctuate` - Not supported by plugin

For multilingual support, use `language="multi"` instead of `detect_language`.