### PR TITLE
🐛(summary) fix MinIO endpoint handling in constructor

### DIFF
--- a/env.d/development/summary.dist
+++ b/env.d/development/summary.dist
@@ -1,7 +1,7 @@
 APP_NAME="meet-app-summary-dev"
 APP_API_TOKEN="password"
 
-AWS_STORAGE_BUCKET_NAME="meet-media-storage"
+AWS_STORAGE_BUCKET_NAME="http://meet-media-storage"
 AWS_S3_ENDPOINT_URL="minio:9000"
 AWS_S3_SECURE_ACCESS=false
 

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -150,7 +150,7 @@ summary:
     APP_NAME: summary-microservice
     APP_API_TOKEN: password
     AWS_STORAGE_BUCKET_NAME: meet-media-storage
-    AWS_S3_ENDPOINT_URL: minio.meet.svc.cluster.local:9000
+    AWS_S3_ENDPOINT_URL: http://minio.meet.svc.cluster.local:9000/
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     AWS_S3_SECURE_ACCESS: False
@@ -187,7 +187,7 @@ celeryTranscribe:
     APP_NAME: summary-microservice
     APP_API_TOKEN: password
     AWS_STORAGE_BUCKET_NAME: meet-media-storage
-    AWS_S3_ENDPOINT_URL: minio.meet.svc.cluster.local:9000
+    AWS_S3_ENDPOINT_URL: http://minio.meet.svc.cluster.local:9000/
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     AWS_S3_SECURE_ACCESS: False
@@ -225,7 +225,7 @@ celerySummarize:
     APP_NAME: summary-microservice
     APP_API_TOKEN: password
     AWS_STORAGE_BUCKET_NAME: meet-media-storage
-    AWS_S3_ENDPOINT_URL: minio.meet.svc.cluster.local:9000
+    AWS_S3_ENDPOINT_URL: http://minio.meet.svc.cluster.local:9000/
     AWS_S3_ACCESS_KEY_ID: meet
     AWS_S3_SECRET_ACCESS_KEY: password
     AWS_S3_SECURE_ACCESS: False

--- a/src/summary/summary/core/file_service.py
+++ b/src/summary/summary/core/file_service.py
@@ -21,8 +21,14 @@ class FileService:
         """Initialize FileService with MinIO client and configuration."""
         self._logger = logger
 
+        endpoint = (
+            settings.aws_s3_endpoint_url.removeprefix("https://")
+            .removeprefix("http://")
+            .rstrip("/")
+        )
+
         self._minio_client = Minio(
-            settings.aws_s3_endpoint_url,
+            endpoint,
             access_key=settings.aws_s3_access_key_id,
             secret_key=settings.aws_s3_secret_access_key.get_secret_value(),
             secure=settings.aws_s3_secure_access,


### PR DESCRIPTION
Fix MinIO client configuration: I was incorrectly passing a full URL instead of an endpoint, which caused errors in staging. Local development values did not reflect the staging setup and were also out of sync with the backend.
