### PR TITLE
♿(frontend) improve contrast for selected options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Fixed
 
 - 🔒(backend) prevent automatic upgrade setuptools
+- ♿(frontend) improve contrast for selected options #863
 
 ## [1.3.0] - 2026-01-13
 

--- a/src/frontend/src/primitives/buttonRecipe.ts
+++ b/src/frontend/src/primitives/buttonRecipe.ts
@@ -112,7 +112,8 @@ export const buttonRecipe = cva({
         },
         transition: 'box-shadow 0.2s ease-in-out',
         '&[data-selected]': {
-          boxShadow: 'token(colors.primary.400) 0px 0px 0px 3px inset',
+          boxShadow:
+            '0 0 0 3px token(colors.primary.600) inset, 0 0 0 5px white inset',
         },
         '&[data-disabled]': {
           backgroundColor: 'greyscale.100',


### PR DESCRIPTION
## Purpose

Improve accessibility contrast for selected options in background and camera effect selection.


https://github.com/user-attachments/assets/aa803d7c-85db-4a60-9712-19672e202f97



## Proposal

Add dark inner border to selected options for better visibility.

- [x] Add dark inner border to selected state in `bigSquare` variant
- [x] Maintain existing focus ring for accessibility
