### PR TITLE
📌(egress) pin egress version to v1.11.0

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -235,7 +235,7 @@ services:
       - livekit-egress
 
   livekit-egress:
-      image: livekit/egress
+      image: livekit/egress:v1.11.0
       environment:
         EGRESS_CONFIG_FILE: ./livekit-egress.yaml
       volumes:

--- a/src/helm/env.d/dev-keycloak/values.egress.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.egress.yaml.gotmpl
@@ -1,6 +1,9 @@
 replicaCount: 1
 terminationGracePeriodSeconds: 18000
 
+image:
+  tag: v1.11.0
+
 egress:
   log_level: debug
   ws_url: ws://livekit-livekit-server:80


### PR DESCRIPTION
Pin egress to the production version, which uses a more recent release than the default chart value (1.9.0).

Using the default could have led to issues; hopefully this change avoids them.