### PR TITLE
🩹(backend) remove environment prefix from recently introduced settings

### DIFF
--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -405,10 +405,10 @@ class Base(Configuration):
     OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = values.BooleanValue(
         default=False,
         environ_name="OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION",
+        environ_prefix=None,
     )
     OIDC_USER_SUB_FIELD_IMMUTABLE = values.BooleanValue(
-        default=True,
-        environ_name="OIDC_USER_SUB_FIELD_IMMUTABLE",
+        default=True, environ_name="OIDC_USER_SUB_FIELD_IMMUTABLE", environ_prefix=None
     )
     OIDC_TIMEOUT = values.IntegerValue(
         5, environ_name="OIDC_TIMEOUT", environ_prefix=None


### PR DESCRIPTION
The prefix was unintentionally added and wasn’t caught during review. This change corrects it.
