### PR TITLE
🩹(frontend) close subtitles on room disconnections

### DIFF
--- a/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
+++ b/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
@@ -2,10 +2,14 @@ import { useSnapshot } from 'valtio'
 import { layoutStore } from '@/stores/layout'
 import { useStartSubtitle } from '../api/startSubtitle'
 import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+import { useRoomContext } from '@livekit/components-react'
+import { useEffect } from 'react'
+import { RoomEvent } from 'livekit-client'
 
 export const useSubtitles = () => {
   const layoutSnap = useSnapshot(layoutStore)
 
+  const room = useRoomContext()
   const apiRoomData = useRoomData()
   const { mutateAsync: startSubtitleRoom, isPending } = useStartSubtitle()
 
@@ -19,6 +23,16 @@ export const useSubtitles = () => {
 
     layoutStore.showSubtitles = !layoutSnap.showSubtitles
   }
+
+  useEffect(() => {
+    const closeSubtitles = () => {
+      layoutStore.showSubtitles = false
+    }
+    room.on(RoomEvent.Disconnected, closeSubtitles)
+    return () => {
+      room.off(RoomEvent.Disconnected, closeSubtitles)
+    }
+  }, [room])
 
   return {
     areSubtitlesOpen: layoutSnap.showSubtitles,


### PR DESCRIPTION
Subtitles were still visible when leaving and rejoining a meeting, even though the backend API call to start them was not triggered again.

Introduce a hook that closes the subtitles layout on unmount, ensuring users must explicitly click the button to restart subtitles when they rejoin a room.