### PR TITLE
✨ (frontend) add configurable external redirect for unauthenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(frontend) add configurable redirect for unauthenticated users #904
+
 ### Changed
 
 - ♿️(frontend) add accessible back button in side panel #881

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -336,6 +336,9 @@ class Base(Configuration):
         "feedback": values.DictValue(
             {}, environ_name="FRONTEND_FEEDBACK", environ_prefix=None
         ),
+        "external_home_url": values.Value(
+            None, environ_name="FRONTEND_EXTERNAL_HOME_URL", environ_prefix=None
+        ),
         "use_french_gov_footer": values.BooleanValue(
             False, environ_name="FRONTEND_USE_FRENCH_GOV_FOOTER", environ_prefix=None
         ),

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -17,6 +17,7 @@ export interface ApiConfig {
   feedback: {
     url: string
   }
+  external_home_url?: string
   silence_livekit_debug_logs?: boolean
   is_silent_login_enabled?: boolean
   custom_css_url?: string


### PR DESCRIPTION
Offer a way to redirect unauthenticated users to an external home page when they visit the app, allowing a more marketing-focused entry point with a clearer value proposition.

In many self-hosted deployments, the default unauthenticated home page is not accessible or already redirects elsewhere. To ensure resilience, the client briefly checks that the target page is reachable and falls back to the default page if not.