### PR TITLE
🐛(frontend) fix unclickable fullscreen warning buttons from commit 53e68b7

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
@@ -113,6 +113,7 @@ export const FullScreenShareWarning = ({
                 display: 'flex',
                 flexDirection: 'row',
                 gap: '1rem',
+                zIndex: '1000',
               })}
             >
               <Button


### PR DESCRIPTION
Adjust z-index values to restore button interactivity broken by previous z-index changes in commit 53e68b7, ensuring fullscreen warning dismiss controls remain accessible to users instead of being blocked by overlay layering.
