### PR TITLE
♿️(frontend) change ptt keybinding from space to v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to
 ### Changed
 
 - ♿(frontend) improve accessibility:
- - ♿️(frontend) hover controls, focus, SR 
+ - ♿️(frontend) hover controls, focus, SR #803
+ - ♿️(frontend) change ptt keybinding from space to v #813
 

--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/ToggleDevice.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/ToggleDevice.tsx
@@ -93,7 +93,7 @@ export const ToggleDevice = <T extends ToggleSource>({
     isDisabled: cannotUseDevice,
   })
   useLongPress({
-    keyCode: kind === 'audioinput' ? 'Space' : undefined,
+    keyCode: kind === 'audioinput' ? 'KeyV' : undefined,
     onKeyDown,
     onKeyUp,
     isDisabled: cannotUseDevice,


### PR DESCRIPTION
## Purpose

Prevent accidental activation of push-to-talk when pressing space while typing.

[812](https://github.com/suitenumerique/meet/issues/812)

## Proposal

Change the PTT keybinding from `Space` to `V`, which is less likely to be triggered
unintentionally and is easier to use ergonomically.

- [x] Update keybinding from Space to V
