### PR TITLE
🔔(frontend) request transcription

### DIFF
--- a/src/frontend/src/features/notifications/MainNotificationToast.tsx
+++ b/src/frontend/src/features/notifications/MainNotificationToast.tsx
@@ -10,6 +10,7 @@ import { decodeNotificationDataReceived } from './utils'
 import { useNotificationSound } from '@/features/notifications/hooks/useSoundNotification'
 import { ToastProvider, toastQueue } from './components/ToastProvider'
 import { WaitingParticipantNotification } from './components/WaitingParticipantNotification'
+import { TranscriptionRequestNotification } from './components/TranscriptionRequestNotification'
 import {
   Emoji,
   Reaction,
@@ -228,6 +229,7 @@ export const MainNotificationToast = () => {
     <Div position="absolute" bottom={0} right={5} zIndex={1000}>
       <ToastProvider />
       <WaitingParticipantNotification />
+      <TranscriptionRequestNotification />
       <ReactionPortals reactions={reactions} />
     </Div>
   )

--- a/src/frontend/src/features/notifications/NotificationType.ts
+++ b/src/frontend/src/features/notifications/NotificationType.ts
@@ -9,6 +9,7 @@ export enum NotificationType {
   TranscriptionStarted = 'transcriptionStarted',
   TranscriptionStopped = 'transcriptionStopped',
   TranscriptionLimitReached = 'transcriptionLimitReached',
+  TranscriptionRequested = 'transcriptionRequested',
   ScreenRecordingStarted = 'screenRecordingStarted',
   ScreenRecordingStopped = 'screenRecordingStopped',
   ScreenRecordingLimitReached = 'screenRecordingLimitReached',

--- a/src/frontend/src/features/notifications/components/ToastRegion.tsx
+++ b/src/frontend/src/features/notifications/components/ToastRegion.tsx
@@ -47,6 +47,7 @@ const renderToast = (
     case NotificationType.TranscriptionStarted:
     case NotificationType.TranscriptionStopped:
     case NotificationType.TranscriptionLimitReached:
+    case NotificationType.TranscriptionRequested:
     case NotificationType.ScreenRecordingStarted:
     case NotificationType.ScreenRecordingStopped:
     case NotificationType.ScreenRecordingLimitReached:

--- a/src/frontend/src/features/notifications/components/TranscriptionRequestNotification.tsx
+++ b/src/frontend/src/features/notifications/components/TranscriptionRequestNotification.tsx
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import { RemoteParticipant, RoomEvent } from 'livekit-client'
+import { StyledToastContainer } from './Toast'
+import { HStack, VStack } from '@/styled-system/jsx'
+import { Avatar } from '@/components/Avatar'
+import { Button, Text } from '@/primitives'
+import { css } from '@/styled-system/css'
+import { useTranslation } from 'react-i18next'
+import { usePrevious } from '@/hooks/usePrevious'
+import { useNotificationSound } from '../hooks/useSoundNotification'
+import { NotificationType } from '../NotificationType'
+import { decodeNotificationDataReceived } from '../utils'
+import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
+import { useRoomId } from '@/features/rooms/livekit/hooks/useRoomId'
+import { getParticipantColor } from '@/features/rooms/utils/getParticipantColor'
+import { RecordingMode, useStartRecording } from '@/features/recording'
+import { RecordingStatus, recordingStore } from '@/stores/recording'
+import { FeatureFlags } from '@/features/analytics/enums'
+import { useHasRecordingAccess } from '@/features/recording/hooks/useHasRecordingAccess'
+import { useNotifyParticipants } from '../hooks/useNotifyParticipants'
+import posthog from 'posthog-js'
+
+export const NOTIFICATION_DISPLAY_DURATION = 10000
+
+interface TranscriptionRequest {
+  participant: RemoteParticipant
+  timestamp: number
+}
+
+export const TranscriptionRequestNotification = () => {
+  const { triggerNotificationSound } = useNotificationSound()
+  const { t } = useTranslation('notifications', {
+    keyPrefix: 'transcriptionRequest',
+  })
+  const room = useRoomContext()
+  const isAdminOrOwner = useIsAdminOrOwner()
+  const { isAdminOpen } = useSidePanel()
+  const roomId = useRoomId()
+
+  const [requests, setRequests] = useState<TranscriptionRequest[]>([])
+  const prevRequests = usePrevious<TranscriptionRequest[] | undefined>(requests)
+  const [showQuickActionsMessage, setShowQuickActionsMessage] = useState(false)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const hasTranscriptAccess = useHasRecordingAccess(
+    RecordingMode.Transcript,
+    FeatureFlags.Transcript
+  )
+
+  const { mutateAsync: startRecordingRoom } = useStartRecording()
+  const { notifyParticipants } = useNotifyParticipants()
+
+  const handleDataReceived = useCallback(
+    (payload: Uint8Array, participant?: RemoteParticipant) => {
+      if (!participant || participant.isLocal || !isAdminOrOwner) return
+
+      const notification = decodeNotificationDataReceived(payload)
+      if (notification?.type === NotificationType.TranscriptionRequested) {
+        // Check if we already have a request from this participant
+        setRequests((prev) => {
+          const existing = prev.find(
+            (req) => req.participant.identity === participant.identity
+          )
+          if (existing) return prev
+          return [...prev, { participant, timestamp: Date.now() }]
+        })
+      }
+    },
+    [isAdminOrOwner]
+  )
+
+  useEffect(() => {
+    if (!isAdminOrOwner) return
+
+    room.on(RoomEvent.DataReceived, handleDataReceived)
+    return () => {
+      room.off(RoomEvent.DataReceived, handleDataReceived)
+    }
+  }, [isAdminOrOwner, room, handleDataReceived])
+
+  useEffect(() => {
+    // Show notification when the first request arrives
+    if (
+      requests.length > 0 &&
+      (!prevRequests || prevRequests.length === 0) &&
+      !isAdminOpen
+    ) {
+      setShowQuickActionsMessage(true)
+      triggerNotificationSound(NotificationType.TranscriptionRequested)
+
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+      timerRef.current = setTimeout(() => {
+        setShowQuickActionsMessage(false)
+        timerRef.current = null
+      }, NOTIFICATION_DISPLAY_DURATION)
+    } else if (requests.length !== prevRequests?.length) {
+      setShowQuickActionsMessage(false)
+    }
+  }, [requests, prevRequests, isAdminOpen, triggerNotificationSound])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isAdminOpen) {
+      setShowQuickActionsMessage(false)
+    }
+  }, [isAdminOpen])
+
+  // Remove requests when participants disconnect
+  const handleParticipantDisconnected = useCallback(
+    (participant: RemoteParticipant) => {
+      setRequests((prev) => {
+        const participantIdentity = participant.identity
+        return prev.filter(
+          (req) => req.participant.identity !== participantIdentity
+        )
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    room.on(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected)
+    return () => {
+      room.off(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected)
+    }
+  }, [room, handleParticipantDisconnected])
+
+  const handleStartTranscription = async () => {
+    if (!roomId || !hasTranscriptAccess) return
+
+    try {
+      await startRecordingRoom({ id: roomId, mode: RecordingMode.Transcript })
+      recordingStore.status = RecordingStatus.TRANSCRIPT_STARTING
+      await notifyParticipants({
+        type: NotificationType.TranscriptionStarted,
+      })
+      posthog.capture('transcript-started', { source: 'request' })
+      // Clear all requests after starting
+      setRequests([])
+      setShowQuickActionsMessage(false)
+    } catch (error) {
+      console.error('Failed to start transcription:', error)
+    }
+  }
+
+  const handleDismiss = () => {
+    if (requests.length > 0) {
+      // Remove the first request
+      setRequests((prev) => prev.slice(1))
+      setShowQuickActionsMessage(false)
+    }
+  }
+
+  if (!isAdminOrOwner || !requests.length) return null
+
+  const firstRequest = requests[0]
+  const participantName =
+    firstRequest.participant.name ||
+    firstRequest.participant.identity ||
+    'Unknown'
+  const participantColor = getParticipantColor(firstRequest.participant)
+
+  return (
+    <StyledToastContainer role="alert">
+      <HStack
+        padding={'1rem'}
+        gap={'1rem'}
+        role={'alertdialog'}
+        aria-label={t('message', { name: participantName })}
+        aria-modal={false}
+      >
+        {showQuickActionsMessage ? (
+          <VStack gap={'1rem'} alignItems={'start'}>
+            <Text
+              variant="paragraph"
+              margin={false}
+              style={{
+                minWidth: '15rem',
+              }}
+            >
+              {t('message', { name: participantName })}
+            </Text>
+            <HStack gap="1rem">
+              <Avatar
+                name={participantName}
+                bgColor={participantColor}
+                context="list"
+                notification
+              />
+              <Text
+                variant="sm"
+                margin={false}
+                className={css({
+                  maxWidth: '10rem',
+                  wordBreak: 'break-word',
+                  overflowWrap: 'break-word',
+                  whiteSpace: 'normal',
+                })}
+              >
+                {participantName}
+              </Text>
+            </HStack>
+            <HStack gap="0.25rem" marginLeft="auto">
+              {hasTranscriptAccess && (
+                <Button
+                  size="sm"
+                  variant="text"
+                  className={css({
+                    color: 'primary.300',
+                  })}
+                  onPress={handleStartTranscription}
+                >
+                  {t('start')}
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="text"
+                className={css({
+                  color: 'primary.300',
+                })}
+                onPress={handleDismiss}
+              >
+                {t('dismiss')}
+              </Button>
+            </HStack>
+          </VStack>
+        ) : (
+          <>
+            <HStack gap={0}>
+              <Avatar
+                name={participantName}
+                bgColor={participantColor}
+                context="list"
+                notification
+              />
+              {requests.length > 1 && (
+                <span
+                  className={css({
+                    width: '32px',
+                    height: '32px',
+                    fontSize: '1rem',
+                    color: 'white',
+                    display: 'flex',
+                    borderRadius: '50%',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    background: 'primaryDark.100',
+                    border: '2px solid white',
+                    marginLeft: '-10px',
+                  })}
+                >
+                  +{requests.length - 1}
+                </span>
+              )}
+            </HStack>
+            <Text
+              variant="paragraph"
+              margin={false}
+              wrap={'balance'}
+              style={{
+                maxWidth: requests.length === 1 ? '10rem' : '15rem',
+              }}
+            >
+              {requests.length > 1
+                ? t('multiple', { count: requests.length })
+                : t('message', { name: participantName })}
+            </Text>
+            {hasTranscriptAccess && (
+              <Button
+                size="sm"
+                variant="text"
+                className={css({
+                  color: 'primary.300',
+                })}
+                onPress={handleStartTranscription}
+              >
+                {t('start')}
+              </Button>
+            )}
+          </>
+        )}
+      </HStack>
+    </StyledToastContainer>
+  )
+}

--- a/src/frontend/src/locales/de/notifications.json
+++ b/src/frontend/src/locales/de/notifications.json
@@ -32,6 +32,12 @@
     "stopped": "{{name}} hat die Transkription des Treffens gestoppt.",
     "limitReached": "Die Transkription hat die maximal zulässige Dauer überschritten und wird automatisch gespeichert."
   },
+  "transcriptionRequest": {
+    "message": "{{name}} hat um den Start der Transkription gebeten.",
+    "multiple": "{{count}} Teilnehmer haben um Transkription gebeten.",
+    "start": "Starten",
+    "dismiss": "Ablehnen"
+  },
   "screenRecording": {
     "started": "{{name}} hat die Aufzeichnung des Treffens gestartet.",
     "stopped": "{{name}} hat die Aufzeichnung des Treffens gestoppt.",

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -322,6 +322,10 @@
       "body": "Aus Sicherheitsgründen kann nur der Ersteller oder ein Administrator des Meetings eine Transkription (Beta) starten.",
       "linkMore": "Mehr erfahren"
     },
+    "request": {
+      "button": "Transkription anfordern",
+      "sent": "Anfrage gesendet"
+    },
     "stop": {
       "heading": "Transkription läuft...",
       "body": "Die Transkription deines Meetings läuft. Du erhältst das Ergebnis per E-Mail, sobald das Meeting beendet ist.",

--- a/src/frontend/src/locales/en/notifications.json
+++ b/src/frontend/src/locales/en/notifications.json
@@ -32,6 +32,12 @@
     "stopped": "{{name}} stopped the meeting transcription.",
     "limitReached": "The transcription has exceeded the maximum allowed duration and will be automatically saved."
   },
+  "transcriptionRequest": {
+    "message": "{{name}} requested to start transcription.",
+    "multiple": "{{count}} participants requested transcription.",
+    "start": "Start",
+    "dismiss": "Dismiss"
+  },
   "screenRecording": {
     "started": "{{name}} started the meeting recording.",
     "stopped": "{{name}} stopped the meeting recording.",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -322,6 +322,10 @@
       "body": "For security reasons, only the meeting creator or an admin can start a transcription (beta).",
       "linkMore": "Learn more"
     },
+    "request": {
+      "button": "Request transcription",
+      "sent": "Request sent"
+    },
     "stop": {
       "heading": "Transcription in progress...",
       "body": "The transcription of your meeting is in progress. You will receive the result by email once the meeting is finished.",

--- a/src/frontend/src/locales/fr/notifications.json
+++ b/src/frontend/src/locales/fr/notifications.json
@@ -32,6 +32,12 @@
     "stopped": "{{name}} a arrêté la transcription de la réunion.",
     "limitReached": "La transcription a dépassé la durée maximale autorisée, elle va être automatiquement sauvegardée."
   },
+  "transcriptionRequest": {
+    "message": "{{name}} a demandé de démarrer la transcription.",
+    "multiple": "{{count}} participants ont demandé la transcription.",
+    "start": "Démarrer",
+    "dismiss": "Ignorer"
+  },
   "screenRecording": {
     "started": "{{name}} a démarré l'enregistrement de la réunion.",
     "stopped": "{{name}} a arrêté l'enregistrement de la réunion.",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -322,6 +322,10 @@
       "body": "Pour des raisons de sécurité, seul le créateur ou un administrateur de la réunion peut lancer une transcription (beta).",
       "linkMore": "En savoir plus"
     },
+    "request": {
+      "button": "Demander la transcription",
+      "sent": "Demande envoyée"
+    },
     "stop": {
       "heading": "Transcription en cours …",
       "body": "La transcription de votre réunion est en cours. Vous recevrez le resultat par email une fois la réunion terminée.",

--- a/src/frontend/src/locales/nl/notifications.json
+++ b/src/frontend/src/locales/nl/notifications.json
@@ -32,6 +32,12 @@
     "stopped": "{{name}} heeft de transcriptie van de vergadering gestopt.",
     "limitReached": "De transcriptie heeft de maximaal toegestane duur overschreden en wordt automatisch opgeslagen."
   },
+  "transcriptionRequest": {
+    "message": "{{name}} heeft gevraagd om transcriptie te starten.",
+    "multiple": "{{count}} deelnemers hebben om transcriptie gevraagd.",
+    "start": "Starten",
+    "dismiss": "Negeren"
+  },
   "screenRecording": {
     "started": "{{name}} is begonnen met het opnemen van de vergadering.",
     "stopped": "{{name}} is gestopt met het opnemen van de vergadering.",

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -322,6 +322,10 @@
       "body": "Om veiligheidsredenen kan alleen de maker of een beheerder van de vergadering een transcriptie starten (beta).",
       "linkMore": "Meer informatie"
     },
+    "request": {
+      "button": "Transcriptie aanvragen",
+      "sent": "Verzoek verzonden"
+    },
     "stop": {
       "heading": "Transcriptie bezig...",
       "body": "De transcriptie van uw vergadering is bezig. U ontvangt het resultaat per e-mail zodra de vergadering is afgelopen.",


### PR DESCRIPTION
## Purpose

Add transcription requests from non-admin users to the admin. I could not test it e2e because I don't have the transcription set up but the flow seems to work ok. @lebaudantoine wdyt?


<img width="397" height="611" alt="Screenshot 2025-11-17 at 2 00 05 PM" src="https://github.com/user-attachments/assets/ae2ab927-51d3-4c6d-ae89-d371320dcb4d" />
<img width="421" height="259" alt="Screenshot 2025-11-17 at 1 59 54 PM" src="https://github.com/user-attachments/assets/1976bcae-8151-4f12-ac8b-e5b6545daf79" />

## Proposal

Description...

- Allow non-admin users to send a request to the admin to start transcription
- The admin receives a request and can accept or dismiss it
