### PR TITLE
🩹(doc) update link to the environment variables

### DIFF
--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -47,7 +47,7 @@ curl -o default.conf.template https://raw.githubusercontent.com/suitenumerique/m
 
 ## Step 2: Configuration
 
-Meet configuration is achieved through environment variables. We provide a [detailed description of all variables](../env.md).
+Meet configuration is achieved through environment variables. We provide a [detailed description of all variables](../../src/helm/meet/README.md).
 
 In this example, we assume the following services:
 


### PR DESCRIPTION
Link was invalid. Update it to point to the chart's README file. Please note this file might be removed.
It closes #889 