### PR TITLE
🩹(frontend) avoid unnecessary redirection while authenticating

### DIFF
--- a/src/frontend/src/features/auth/utils/authUrl.ts
+++ b/src/frontend/src/features/auth/utils/authUrl.ts
@@ -5,6 +5,6 @@ export const authUrl = ({
   returnTo = window.location.href,
 } = {}) => {
   return apiUrl(
-    `/authenticate?silent=${encodeURIComponent(silent)}&returnTo=${encodeURIComponent(returnTo)}`
+    `/authenticate/?silent=${encodeURIComponent(silent)}&returnTo=${encodeURIComponent(returnTo)}`
   )
 }


### PR DESCRIPTION
A manually constructed authentication URL didn’t match the actual endpoint address, causing the Django backend to issue a 301 redirect to the correct URL.

This wasn’t a problem for regular users at first, but once a client integrating through a virtual browser came on board, it became significant. The 301 redirect was disrupting the virtual browser’s cookie/cache system, which in turn broke the authentication flow.

This change aims to resolve the issue, although it’s not yet certain that it will fully address their problem.