### PR TITLE
♿(frontend) fix heading level in modal to maintain semantic hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to
 - ♿️(frontend) hover controls, focus, SR #803
 - ♿️(frontend) change ptt keybinding from space to v #813
 - ♿(frontend) indicate external link opens in new window on feedback #816
+- ♿(frontend) fix heading level in modal to maintain semantic hierarchy #815

--- a/src/frontend/src/features/rooms/components/InviteDialog.tsx
+++ b/src/frontend/src/features/rooms/components/InviteDialog.tsx
@@ -67,7 +67,7 @@ export const InviteDialog = (props: Omit<DialogProps, 'title'>) => {
           gap={0}
           style={{ maxWidth: '100%', overflow: 'hidden' }}
         >
-          <Heading slot="title" level={3} className={text({ variant: 'h2' })}>
+          <Heading slot="title" level={2} className={text({ variant: 'h2' })}>
             {t('heading')}
           </Heading>
           <Div position="absolute" top="5" right="5">


### PR DESCRIPTION
## Purpose

Ensure semantic correctness and accessibility by fixing the heading level in
the "Your meeting is ready" modal.

issue : [729](https://github.com/suitenumerique/meet/issues/729)

## Proposal

Replace the `<h3>` tag with `<h2>` to maintain a logical and accessible

- [x] Replaced h3 with h2 in the modal