### PR TITLE
🌐(backend) update translation files with newly introduced strings

### DIFF
--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-11 11:33+0000\n"
+"POT-Creation-Date: 2025-11-13 16:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,121 +17,153 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: core/admin.py:26
+#: core/admin.py:29
 msgid "Personal info"
 msgstr "Persönliche Informationen"
 
-#: core/admin.py:39
+#: core/admin.py:42
 msgid "Permissions"
 msgstr "Berechtigungen"
 
-#: core/admin.py:51
+#: core/admin.py:54
 msgid "Important dates"
 msgstr "Wichtige Daten"
 
-#: core/admin.py:147
+#: core/admin.py:128 core/admin.py:228
 msgid "No owner"
 msgstr "Kein Eigentümer"
 
-#: core/admin.py:150
+#: core/admin.py:131 core/admin.py:231
 msgid "Multiple owners"
 msgstr "Mehrere Eigentümer"
 
-#: core/api/serializers.py:67
+#: core/admin.py:143
+msgid "Resend notification to external service"
+msgstr "Benachrichtigung erneut an externen Dienst senden"
+
+#: core/admin.py:166
+#, python-format
+msgid "Failed to notify for recording %(id)s"
+msgstr "Benachrichtigung für Aufnahme %(id)s fehlgeschlagen"
+
+#: core/admin.py:174
+#, python-format
+msgid "Failed to notify for recording %(id)s: %(error)s"
+msgstr "Benachrichtigung für Aufnahme %(id)s fehlgeschlagen: %(error)s"
+
+#: core/admin.py:182
+#, python-format
+msgid "Successfully sent notifications for %(count)s recording(s)."
+msgstr "Benachrichtigungen für %(count)s Aufnahme(n) erfolgreich gesendet."
+
+#: core/admin.py:190
+#, python-format
+msgid "Skipped %(count)s expired recording(s)."
+msgstr "%(count)s abgelaufene Aufnahme(n) übersprungen."
+
+#: core/admin.py:294
+msgid "No scopes"
+msgstr "Keine Scopes"
+
+#: core/admin.py:296
+msgid "Scopes"
+msgstr "Scopes"
+
+#: core/api/serializers.py:68
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Sie müssen Administrator oder Eigentümer eines Raums sein, um Zugriffe "
 "hinzuzufügen."
 
-#: core/models.py:31
+#: core/models.py:34
 msgid "Member"
 msgstr "Mitglied"
 
-#: core/models.py:32
+#: core/models.py:35
 msgid "Administrator"
 msgstr "Administrator"
 
-#: core/models.py:33
+#: core/models.py:36
 msgid "Owner"
 msgstr "Eigentümer"
 
-#: core/models.py:49
+#: core/models.py:52
 msgid "Initiated"
 msgstr "Gestartet"
 
-#: core/models.py:50
+#: core/models.py:53
 msgid "Active"
 msgstr "Aktiv"
 
-#: core/models.py:51
+#: core/models.py:54
 msgid "Stopped"
 msgstr "Beendet"
 
-#: core/models.py:52
+#: core/models.py:55
 msgid "Saved"
 msgstr "Gespeichert"
 
-#: core/models.py:53
+#: core/models.py:56
 msgid "Aborted"
 msgstr "Abgebrochen"
 
-#: core/models.py:54
+#: core/models.py:57
 msgid "Failed to Start"
 msgstr "Start fehlgeschlagen"
 
-#: core/models.py:55
+#: core/models.py:58
 msgid "Failed to Stop"
 msgstr "Stopp fehlgeschlagen"
 
-#: core/models.py:56
+#: core/models.py:59
 msgid "Notification succeeded"
 msgstr "Benachrichtigung erfolgreich"
 
-#: core/models.py:83
+#: core/models.py:86
 msgid "SCREEN_RECORDING"
 msgstr "BILDSCHIRMAUFZEICHNUNG"
 
-#: core/models.py:84
+#: core/models.py:87
 msgid "TRANSCRIPT"
 msgstr "TRANSKRIPT"
 
-#: core/models.py:90
+#: core/models.py:93
 msgid "Public Access"
 msgstr "Öffentlicher Zugriff"
 
-#: core/models.py:91
+#: core/models.py:94
 msgid "Trusted Access"
 msgstr "Vertrauenswürdiger Zugriff"
 
-#: core/models.py:92
+#: core/models.py:95
 msgid "Restricted Access"
 msgstr "Eingeschränkter Zugriff"
 
-#: core/models.py:104
+#: core/models.py:107
 msgid "id"
 msgstr "ID"
 
-#: core/models.py:105
+#: core/models.py:108
 msgid "primary key for the record as UUID"
 msgstr "Primärschlüssel des Eintrags als UUID"
 
-#: core/models.py:111
+#: core/models.py:114
 msgid "created on"
 msgstr "erstellt am"
 
-#: core/models.py:112
+#: core/models.py:115
 msgid "date and time at which a record was created"
 msgstr "Datum und Uhrzeit der Erstellung eines Eintrags"
 
-#: core/models.py:117
+#: core/models.py:120
 msgid "updated on"
 msgstr "aktualisiert am"
 
-#: core/models.py:118
+#: core/models.py:121
 msgid "date and time at which a record was last updated"
 msgstr "Datum und Uhrzeit der letzten Aktualisierung eines Eintrags"
 
-#: core/models.py:138
+#: core/models.py:141
 msgid ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
@@ -139,11 +171,11 @@ msgstr ""
 "Geben Sie einen gültigen Sub ein. Dieser Wert darf nur Buchstaben, Zahlen "
 "und die Zeichen @/./+/-/_ enthalten."
 
-#: core/models.py:144
+#: core/models.py:147
 msgid "sub"
 msgstr "Sub"
 
-#: core/models.py:146
+#: core/models.py:149
 msgid ""
 "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
 "characters only."
@@ -151,55 +183,55 @@ msgstr ""
 "Erforderlich. Maximal 255 Zeichen. Nur Buchstaben, Zahlen und @/./+/-/_ sind "
 "erlaubt."
 
-#: core/models.py:154
+#: core/models.py:157
 msgid "identity email address"
 msgstr "Identitäts-E-Mail-Adresse"
 
-#: core/models.py:159
+#: core/models.py:162
 msgid "admin email address"
 msgstr "Administrator-E-Mail-Adresse"
 
-#: core/models.py:161
+#: core/models.py:164
 msgid "full name"
 msgstr "Vollständiger Name"
 
-#: core/models.py:163
+#: core/models.py:166
 msgid "short name"
 msgstr "Kurzname"
 
-#: core/models.py:169
+#: core/models.py:172
 msgid "language"
 msgstr "Sprache"
 
-#: core/models.py:170
+#: core/models.py:173
 msgid "The language in which the user wants to see the interface."
 msgstr "Die Sprache, in der der Benutzer die Oberfläche sehen möchte."
 
-#: core/models.py:176
+#: core/models.py:179
 msgid "The timezone in which the user wants to see times."
 msgstr "Die Zeitzone, in der der Benutzer die Zeiten sehen möchte."
 
-#: core/models.py:179
+#: core/models.py:182
 msgid "device"
 msgstr "Gerät"
 
-#: core/models.py:181
+#: core/models.py:184
 msgid "Whether the user is a device or a real user."
 msgstr "Ob es sich um ein Gerät oder einen echten Benutzer handelt."
 
-#: core/models.py:184
+#: core/models.py:187
 msgid "staff status"
 msgstr "Mitarbeiterstatus"
 
-#: core/models.py:186
+#: core/models.py:189
 msgid "Whether the user can log into this admin site."
 msgstr "Ob der Benutzer sich bei dieser Admin-Seite anmelden kann."
 
-#: core/models.py:189
+#: core/models.py:192
 msgid "active"
 msgstr "aktiv"
 
-#: core/models.py:192
+#: core/models.py:195
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -207,66 +239,66 @@ msgstr ""
 "Ob dieser Benutzer als aktiv behandelt werden soll. Deaktivieren Sie dies "
 "anstelle des Löschens des Kontos."
 
-#: core/models.py:205
+#: core/models.py:208
 msgid "user"
 msgstr "Benutzer"
 
-#: core/models.py:206
+#: core/models.py:209
 msgid "users"
 msgstr "Benutzer"
 
-#: core/models.py:265
+#: core/models.py:268
 msgid "Resource"
 msgstr "Ressource"
 
-#: core/models.py:266
+#: core/models.py:269
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: core/models.py:320
+#: core/models.py:323
 msgid "Resource access"
 msgstr "Ressourcenzugriff"
 
-#: core/models.py:321
+#: core/models.py:324
 msgid "Resource accesses"
 msgstr "Ressourcenzugriffe"
 
-#: core/models.py:327
+#: core/models.py:330
 msgid "Resource access with this User and Resource already exists."
 msgstr ""
 "Ein Ressourcenzugriff mit diesem Benutzer und dieser Ressource existiert "
 "bereits."
 
-#: core/models.py:383
+#: core/models.py:386
 msgid "Visio room configuration"
 msgstr "Visio-Raumkonfiguration"
 
-#: core/models.py:384
+#: core/models.py:387
 msgid "Values for Visio parameters to configure the room."
 msgstr "Werte für Visio-Parameter zur Konfiguration des Raums."
 
-#: core/models.py:391
+#: core/models.py:394
 msgid "Room PIN code"
 msgstr "PIN-Code für den Raum"
 
-#: core/models.py:392
+#: core/models.py:395
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Eindeutiger n-stelliger Code, der diesen Raum im Telephonmodus identifiziert."
 
-#: core/models.py:398 core/models.py:552
+#: core/models.py:401 core/models.py:555
 msgid "Room"
 msgstr "Raum"
 
-#: core/models.py:399
+#: core/models.py:402
 msgid "Rooms"
 msgstr "Räume"
 
-#: core/models.py:563
+#: core/models.py:566
 msgid "Worker ID"
 msgstr "Worker-ID"
 
-#: core/models.py:565
+#: core/models.py:568
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -275,41 +307,101 @@ msgstr ""
 "erhalten, auch wenn der Worker stoppt, was ein einfaches Nachverfolgen "
 "ermöglicht."
 
-#: core/models.py:573
+#: core/models.py:576
 msgid "Recording mode"
 msgstr "Aufzeichnungsmodus"
 
-#: core/models.py:574
+#: core/models.py:577
 msgid "Defines the mode of recording being called."
 msgstr "Definiert den aufgerufenen Aufzeichnungsmodus."
 
-#: core/models.py:580
+#: core/models.py:583
 msgid "Recording"
 msgstr "Aufzeichnung"
 
-#: core/models.py:581
+#: core/models.py:584
 msgid "Recordings"
 msgstr "Aufzeichnungen"
 
-#: core/models.py:689
+#: core/models.py:692
 msgid "Recording/user relation"
 msgstr "Beziehung Aufzeichnung/Benutzer"
 
-#: core/models.py:690
+#: core/models.py:693
 msgid "Recording/user relations"
 msgstr "Beziehungen Aufzeichnung/Benutzer"
 
-#: core/models.py:696
+#: core/models.py:699
 msgid "This user is already in this recording."
 msgstr "Dieser Benutzer ist bereits Teil dieser Aufzeichnung."
 
-#: core/models.py:702
+#: core/models.py:705
 msgid "This team is already in this recording."
 msgstr "Dieses Team ist bereits Teil dieser Aufzeichnung."
 
-#: core/models.py:708
+#: core/models.py:711
 msgid "Either user or team must be set, not both."
 msgstr "Entweder Benutzer oder Team muss festgelegt werden, nicht beides."
+
+#: core/models.py:728
+msgid "Create rooms"
+msgstr "Räume erstellen"
+
+#: core/models.py:729
+msgid "List rooms"
+msgstr "Räume auflisten"
+
+#: core/models.py:730
+msgid "Retrieve room details"
+msgstr "Raumdetails abrufen"
+
+#: core/models.py:731
+msgid "Update rooms"
+msgstr "Räume aktualisieren"
+
+#: core/models.py:732
+msgid "Delete rooms"
+msgstr "Räume löschen"
+
+#: core/models.py:745
+msgid "Application name"
+msgstr "Anwendungsname"
+
+#: core/models.py:746
+msgid "Descriptive name for this application."
+msgstr "Beschreibender Name für diese Anwendung."
+
+#: core/models.py:756
+msgid "Hashed on Save. Copy it now if this is a new secret."
+msgstr "Beim Speichern gehasht. Jetzt kopieren, wenn dies ein neues Geheimnis ist."
+
+#: core/models.py:767
+msgid "Application"
+msgstr "Anwendung"
+
+#: core/models.py:768
+msgid "Applications"
+msgstr "Anwendungen"
+
+#: core/models.py:791
+msgid "Enter a valid domain"
+msgstr "Geben Sie eine gültige Domain ein"
+
+#: core/models.py:794
+msgid "Domain"
+msgstr "Domain"
+
+#: core/models.py:795
+msgid "Email domain this application can act on behalf of."
+msgstr "E-Mail-Domain, im Namen der diese Anwendung handeln kann."
+
+#: core/models.py:807
+msgid "Application domain"
+msgstr "Anwendungsdomain"
+
+#: core/models.py:808
+msgid "Application domains"
+msgstr "Anwendungsdomains"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"
@@ -401,7 +493,8 @@ msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
 msgstr ""
-" Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur Organisatoren können sie herunterladen. "
+" Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur "
+"Organisatoren können sie herunterladen. "
 
 #: core/templates/mail/html/screen_recording.html:206
 #: core/templates/mail/text/screen_recording.txt:11
@@ -438,18 +531,18 @@ msgstr ""
 " Wenn Sie Fragen haben oder Unterstützung benötigen, wenden Sie sich bitte "
 "an unser Support-Team unter %(support_email)s. "
 
-#: meet/settings.py:163
+#: meet/settings.py:167
 msgid "English"
 msgstr "Englisch"
 
-#: meet/settings.py:164
+#: meet/settings.py:168
 msgid "French"
 msgstr "Französisch"
 
-#: meet/settings.py:165
+#: meet/settings.py:169
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: meet/settings.py:166
+#: meet/settings.py:170
 msgid "German"
 msgstr "Deutsch"

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-11 11:33+0000\n"
+"POT-Creation-Date: 2025-11-13 16:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,119 +17,151 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: core/admin.py:26
+#: core/admin.py:29
 msgid "Personal info"
-msgstr ""
+msgstr "Personal info"
 
-#: core/admin.py:39
+#: core/admin.py:42
 msgid "Permissions"
 msgstr "Permissions"
 
-#: core/admin.py:51
+#: core/admin.py:54
 msgid "Important dates"
 msgstr "Important dates"
 
-#: core/admin.py:147
+#: core/admin.py:128 core/admin.py:228
 msgid "No owner"
 msgstr "No owner"
 
-#: core/admin.py:150
+#: core/admin.py:131 core/admin.py:231
 msgid "Multiple owners"
 msgstr "Multiple owners"
 
-#: core/api/serializers.py:67
+#: core/admin.py:143
+msgid "Resend notification to external service"
+msgstr "Resend notification to external service"
+
+#: core/admin.py:166
+#, python-format
+msgid "Failed to notify for recording %(id)s"
+msgstr "Failed to notify for recording %(id)s"
+
+#: core/admin.py:174
+#, python-format
+msgid "Failed to notify for recording %(id)s: %(error)s"
+msgstr "Failed to notify for recording %(id)s: %(error)s"
+
+#: core/admin.py:182
+#, python-format
+msgid "Successfully sent notifications for %(count)s recording(s)."
+msgstr "Successfully sent notifications for %(count)s recording(s)."
+
+#: core/admin.py:190
+#, python-format
+msgid "Skipped %(count)s expired recording(s)."
+msgstr "Skipped %(count)s expired recording(s)."
+
+#: core/admin.py:294
+msgid "No scopes"
+msgstr "No scopes"
+
+#: core/admin.py:296
+msgid "Scopes"
+msgstr "Scopes"
+
+#: core/api/serializers.py:68
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr "You must be administrator or owner of a room to add accesses to it."
 
-#: core/models.py:31
+#: core/models.py:34
 msgid "Member"
 msgstr "Member"
 
-#: core/models.py:32
+#: core/models.py:35
 msgid "Administrator"
 msgstr "Administrator"
 
-#: core/models.py:33
+#: core/models.py:36
 msgid "Owner"
 msgstr "Owner"
 
-#: core/models.py:49
+#: core/models.py:52
 msgid "Initiated"
 msgstr "Initiated"
 
-#: core/models.py:50
+#: core/models.py:53
 msgid "Active"
 msgstr "Active"
 
-#: core/models.py:51
+#: core/models.py:54
 msgid "Stopped"
 msgstr "Stopped"
 
-#: core/models.py:52
+#: core/models.py:55
 msgid "Saved"
 msgstr "Saved"
 
-#: core/models.py:53
+#: core/models.py:56
 msgid "Aborted"
 msgstr "Aborted"
 
-#: core/models.py:54
+#: core/models.py:57
 msgid "Failed to Start"
 msgstr "Failed to Start"
 
-#: core/models.py:55
+#: core/models.py:58
 msgid "Failed to Stop"
 msgstr "Failed to Stop"
 
-#: core/models.py:56
+#: core/models.py:59
 msgid "Notification succeeded"
 msgstr "Notification succeeded"
 
-#: core/models.py:83
+#: core/models.py:86
 msgid "SCREEN_RECORDING"
 msgstr "SCREEN_RECORDING"
 
-#: core/models.py:84
+#: core/models.py:87
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPT"
 
-#: core/models.py:90
+#: core/models.py:93
 msgid "Public Access"
 msgstr "Public Access"
 
-#: core/models.py:91
+#: core/models.py:94
 msgid "Trusted Access"
 msgstr "Trusted Access"
 
-#: core/models.py:92
+#: core/models.py:95
 msgid "Restricted Access"
 msgstr "Restricted Access"
 
-#: core/models.py:104
+#: core/models.py:107
 msgid "id"
 msgstr "id"
 
-#: core/models.py:105
+#: core/models.py:108
 msgid "primary key for the record as UUID"
 msgstr "primary key for the record as UUID"
 
-#: core/models.py:111
+#: core/models.py:114
 msgid "created on"
 msgstr "created on"
 
-#: core/models.py:112
+#: core/models.py:115
 msgid "date and time at which a record was created"
 msgstr "date and time at which a record was created"
 
-#: core/models.py:117
+#: core/models.py:120
 msgid "updated on"
 msgstr "updated on"
 
-#: core/models.py:118
+#: core/models.py:121
 msgid "date and time at which a record was last updated"
 msgstr "date and time at which a record was last updated"
 
-#: core/models.py:138
+#: core/models.py:141
 msgid ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
@@ -137,11 +169,11 @@ msgstr ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
 
-#: core/models.py:144
+#: core/models.py:147
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:146
+#: core/models.py:149
 msgid ""
 "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
 "characters only."
@@ -149,55 +181,55 @@ msgstr ""
 "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
 "characters only."
 
-#: core/models.py:154
+#: core/models.py:157
 msgid "identity email address"
 msgstr "identity email address"
 
-#: core/models.py:159
+#: core/models.py:162
 msgid "admin email address"
 msgstr "admin email address"
 
-#: core/models.py:161
+#: core/models.py:164
 msgid "full name"
 msgstr "full name"
 
-#: core/models.py:163
+#: core/models.py:166
 msgid "short name"
 msgstr "short name"
 
-#: core/models.py:169
+#: core/models.py:172
 msgid "language"
 msgstr "language"
 
-#: core/models.py:170
+#: core/models.py:173
 msgid "The language in which the user wants to see the interface."
 msgstr "The language in which the user wants to see the interface."
 
-#: core/models.py:176
+#: core/models.py:179
 msgid "The timezone in which the user wants to see times."
 msgstr "The timezone in which the user wants to see times."
 
-#: core/models.py:179
+#: core/models.py:182
 msgid "device"
 msgstr "device"
 
-#: core/models.py:181
+#: core/models.py:184
 msgid "Whether the user is a device or a real user."
 msgstr "Whether the user is a device or a real user."
 
-#: core/models.py:184
+#: core/models.py:187
 msgid "staff status"
 msgstr "staff status"
 
-#: core/models.py:186
+#: core/models.py:189
 msgid "Whether the user can log into this admin site."
 msgstr "Whether the user can log into this admin site."
 
-#: core/models.py:189
+#: core/models.py:192
 msgid "active"
 msgstr "active"
 
-#: core/models.py:192
+#: core/models.py:195
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -205,63 +237,63 @@ msgstr ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
 
-#: core/models.py:205
+#: core/models.py:208
 msgid "user"
 msgstr "user"
 
-#: core/models.py:206
+#: core/models.py:209
 msgid "users"
 msgstr "users"
 
-#: core/models.py:265
+#: core/models.py:268
 msgid "Resource"
 msgstr "Resource"
 
-#: core/models.py:266
+#: core/models.py:269
 msgid "Resources"
 msgstr "Resources"
 
-#: core/models.py:320
+#: core/models.py:323
 msgid "Resource access"
 msgstr "Resource access"
 
-#: core/models.py:321
+#: core/models.py:324
 msgid "Resource accesses"
 msgstr "Resource accesses"
 
-#: core/models.py:327
+#: core/models.py:330
 msgid "Resource access with this User and Resource already exists."
 msgstr "Resource access with this User and Resource already exists."
 
-#: core/models.py:383
+#: core/models.py:386
 msgid "Visio room configuration"
 msgstr "Visio room configuration"
 
-#: core/models.py:384
+#: core/models.py:387
 msgid "Values for Visio parameters to configure the room."
 msgstr "Values for Visio parameters to configure the room."
 
-#: core/models.py:391
+#: core/models.py:394
 msgid "Room PIN code"
 msgstr "Room PIN code"
 
-#: core/models.py:392
+#: core/models.py:395
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr "Unique n-digit code that identifies this room in telephony mode."
 
-#: core/models.py:398 core/models.py:552
+#: core/models.py:401 core/models.py:555
 msgid "Room"
 msgstr "Room"
 
-#: core/models.py:399
+#: core/models.py:402
 msgid "Rooms"
 msgstr "Rooms"
 
-#: core/models.py:563
+#: core/models.py:566
 msgid "Worker ID"
 msgstr "Worker ID"
 
-#: core/models.py:565
+#: core/models.py:568
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -269,41 +301,105 @@ msgstr ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
 
-#: core/models.py:573
+#: core/models.py:576
 msgid "Recording mode"
 msgstr "Recording mode"
 
-#: core/models.py:574
+#: core/models.py:577
 msgid "Defines the mode of recording being called."
 msgstr "Defines the mode of recording being called."
 
-#: core/models.py:580
+#: core/models.py:583
 msgid "Recording"
 msgstr "Recording"
 
-#: core/models.py:581
+#: core/models.py:584
 msgid "Recordings"
 msgstr "Recordings"
 
-#: core/models.py:689
+#: core/models.py:692
 msgid "Recording/user relation"
 msgstr "Recording/user relation"
 
-#: core/models.py:690
+#: core/models.py:693
 msgid "Recording/user relations"
 msgstr "Recording/user relations"
 
-#: core/models.py:696
+#: core/models.py:699
 msgid "This user is already in this recording."
 msgstr "This user is already in this recording."
 
-#: core/models.py:702
+#: core/models.py:705
 msgid "This team is already in this recording."
 msgstr "This team is already in this recording."
 
-#: core/models.py:708
+#: core/models.py:711
 msgid "Either user or team must be set, not both."
 msgstr "Either user or team must be set, not both."
+
+#: core/models.py:728
+#, fuzzy
+#| msgid "created on"
+msgid "Create rooms"
+msgstr "Create rooms"
+
+#: core/models.py:729
+msgid "List rooms"
+msgstr "List rooms"
+
+#: core/models.py:730
+msgid "Retrieve room details"
+msgstr "Retrieve room details"
+
+#: core/models.py:731
+#, fuzzy
+#| msgid "updated on"
+msgid "Update rooms"
+msgstr "Update rooms"
+
+#: core/models.py:732
+msgid "Delete rooms"
+msgstr "Delete rooms"
+
+#: core/models.py:745
+msgid "Application name"
+msgstr "Application name"
+
+#: core/models.py:746
+msgid "Descriptive name for this application."
+msgstr "Descriptive name for this application."
+
+#: core/models.py:756
+msgid "Hashed on Save. Copy it now if this is a new secret."
+msgstr "Hashed on Save. Copy it now if this is a new secret."
+
+#: core/models.py:767
+msgid "Application"
+msgstr "Application"
+
+#: core/models.py:768
+msgid "Applications"
+msgstr "Applications"
+
+#: core/models.py:791
+msgid "Enter a valid domain"
+msgstr "Enter a valid domain"
+
+#: core/models.py:794
+msgid "Domain"
+msgstr "Domain"
+
+#: core/models.py:795
+msgid "Email domain this application can act on behalf of."
+msgstr "Email domain this application can act on behalf of."
+
+#: core/models.py:807
+msgid "Application domain"
+msgstr "Application domain"
+
+#: core/models.py:808
+msgid "Application domains"
+msgstr "Application domains"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"
@@ -433,18 +529,18 @@ msgstr ""
 " If you have any questions or need assistance, please contact our support "
 "team at %(support_email)s. "
 
-#: meet/settings.py:163
+#: meet/settings.py:167
 msgid "English"
 msgstr "English"
 
-#: meet/settings.py:164
+#: meet/settings.py:168
 msgid "French"
 msgstr "French"
 
-#: meet/settings.py:165
+#: meet/settings.py:169
 msgid "Dutch"
 msgstr "Dutch"
 
-#: meet/settings.py:166
+#: meet/settings.py:170
 msgid "German"
 msgstr "German"

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-11 11:33+0000\n"
+"POT-Creation-Date: 2025-11-13 16:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: antoine.lebaud@mail.numerique.gouv.fr\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,123 +17,155 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: core/admin.py:26
+#: core/admin.py:29
 msgid "Personal info"
 msgstr "Informations personnelles"
 
-#: core/admin.py:39
+#: core/admin.py:42
 msgid "Permissions"
 msgstr "Permissions"
 
-#: core/admin.py:51
+#: core/admin.py:54
 msgid "Important dates"
 msgstr "Dates importantes"
 
-#: core/admin.py:147
+#: core/admin.py:128 core/admin.py:228
 msgid "No owner"
 msgstr "Pas de propriétaire"
 
-#: core/admin.py:150
+#: core/admin.py:131 core/admin.py:231
 msgid "Multiple owners"
 msgstr "Plusieurs propriétaires"
 
-#: core/api/serializers.py:67
+#: core/admin.py:143
+msgid "Resend notification to external service"
+msgstr "Renvoyer la notification au service externe"
+
+#: core/admin.py:166
+#, python-format
+msgid "Failed to notify for recording %(id)s"
+msgstr "Échec de la notification pour l’enregistrement %(id)s"
+
+#: core/admin.py:174
+#, python-format
+msgid "Failed to notify for recording %(id)s: %(error)s"
+msgstr "Échec de la notification pour l’enregistrement %(id)s : %(error)s"
+
+#: core/admin.py:182
+#, python-format
+msgid "Successfully sent notifications for %(count)s recording(s)."
+msgstr "Notifications envoyées avec succès pour %(count)s enregistrement(s)."
+
+#: core/admin.py:190
+#, python-format
+msgid "Skipped %(count)s expired recording(s)."
+msgstr "%(count)s enregistrement(s) expiré(s) ignoré(s)."
+
+#: core/admin.py:294
+msgid "No scopes"
+msgstr "Aucun scopes"
+
+#: core/admin.py:296
+msgid "Scopes"
+msgstr "Scopes"
+
+#: core/api/serializers.py:68
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Vous devez être administrateur ou propriétaire d'une salle pour y ajouter "
 "des accès."
 
-#: core/models.py:31
+#: core/models.py:34
 msgid "Member"
 msgstr "Membre"
 
-#: core/models.py:32
+#: core/models.py:35
 msgid "Administrator"
 msgstr "Administrateur"
 
-#: core/models.py:33
+#: core/models.py:36
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: core/models.py:49
+#: core/models.py:52
 msgid "Initiated"
 msgstr "Initié"
 
-#: core/models.py:50
+#: core/models.py:53
 msgid "Active"
 msgstr "Actif"
 
-#: core/models.py:51
+#: core/models.py:54
 msgid "Stopped"
 msgstr "Arrêté"
 
-#: core/models.py:52
+#: core/models.py:55
 msgid "Saved"
 msgstr "Enregistré"
 
-#: core/models.py:53
+#: core/models.py:56
 msgid "Aborted"
 msgstr "Abandonné"
 
-#: core/models.py:54
+#: core/models.py:57
 msgid "Failed to Start"
 msgstr "Échec au démarrage"
 
-#: core/models.py:55
+#: core/models.py:58
 msgid "Failed to Stop"
 msgstr "Échec à l'arrêt"
 
-#: core/models.py:56
+#: core/models.py:59
 msgid "Notification succeeded"
 msgstr "Notification réussie"
 
-#: core/models.py:83
+#: core/models.py:86
 msgid "SCREEN_RECORDING"
 msgstr "ENREGISTREMENT_ÉCRAN"
 
-#: core/models.py:84
+#: core/models.py:87
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPTION"
 
-#: core/models.py:90
+#: core/models.py:93
 msgid "Public Access"
 msgstr "Accès public"
 
-#: core/models.py:91
+#: core/models.py:94
 msgid "Trusted Access"
 msgstr "Accès de confiance"
 
-#: core/models.py:92
+#: core/models.py:95
 msgid "Restricted Access"
 msgstr "Accès restreint"
 
-#: core/models.py:104
+#: core/models.py:107
 msgid "id"
 msgstr "id"
 
-#: core/models.py:105
+#: core/models.py:108
 msgid "primary key for the record as UUID"
 msgstr "clé primaire pour l'enregistrement sous forme d'UUID"
 
-#: core/models.py:111
+#: core/models.py:114
 msgid "created on"
 msgstr "créé le"
 
-#: core/models.py:112
+#: core/models.py:115
 msgid "date and time at which a record was created"
 msgstr "date et heure auxquelles un enregistrement a été créé"
 
-#: core/models.py:117
+#: core/models.py:120
 msgid "updated on"
 msgstr "mis à jour le"
 
-#: core/models.py:118
+#: core/models.py:121
 msgid "date and time at which a record was last updated"
 msgstr ""
 "date et heure auxquelles un enregistrement a été mis à jour pour la dernière "
 "fois"
 
-#: core/models.py:138
+#: core/models.py:141
 msgid ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
@@ -141,11 +173,11 @@ msgstr ""
 "Entrez un sub valide. Cette valeur ne peut contenir que des lettres, des "
 "chiffres et les caractères @/./+/-/_."
 
-#: core/models.py:144
+#: core/models.py:147
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:146
+#: core/models.py:149
 msgid ""
 "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
 "characters only."
@@ -153,55 +185,55 @@ msgstr ""
 "Obligatoire. 255 caractères ou moins. Lettres, chiffres et caractères @/./"
 "+/-/_ uniquement."
 
-#: core/models.py:154
+#: core/models.py:157
 msgid "identity email address"
 msgstr "adresse e-mail d'identité"
 
-#: core/models.py:159
+#: core/models.py:162
 msgid "admin email address"
 msgstr "adresse e-mail d'administrateur"
 
-#: core/models.py:161
+#: core/models.py:164
 msgid "full name"
 msgstr "nom complet"
 
-#: core/models.py:163
+#: core/models.py:166
 msgid "short name"
 msgstr "nom court"
 
-#: core/models.py:169
+#: core/models.py:172
 msgid "language"
 msgstr "langue"
 
-#: core/models.py:170
+#: core/models.py:173
 msgid "The language in which the user wants to see the interface."
 msgstr "La langue dans laquelle l'utilisateur souhaite voir l'interface."
 
-#: core/models.py:176
+#: core/models.py:179
 msgid "The timezone in which the user wants to see times."
 msgstr "Le fuseau horaire dans lequel l'utilisateur souhaite voir les heures."
 
-#: core/models.py:179
+#: core/models.py:182
 msgid "device"
 msgstr "appareil"
 
-#: core/models.py:181
+#: core/models.py:184
 msgid "Whether the user is a device or a real user."
 msgstr "Si l'utilisateur est un appareil ou un utilisateur réel."
 
-#: core/models.py:184
+#: core/models.py:187
 msgid "staff status"
 msgstr "statut du personnel"
 
-#: core/models.py:186
+#: core/models.py:189
 msgid "Whether the user can log into this admin site."
 msgstr "Si l'utilisateur peut se connecter à ce site d'administration."
 
-#: core/models.py:189
+#: core/models.py:192
 msgid "active"
 msgstr "actif"
 
-#: core/models.py:192
+#: core/models.py:195
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -209,65 +241,65 @@ msgstr ""
 "Si cet utilisateur doit être traité comme actif. Désélectionnez cette option "
 "au lieu de supprimer des comptes."
 
-#: core/models.py:205
+#: core/models.py:208
 msgid "user"
 msgstr "utilisateur"
 
-#: core/models.py:206
+#: core/models.py:209
 msgid "users"
 msgstr "utilisateurs"
 
-#: core/models.py:265
+#: core/models.py:268
 msgid "Resource"
 msgstr "Ressource"
 
-#: core/models.py:266
+#: core/models.py:269
 msgid "Resources"
 msgstr "Ressources"
 
-#: core/models.py:320
+#: core/models.py:323
 msgid "Resource access"
 msgstr "Accès aux ressources"
 
-#: core/models.py:321
+#: core/models.py:324
 msgid "Resource accesses"
 msgstr "Accès aux ressources"
 
-#: core/models.py:327
+#: core/models.py:330
 msgid "Resource access with this User and Resource already exists."
 msgstr ""
 "L'accès à la ressource avec cet utilisateur et cette ressource existe déjà."
 
-#: core/models.py:383
+#: core/models.py:386
 msgid "Visio room configuration"
 msgstr "Configuration de la salle de visioconférence"
 
-#: core/models.py:384
+#: core/models.py:387
 msgid "Values for Visio parameters to configure the room."
 msgstr "Valeurs des paramètres de visioconférence pour configurer la salle."
 
-#: core/models.py:391
+#: core/models.py:394
 msgid "Room PIN code"
 msgstr "Code PIN de la salle"
 
-#: core/models.py:392
+#: core/models.py:395
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Code unique à n chiffres qui identifie cette salle en mode téléphonique."
 
-#: core/models.py:398 core/models.py:552
+#: core/models.py:401 core/models.py:555
 msgid "Room"
 msgstr "Salle"
 
-#: core/models.py:399
+#: core/models.py:402
 msgid "Rooms"
 msgstr "Salles"
 
-#: core/models.py:563
+#: core/models.py:566
 msgid "Worker ID"
 msgstr "ID du Worker"
 
-#: core/models.py:565
+#: core/models.py:568
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -275,41 +307,101 @@ msgstr ""
 "Entrez un identifiant pour l'enregistrement du Worker. Cet identifiant est "
 "conservé même lorsque le Worker s'arrête, permettant un suivi facile."
 
-#: core/models.py:573
+#: core/models.py:576
 msgid "Recording mode"
 msgstr "Mode d'enregistrement"
 
-#: core/models.py:574
+#: core/models.py:577
 msgid "Defines the mode of recording being called."
 msgstr "Définit le mode d'enregistrement appelé."
 
-#: core/models.py:580
+#: core/models.py:583
 msgid "Recording"
 msgstr "Enregistrement"
 
-#: core/models.py:581
+#: core/models.py:584
 msgid "Recordings"
 msgstr "Enregistrements"
 
-#: core/models.py:689
+#: core/models.py:692
 msgid "Recording/user relation"
 msgstr "Relation enregistrement/utilisateur"
 
-#: core/models.py:690
+#: core/models.py:693
 msgid "Recording/user relations"
 msgstr "Relations enregistrement/utilisateur"
 
-#: core/models.py:696
+#: core/models.py:699
 msgid "This user is already in this recording."
 msgstr "Cet utilisateur est déjà dans cet enregistrement."
 
-#: core/models.py:702
+#: core/models.py:705
 msgid "This team is already in this recording."
 msgstr "Cette équipe est déjà dans cet enregistrement."
 
-#: core/models.py:708
+#: core/models.py:711
 msgid "Either user or team must be set, not both."
 msgstr "Soit l'utilisateur, soit l'équipe doit être défini, pas les deux."
+
+#: core/models.py:728
+msgid "Create rooms"
+msgstr "Créer des salles"
+
+#: core/models.py:729
+msgid "List rooms"
+msgstr "Lister les salles"
+
+#: core/models.py:730
+msgid "Retrieve room details"
+msgstr "Afficher les détails d’une salle"
+
+#: core/models.py:731
+msgid "Update rooms"
+msgstr "Mettre à jour les salles"
+
+#: core/models.py:732
+msgid "Delete rooms"
+msgstr "Supprimer les salles"
+
+#: core/models.py:745
+msgid "Application name"
+msgstr "Nom de l’application"
+
+#: core/models.py:746
+msgid "Descriptive name for this application."
+msgstr "Nom descriptif de cette application."
+
+#: core/models.py:756
+msgid "Hashed on Save. Copy it now if this is a new secret."
+msgstr "Haché lors de l’enregistrement. Copiez-le maintenant s’il s’agit d’un nouveau secret."
+
+#: core/models.py:767
+msgid "Application"
+msgstr "Application"
+
+#: core/models.py:768
+msgid "Applications"
+msgstr "Applications"
+
+#: core/models.py:791
+msgid "Enter a valid domain"
+msgstr "Saisissez un domaine valide"
+
+#: core/models.py:794
+msgid "Domain"
+msgstr "Domaine"
+
+#: core/models.py:795
+msgid "Email domain this application can act on behalf of."
+msgstr "Domaine de messagerie au nom duquel cette application peut agir."
+
+#: core/models.py:807
+msgid "Application domain"
+msgstr "Domaine d’application"
+
+#: core/models.py:808
+msgid "Application domains"
+msgstr "Domaines d’application"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"
@@ -401,7 +493,8 @@ msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
 msgstr ""
-"Le partage de l'enregistrement via lien n'est pas encore disponible. Seuls les organisateurs peuvent le télécharger."
+"Le partage de l'enregistrement via lien n'est pas encore disponible. Seuls "
+"les organisateurs peuvent le télécharger."
 
 #: core/templates/mail/html/screen_recording.html:206
 #: core/templates/mail/text/screen_recording.txt:11
@@ -438,18 +531,18 @@ msgstr ""
 " Si vous avez des questions ou besoin d'assistance, veuillez contacter notre "
 "équipe d'assistance à %(support_email)s. "
 
-#: meet/settings.py:163
+#: meet/settings.py:167
 msgid "English"
 msgstr "Anglais"
 
-#: meet/settings.py:164
+#: meet/settings.py:168
 msgid "French"
 msgstr "Français"
 
-#: meet/settings.py:165
+#: meet/settings.py:169
 msgid "Dutch"
 msgstr "Néerlandais"
 
-#: meet/settings.py:166
+#: meet/settings.py:170
 msgid "German"
 msgstr "Allemand"

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-11 11:33+0000\n"
+"POT-Creation-Date: 2025-11-13 16:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,120 +17,152 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: core/admin.py:26
+#: core/admin.py:29
 msgid "Personal info"
 msgstr "Persoonlijke informatie"
 
-#: core/admin.py:39
+#: core/admin.py:42
 msgid "Permissions"
 msgstr "Rechten"
 
-#: core/admin.py:51
+#: core/admin.py:54
 msgid "Important dates"
 msgstr "Belangrijke datums"
 
-#: core/admin.py:147
+#: core/admin.py:128 core/admin.py:228
 msgid "No owner"
 msgstr "Geen eigenaar"
 
-#: core/admin.py:150
+#: core/admin.py:131 core/admin.py:231
 msgid "Multiple owners"
 msgstr "Meerdere eigenaren"
 
-#: core/api/serializers.py:67
+#: core/admin.py:143
+msgid "Resend notification to external service"
+msgstr "Melding opnieuw verzenden naar externe dienst"
+
+#: core/admin.py:166
+#, python-format
+msgid "Failed to notify for recording %(id)s"
+msgstr "Melding voor opname %(id)s mislukt"
+
+#: core/admin.py:174
+#, python-format
+msgid "Failed to notify for recording %(id)s: %(error)s"
+msgstr "Melding voor opname %(id)s mislukt: %(error)s"
+
+#: core/admin.py:182
+#, python-format
+msgid "Successfully sent notifications for %(count)s recording(s)."
+msgstr "Meldingen succesvol verzonden voor %(count)s opname(n)."
+
+#: core/admin.py:190
+#, python-format
+msgid "Skipped %(count)s expired recording(s)."
+msgstr "%(count)s verlopen opname(n) overgeslagen."
+
+#: core/admin.py:294
+msgid "No scopes"
+msgstr "Geen scopes"
+
+#: core/admin.py:296
+msgid "Scopes"
+msgstr "Scopes"
+
+#: core/api/serializers.py:68
 msgid "You must be administrator or owner of a room to add accesses to it."
 msgstr ""
 "Je moet beheerder of eigenaar van een ruimte zijn om toegang toe te voegen."
 
-#: core/models.py:31
+#: core/models.py:34
 msgid "Member"
 msgstr "Lid"
 
-#: core/models.py:32
+#: core/models.py:35
 msgid "Administrator"
 msgstr "Beheerder"
 
-#: core/models.py:33
+#: core/models.py:36
 msgid "Owner"
 msgstr "Eigenaar"
 
-#: core/models.py:49
+#: core/models.py:52
 msgid "Initiated"
 msgstr "Gestart"
 
-#: core/models.py:50
+#: core/models.py:53
 msgid "Active"
 msgstr "Actief"
 
-#: core/models.py:51
+#: core/models.py:54
 msgid "Stopped"
 msgstr "Gestopt"
 
-#: core/models.py:52
+#: core/models.py:55
 msgid "Saved"
 msgstr "Opgeslagen"
 
-#: core/models.py:53
+#: core/models.py:56
 msgid "Aborted"
 msgstr "Afgebroken"
 
-#: core/models.py:54
+#: core/models.py:57
 msgid "Failed to Start"
 msgstr "Starten mislukt"
 
-#: core/models.py:55
+#: core/models.py:58
 msgid "Failed to Stop"
 msgstr "Stoppen mislukt"
 
-#: core/models.py:56
+#: core/models.py:59
 msgid "Notification succeeded"
 msgstr "Notificatie geslaagd"
 
-#: core/models.py:83
+#: core/models.py:86
 msgid "SCREEN_RECORDING"
 msgstr "SCHERM_OPNAME"
 
-#: core/models.py:84
+#: core/models.py:87
 msgid "TRANSCRIPT"
 msgstr "TRANSCRIPT"
 
-#: core/models.py:90
+#: core/models.py:93
 msgid "Public Access"
 msgstr "Openbare toegang"
 
-#: core/models.py:91
+#: core/models.py:94
 msgid "Trusted Access"
 msgstr "Vertrouwde toegang"
 
-#: core/models.py:92
+#: core/models.py:95
 msgid "Restricted Access"
 msgstr "Beperkte toegang"
 
-#: core/models.py:104
+#: core/models.py:107
 msgid "id"
 msgstr "id"
 
-#: core/models.py:105
+#: core/models.py:108
 msgid "primary key for the record as UUID"
 msgstr "primaire sleutel voor het record als UUID"
 
-#: core/models.py:111
+#: core/models.py:114
 msgid "created on"
 msgstr "aangemaakt op"
 
-#: core/models.py:112
+#: core/models.py:115
 msgid "date and time at which a record was created"
 msgstr "datum en tijd waarop een record werd aangemaakt"
 
-#: core/models.py:117
+#: core/models.py:120
 msgid "updated on"
 msgstr "bijgewerkt op"
 
-#: core/models.py:118
+#: core/models.py:121
 msgid "date and time at which a record was last updated"
 msgstr "datum en tijd waarop een record voor het laatst werd bijgewerkt"
 
-#: core/models.py:138
+#: core/models.py:141
 msgid ""
 "Enter a valid sub. This value may contain only letters, numbers, and @/./+/-/"
 "_ characters."
@@ -138,66 +170,66 @@ msgstr ""
 "Voer een geldige sub in. Deze waarde mag alleen letters, cijfers en @/./+/-/"
 "_ tekens bevatten."
 
-#: core/models.py:144
+#: core/models.py:147
 msgid "sub"
 msgstr "sub"
 
-#: core/models.py:146
+#: core/models.py:149
 msgid ""
 "Required. 255 characters or fewer. Letters, numbers, and @/./+/-/_ "
 "characters only."
 msgstr ""
 "Vereist. 255 tekens of minder. Alleen letters, cijfers en @/./+/-/_ tekens."
 
-#: core/models.py:154
+#: core/models.py:157
 msgid "identity email address"
 msgstr "identiteit e-mailadres"
 
-#: core/models.py:159
+#: core/models.py:162
 msgid "admin email address"
 msgstr "beheerder e-mailadres"
 
-#: core/models.py:161
+#: core/models.py:164
 msgid "full name"
 msgstr "volledige naam"
 
-#: core/models.py:163
+#: core/models.py:166
 msgid "short name"
 msgstr "korte naam"
 
-#: core/models.py:169
+#: core/models.py:172
 msgid "language"
 msgstr "taal"
 
-#: core/models.py:170
+#: core/models.py:173
 msgid "The language in which the user wants to see the interface."
 msgstr "De taal waarin de gebruiker de interface wil zien."
 
-#: core/models.py:176
+#: core/models.py:179
 msgid "The timezone in which the user wants to see times."
 msgstr "De tijdzone waarin de gebruiker tijden wil zien."
 
-#: core/models.py:179
+#: core/models.py:182
 msgid "device"
 msgstr "apparaat"
 
-#: core/models.py:181
+#: core/models.py:184
 msgid "Whether the user is a device or a real user."
 msgstr "Of de gebruiker een apparaat is of een echte gebruiker."
 
-#: core/models.py:184
+#: core/models.py:187
 msgid "staff status"
 msgstr "personeelsstatus"
 
-#: core/models.py:186
+#: core/models.py:189
 msgid "Whether the user can log into this admin site."
 msgstr "Of de gebruiker kan inloggen op deze beheersite."
 
-#: core/models.py:189
+#: core/models.py:192
 msgid "active"
 msgstr "actief"
 
-#: core/models.py:192
+#: core/models.py:195
 msgid ""
 "Whether this user should be treated as active. Unselect this instead of "
 "deleting accounts."
@@ -205,64 +237,64 @@ msgstr ""
 "Of deze gebruiker als actief moet worden behandeld. Deselecteer dit in "
 "plaats van accounts te verwijderen."
 
-#: core/models.py:205
+#: core/models.py:208
 msgid "user"
 msgstr "gebruiker"
 
-#: core/models.py:206
+#: core/models.py:209
 msgid "users"
 msgstr "gebruikers"
 
-#: core/models.py:265
+#: core/models.py:268
 msgid "Resource"
 msgstr "Bron"
 
-#: core/models.py:266
+#: core/models.py:269
 msgid "Resources"
 msgstr "Bronnen"
 
-#: core/models.py:320
+#: core/models.py:323
 msgid "Resource access"
 msgstr "Brontoegang"
 
-#: core/models.py:321
+#: core/models.py:324
 msgid "Resource accesses"
 msgstr "Brontoegangsrechten"
 
-#: core/models.py:327
+#: core/models.py:330
 msgid "Resource access with this User and Resource already exists."
 msgstr "Brontoegang met deze gebruiker en bron bestaat al."
 
-#: core/models.py:383
+#: core/models.py:386
 msgid "Visio room configuration"
 msgstr "Visio-ruimteconfiguratie"
 
-#: core/models.py:384
+#: core/models.py:387
 msgid "Values for Visio parameters to configure the room."
 msgstr "Waarden voor Visio-parameters om de ruimte te configureren."
 
-#: core/models.py:391
+#: core/models.py:394
 msgid "Room PIN code"
 msgstr "Pincode van de kamer"
 
-#: core/models.py:392
+#: core/models.py:395
 msgid "Unique n-digit code that identifies this room in telephony mode."
 msgstr ""
 "Unieke n-cijferige code die deze kamer identificeert in telefonie-modus."
 
-#: core/models.py:398 core/models.py:552
+#: core/models.py:401 core/models.py:555
 msgid "Room"
 msgstr "Ruimte"
 
-#: core/models.py:399
+#: core/models.py:402
 msgid "Rooms"
 msgstr "Ruimtes"
 
-#: core/models.py:563
+#: core/models.py:566
 msgid "Worker ID"
 msgstr "Worker ID"
 
-#: core/models.py:565
+#: core/models.py:568
 msgid ""
 "Enter an identifier for the worker recording.This ID is retained even when "
 "the worker stops, allowing for easy tracking."
@@ -270,41 +302,101 @@ msgstr ""
 "Voer een identificatie in voor de worker-opname. Deze ID blijft behouden, "
 "zelfs wanneer de worker stopt, waardoor eenvoudige tracking mogelijk is."
 
-#: core/models.py:573
+#: core/models.py:576
 msgid "Recording mode"
 msgstr "Opnamemodus"
 
-#: core/models.py:574
+#: core/models.py:577
 msgid "Defines the mode of recording being called."
 msgstr "Definieert de modus van opname die wordt aangeroepen."
 
-#: core/models.py:580
+#: core/models.py:583
 msgid "Recording"
 msgstr "Opname"
 
-#: core/models.py:581
+#: core/models.py:584
 msgid "Recordings"
 msgstr "Opnames"
 
-#: core/models.py:689
+#: core/models.py:692
 msgid "Recording/user relation"
 msgstr "Opname/gebruiker-relatie"
 
-#: core/models.py:690
+#: core/models.py:693
 msgid "Recording/user relations"
 msgstr "Opname/gebruiker-relaties"
 
-#: core/models.py:696
+#: core/models.py:699
 msgid "This user is already in this recording."
 msgstr "Deze gebruiker is al in deze opname."
 
-#: core/models.py:702
+#: core/models.py:705
 msgid "This team is already in this recording."
 msgstr "Dit team is al in deze opname."
 
-#: core/models.py:708
+#: core/models.py:711
 msgid "Either user or team must be set, not both."
 msgstr "Ofwel gebruiker of team moet worden ingesteld, niet beide."
+
+#: core/models.py:728
+msgid "Create rooms"
+msgstr "Ruimtes aanmaken"
+
+#: core/models.py:729
+msgid "List rooms"
+msgstr "Ruimtes weergeven"
+
+#: core/models.py:730
+msgid "Retrieve room details"
+msgstr "Details van een ruimte ophalen"
+
+#: core/models.py:731
+msgid "Update rooms"
+msgstr "Ruimtes bijwerken"
+
+#: core/models.py:732
+msgid "Delete rooms"
+msgstr "Ruimtes verwijderen"
+
+#: core/models.py:745
+msgid "Application name"
+msgstr "Naam van de applicatie"
+
+#: core/models.py:746
+msgid "Descriptive name for this application."
+msgstr "Beschrijvende naam voor deze applicatie."
+
+#: core/models.py:756
+msgid "Hashed on Save. Copy it now if this is a new secret."
+msgstr "Wordt gehasht bij het opslaan. Kopieer het nu als dit een nieuw geheim is."
+
+#: core/models.py:767
+msgid "Application"
+msgstr "Applicatie"
+
+#: core/models.py:768
+msgid "Applications"
+msgstr "Applicaties"
+
+#: core/models.py:791
+msgid "Enter a valid domain"
+msgstr "Voer een geldig domein in"
+
+#: core/models.py:794
+msgid "Domain"
+msgstr "Domein"
+
+#: core/models.py:795
+msgid "Email domain this application can act on behalf of."
+msgstr "E-maildomein namens welke deze applicatie kan handelen."
+
+#: core/models.py:807
+msgid "Application domain"
+msgstr "Applicatiedomein"
+
+#: core/models.py:808
+msgid "Application domains"
+msgstr "Applicatiedomeinen"
 
 #: core/recording/event/notification.py:94
 msgid "Your recording is ready"
@@ -396,7 +488,8 @@ msgid ""
 " Sharing the recording via link is not yet available. Only organizers can "
 "download it. "
 msgstr ""
-"Het delen van de opname via een link is nog niet beschikbaar. Alleen organisatoren kunnen deze downloaden."
+"Het delen van de opname via een link is nog niet beschikbaar. Alleen "
+"organisatoren kunnen deze downloaden."
 
 #: core/templates/mail/html/screen_recording.html:206
 #: core/templates/mail/text/screen_recording.txt:11
@@ -433,18 +526,18 @@ msgstr ""
 " Als je vragen hebt of hulp nodig hebt, neem dan contact op met ons support "
 "team via %(support_email)s. "
 
-#: meet/settings.py:163
+#: meet/settings.py:167
 msgid "English"
 msgstr "Engels"
 
-#: meet/settings.py:164
+#: meet/settings.py:168
 msgid "French"
 msgstr "Frans"
 
-#: meet/settings.py:165
+#: meet/settings.py:169
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: meet/settings.py:166
+#: meet/settings.py:170
 msgid "German"
 msgstr "Duits"


### PR DESCRIPTION
Regenerate backend translation files to include missing translations for newly added translatable strings in recent code changes, ensuring complete internationalization coverage across all supported languages.