### PR TITLE
✨(summary) add dutch and german languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(summary) add dutch and german languages
+
 ### Changed
 
 - 📈(frontend) track new recording's modes

--- a/src/frontend/src/features/settings/hook/useTranscriptionLanguage.ts
+++ b/src/frontend/src/features/settings/hook/useTranscriptionLanguage.ts
@@ -19,6 +19,14 @@ export const useTranscriptionLanguage = () => {
         label: t('language.options.english'),
       },
       {
+        key: RecordingLanguage.GERMAN,
+        label: t('language.options.german'),
+      },
+      {
+        key: RecordingLanguage.DUTCH,
+        label: t('language.options.dutch'),
+      },
+      {
         key: RecordingLanguage.AUTOMATIC,
         label: t('language.options.auto'),
       },

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -75,6 +75,8 @@
       "options": {
         "french": "Französisch (fr)",
         "english": "Englisch (en)",
+        "dutch": "Niederländisch (nl)",
+        "german": "Deutsch (de)",
         "auto": "Automatisch"
       }
     }

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -75,6 +75,8 @@
       "options": {
         "french": "French (fr)",
         "english": "English (en)",
+        "dutch": "Dutch (nl)",
+        "german": "German (de)",
         "auto": "Automatic"
       }
     }

--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -75,6 +75,8 @@
       "options": {
         "french": "Français (fr)",
         "english": "Anglais (en)",
+        "dutch": "Hollandais (nl)",
+        "german": "Allemand (de)",
         "auto": "Automatique"
       }
     }

--- a/src/frontend/src/locales/nl/settings.json
+++ b/src/frontend/src/locales/nl/settings.json
@@ -75,6 +75,8 @@
       "options": {
         "french": "Frans (fr)",
         "english": "Engels (en)",
+        "dutch": "Nederlands (nl)",
+        "german": "Duits (de)",
         "auto": "Automatisch"
       }
     }

--- a/src/frontend/src/stores/recording.ts
+++ b/src/frontend/src/stores/recording.ts
@@ -3,6 +3,8 @@ import { proxy } from 'valtio'
 export enum RecordingLanguage {
   ENGLISH = 'en',
   FRENCH = 'fr',
+  DUTCH = 'nl',
+  GERMAN = 'de',
   AUTOMATIC = 'auto',
 }
 

--- a/src/summary/summary/core/config.py
+++ b/src/summary/summary/core/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     whisperx_max_retries: int = 0
     # ISO 639-1 language code (e.g., "en", "fr", "es")
     whisperx_default_language: Optional[str] = None
-    whisperx_allowed_languages: Set[str] = {"en", "fr"}
+    whisperx_allowed_languages: Set[str] = {"en", "fr", "de", "nl"}
     llm_base_url: str
     llm_api_key: SecretStr
     llm_model: str


### PR DESCRIPTION
Based on a request from our European partners, introduce new languages for the transcription feature. Dutch and German are now supported, which is a great addition.

It closes #837.

WhisperX is expected to support both languages.