### PR TITLE
🔧(agents) make Silero VAD optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(summary) add dutch and german languages
+- 🔧(agents) make Silero VAD optional
 
 ### Changed
 

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -267,6 +267,7 @@ agents:
     LIVEKIT_API_KEY: {{ $key }}
     {{- end }}
     {{- end }}
+    ENABLE_SILERO_VAD: "false"
 
   image:
     repository: localhost:5001/meet-agents


### PR DESCRIPTION
Allow configuring whether a VAD model runs before calling an external ASR API. Running VAD can save API calls (and costs) when no audible sound is detected, but comes with the trade-off of additional computational overhead.