### PR TITLE
♿(frontend) indicate external link opens in new window on feedback 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -12,6 +11,6 @@ and this project adheres to
 ### Changed
 
 - ♿(frontend) improve accessibility:
- - ♿️(frontend) hover controls, focus, SR #803
- - ♿️(frontend) change ptt keybinding from space to v #813
-
+- ♿️(frontend) hover controls, focus, SR #803
+- ♿️(frontend) change ptt keybinding from space to v #813
+- ♿(frontend) indicate external link opens in new window on feedback #816

--- a/src/frontend/src/locales/de/global.json
+++ b/src/frontend/src/locales/de/global.json
@@ -7,7 +7,7 @@
   },
   "feedback": {
     "context": "Produkt in Entwicklung — Ihr Feedback ist wichtig!",
-    "cta": "Teilen Sie uns Ihre Meinung mit"
+    "cta": "Teilen Sie uns Ihre Meinung mit - neues Fenster"
   },
   "forbidden": {
     "heading": "Zugriff verweigert"

--- a/src/frontend/src/locales/en/global.json
+++ b/src/frontend/src/locales/en/global.json
@@ -7,7 +7,7 @@
   },
   "feedback": {
     "context": "Product under development — your input matters!",
-    "cta": "Share your feedback"
+    "cta": "Share your feedback - new tab"
   },
   "forbidden": {
     "heading": "You don't have the permission to view this page"

--- a/src/frontend/src/locales/fr/global.json
+++ b/src/frontend/src/locales/fr/global.json
@@ -7,7 +7,7 @@
   },
   "feedback": {
     "context": "Produit en cours de développement — votre avis compte !",
-    "cta": "Partagez votre avis"
+    "cta": "Partagez votre avis - nouvelle fenêtre"
   },
   "forbidden": {
     "heading": "Accès interdit"

--- a/src/frontend/src/locales/nl/global.json
+++ b/src/frontend/src/locales/nl/global.json
@@ -7,7 +7,7 @@
   },
   "feedback": {
     "context": "Product in ontwikkeling - uw input is belangrijk!",
-    "cta": "Deel uw feedback"
+    "cta": "Deel uw feedback - nieuw tabblad"
   },
   "forbidden": {
     "heading": "U hebt geen toestemming om deze pagina te bekijken"


### PR DESCRIPTION
## Purpose

Improve accessibility of the feedback banner link on the homepage by informing
users that it opens a new window.

issue : [765](https://github.com/suitenumerique/meet/issues/765)

## Proposal

Add a `title` attribute to the external feedback link to notify screen reader
users that it opens in a new tab. 

- [x] Added `title="Partagez votre avis - nouvelle fenêtre"` to the link
