### PR TITLE
♿️(frontend) improve background effect announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ♿️(frontend) improve participants toggle a11y label #880
 - ♿️(frontend) make carousel image decorative #871
 - ♿️(frontend) reactions are now vocalized and configurable #849
+- ♿️(frontend) improve background effect announcements #879
 
 ### Fixed
 


### PR DESCRIPTION
## Purpose

Fix sr feedback for background effects by ensuring the active or cleared
state is always announced.

## Proposal

Add a unified screen‑reader announcement path for blur and virtual backgrounds,
including the "no effect" case.
 
- [x] validate SR announces "background clear" when effect is removed
- [x] validate SR announces virtual background name when applied