### PR TITLE
🐛(frontend) Fix layout shift when opening menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - 📝(frontend) align close dialog label in rooms locale #878
 - 🩹(backend) use case-insensitive email matching in the external api #887
 - 🐛(frontend) ensure transcript segments are sorted by their timestamp #899
+- 🐛(frontend) scope scrollbar gutter override to video rooms #882
 
 ## [1.3.0] - 2026-01-13
 

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -45,6 +45,10 @@ body:has(.lk-video-conference) #crisp-chatbox > * > div[role='button'] {
   display: none !important;
 }
 
+html:has(.lk-video-conference) {
+  scrollbar-gutter: auto !important;
+}
+
 @keyframes slide-full {
   from {
     transform: translateY(100%);


### PR DESCRIPTION
## Purpose

React Aria menus are modal by default and call `usePreventScroll`, which applies
`overflow: hidden` and `scrollbar-gutter: stable` on `html`. This reserves space
for the scrollbar and creates the visual gutter/shift when the menu opens.
I switch the menu popover to `isNonModal` to prevent that scroll lock.

Because `isNonModal` disables the modal underlay, React Aria no longer closes
the menu when clicking outside. I add a small reusable hook to fix it

## Proposal

- [x] Update menu popover to `isNonModal` to avoid scroll lock
- [x] Add `useOnOutsidePointerDown` hook and close menu on outside click