### PR TITLE
✨(all) add/remove owners to your meeting

### DIFF
--- a/src/backend/core/api/permissions.py
+++ b/src/backend/core/api/permissions.py
@@ -106,3 +106,13 @@ class HasLiveKitRoomAccess(permissions.BasePermission):
         if not request.auth or not hasattr(request.auth, "video"):
             return False
         return request.auth.video.room == str(obj.id)
+
+
+class IsRoomOwner(IsAuthenticated):
+    """Check if user is an owner of the room."""
+
+    message = "You must be an owner of the room to perform this action."
+
+    def has_object_permission(self, request, view, obj):
+        """Determine if user is an owner of the room."""
+        return obj.is_owner(request.user)

--- a/src/backend/core/tests/rooms/test_api_rooms_demote.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_demote.py
@@ -1,0 +1,266 @@
+"""
+Test rooms API endpoints in the Meet core app: demote participant from owner.
+"""
+
+# pylint: disable=redefined-outer-name,unused-argument
+
+from unittest import mock
+
+from django.urls import reverse
+
+import pytest
+from livekit.api import TwirpError
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.factories import RoomFactory, UserFactory, UserResourceAccessFactory
+from core.models import ResourceAccess, RoleChoices
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_livekit_client():
+    """Mock LiveKit API client."""
+    with mock.patch("core.utils.create_livekit_client") as mock_create:
+        mock_client = mock.AsyncMock()
+        mock_create.return_value = mock_client
+        yield mock_client
+
+
+def test_demote_participant_unauthenticated():
+    """Test demote participant returns 401 when not authenticated."""
+    client = APIClient()
+    room = RoomFactory()
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(url, {"participant_identity": "test-user"}, format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_demote_participant_forbidden_non_owner():
+    """Test demote participant returns 403 when user is admin but not owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    admin = UserFactory()
+    target_owner = UserFactory(sub="target-owner-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    UserResourceAccessFactory(resource=room, user=target_owner, role="owner")
+    # Create admin access for the requesting user
+    UserResourceAccessFactory(resource=room, user=admin, role="administrator")
+
+    client.force_authenticate(user=admin)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_owner.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_demote_participant_forbidden_member():
+    """Test demote participant returns 403 when user is just a member."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    member = UserFactory()
+    target_owner = UserFactory(sub="target-owner-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    UserResourceAccessFactory(resource=room, user=target_owner, role="owner")
+    # Create member access for the requesting user
+    UserResourceAccessFactory(resource=room, user=member, role="member")
+
+    client.force_authenticate(user=member)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_owner.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_demote_participant_success(mock_livekit_client):
+    """Test owner can successfully demote another owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_owner = UserFactory(sub="target-owner-sub")
+
+    # Create owner accesses - need at least 2 owners
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    UserResourceAccessFactory(resource=room, user=target_owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_owner.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["status"] == "success"
+
+    # Verify ResourceAccess was deleted
+    assert not ResourceAccess.objects.filter(
+        resource=room, user=target_owner, role=RoleChoices.OWNER
+    ).exists()
+
+    # Verify LiveKit update was called
+    mock_livekit_client.room.update_participant.assert_called_once()
+    # aclose called twice: once for participant update, once for notification
+    assert mock_livekit_client.aclose.call_count == 2
+
+
+def test_demote_participant_cannot_demote_last_owner():
+    """Test cannot demote the last owner of a room."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory(sub="owner-sub")
+
+    # Create only one owner
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(url, {"participant_identity": owner.sub}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Cannot demote the last owner" in str(response.data)
+
+    # Verify owner access still exists
+    assert ResourceAccess.objects.filter(
+        resource=room, user=owner, role=RoleChoices.OWNER
+    ).exists()
+
+
+def test_demote_participant_not_an_owner():
+    """Test demoting a non-owner returns error."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    member = UserFactory(sub="member-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # Target is a member, not an owner
+    UserResourceAccessFactory(resource=room, user=member, role="member")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(url, {"participant_identity": member.sub}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "User is not an owner" in str(response.data)
+
+
+def test_demote_participant_user_not_found():
+    """Test demoting non-existent user fails."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": "non-existent-user-sub"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "No user found" in str(response.data)
+
+
+def test_demote_participant_no_access():
+    """Test demoting user with no access to room."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    unrelated_user = UserFactory(sub="unrelated-user-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # unrelated_user has no access to room
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": unrelated_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "User is not an owner" in str(response.data)
+
+
+def test_demote_participant_livekit_error_still_succeeds(mock_livekit_client):
+    """Test that database changes persist even if LiveKit update fails."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_owner = UserFactory(sub="target-owner-sub")
+
+    # Create owner accesses - need at least 2 owners
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    UserResourceAccessFactory(resource=room, user=target_owner, role="owner")
+
+    # Make LiveKit fail
+    mock_livekit_client.room.update_participant.side_effect = TwirpError(
+        msg="Internal server error", code=500, status=500
+    )
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_owner.sub}, format="json"
+    )
+
+    # Should still succeed - database update worked
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify ResourceAccess was deleted despite LiveKit failure
+    assert not ResourceAccess.objects.filter(
+        resource=room, user=target_owner, role=RoleChoices.OWNER
+    ).exists()
+
+
+def test_demote_participant_owner_can_demote_self_if_not_last(mock_livekit_client):
+    """Test owner can demote themselves if not the last owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner1 = UserFactory(sub="owner1-sub")
+    owner2 = UserFactory(sub="owner2-sub")
+
+    # Create two owner accesses
+    UserResourceAccessFactory(resource=room, user=owner1, role="owner")
+    UserResourceAccessFactory(resource=room, user=owner2, role="owner")
+
+    client.force_authenticate(user=owner1)
+
+    url = reverse("rooms-demote-participant", kwargs={"pk": room.id})
+    response = client.post(url, {"participant_identity": owner1.sub}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify owner1's access was deleted
+    assert not ResourceAccess.objects.filter(
+        resource=room, user=owner1, role=RoleChoices.OWNER
+    ).exists()
+
+    # Verify owner2 is still owner
+    assert ResourceAccess.objects.filter(
+        resource=room, user=owner2, role=RoleChoices.OWNER
+    ).exists()

--- a/src/backend/core/tests/rooms/test_api_rooms_promote.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_promote.py
@@ -1,0 +1,245 @@
+"""
+Test rooms API endpoints in the Meet core app: promote participant to owner.
+"""
+
+# pylint: disable=redefined-outer-name,unused-argument
+
+from unittest import mock
+from uuid import uuid4
+
+from django.urls import reverse
+
+import pytest
+from livekit.api import TwirpError
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.factories import RoomFactory, UserFactory, UserResourceAccessFactory
+from core.models import ResourceAccess, RoleChoices
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_livekit_client():
+    """Mock LiveKit API client."""
+    with mock.patch("core.utils.create_livekit_client") as mock_create:
+        mock_client = mock.AsyncMock()
+        mock_create.return_value = mock_client
+        yield mock_client
+
+
+def test_promote_participant_unauthenticated():
+    """Test promote participant returns 401 when not authenticated."""
+    client = APIClient()
+    room = RoomFactory()
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(url, {"participant_identity": "test-user"}, format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_promote_participant_forbidden_non_owner():
+    """Test promote participant returns 403 when user is admin but not owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    admin = UserFactory()
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # Create admin access for the requesting user
+    UserResourceAccessFactory(resource=room, user=admin, role="administrator")
+
+    client.force_authenticate(user=admin)
+
+    target_user = UserFactory(sub="target-user-sub")
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_promote_participant_forbidden_member():
+    """Test promote participant returns 403 when user is just a member."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    member = UserFactory()
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # Create member access for the requesting user
+    UserResourceAccessFactory(resource=room, user=member, role="member")
+
+    client.force_authenticate(user=member)
+
+    target_user = UserFactory(sub="target-user-sub")
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_promote_participant_success(mock_livekit_client):
+    """Test owner can successfully promote a participant to owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_user = UserFactory(sub="target-user-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["status"] == "success"
+    assert response.data["created"] is True
+
+    # Verify ResourceAccess was created
+    access = ResourceAccess.objects.get(resource=room, user=target_user)
+    assert access.role == RoleChoices.OWNER
+
+    # Verify LiveKit update was called
+    mock_livekit_client.room.update_participant.assert_called_once()
+    # aclose called twice: once for participant update, once for notification
+    assert mock_livekit_client.aclose.call_count == 2
+
+
+def test_promote_participant_already_owner(mock_livekit_client):
+    """Test promoting already-owner is idempotent."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_user = UserFactory(sub="target-user-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # Target is already an owner
+    UserResourceAccessFactory(resource=room, user=target_user, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["status"] == "success"
+    assert response.data["created"] is False  # Not newly created
+
+    # Verify still owner
+    access = ResourceAccess.objects.get(resource=room, user=target_user)
+    assert access.role == RoleChoices.OWNER
+
+
+def test_promote_participant_anonymous_fails():
+    """Test promoting anonymous participant (UUID identity) fails."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    # UUID identity indicates anonymous user
+    anonymous_identity = str(uuid4())
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": anonymous_identity}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Anonymous participants cannot be promoted" in str(response.data)
+
+
+def test_promote_participant_user_not_found():
+    """Test promoting non-existent user fails."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": "non-existent-user-sub"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "No user found" in str(response.data)
+
+
+def test_promote_participant_upgrades_member_to_owner(mock_livekit_client):
+    """Test promoting a member upgrades them to owner."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_user = UserFactory(sub="target-user-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+    # Target is a member
+    UserResourceAccessFactory(resource=room, user=target_user, role="member")
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["status"] == "success"
+    assert response.data["created"] is False  # Updated, not created
+
+    # Verify upgraded to owner
+    access = ResourceAccess.objects.get(resource=room, user=target_user)
+    assert access.role == RoleChoices.OWNER
+
+
+def test_promote_participant_livekit_error_still_succeeds(mock_livekit_client):
+    """Test that database changes persist even if LiveKit update fails."""
+    client = APIClient()
+    room = RoomFactory()
+    owner = UserFactory()
+    target_user = UserFactory(sub="target-user-sub")
+
+    # Create owner access
+    UserResourceAccessFactory(resource=room, user=owner, role="owner")
+
+    # Make LiveKit fail
+    mock_livekit_client.room.update_participant.side_effect = TwirpError(
+        msg="Internal server error", code=500, status=500
+    )
+
+    client.force_authenticate(user=owner)
+
+    url = reverse("rooms-promote-participant", kwargs={"pk": room.id})
+    response = client.post(
+        url, {"participant_identity": target_user.sub}, format="json"
+    )
+
+    # Should still succeed - database update worked
+    assert response.status_code == status.HTTP_200_OK
+
+    # Verify ResourceAccess was created despite LiveKit failure
+    access = ResourceAccess.objects.get(resource=room, user=target_user)
+    assert access.role == RoleChoices.OWNER

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -106,6 +106,8 @@ def generate_token(
     if color is None:
         color = generate_color(identity)
 
+    is_authenticated = not user.is_anonymous
+
     token = (
         AccessToken(
             api_key=settings.LIVEKIT_CONFIGURATION["api_key"],
@@ -115,7 +117,11 @@ def generate_token(
         .with_identity(identity)
         .with_name(username or default_username)
         .with_attributes(
-            {"color": color, "room_admin": "true" if is_admin_or_owner else "false"}
+            {
+                "color": color,
+                "room_admin": "true" if is_admin_or_owner else "false",
+                "authenticated": "true" if is_authenticated else "false",
+            }
         )
     )
 

--- a/src/frontend/src/features/notifications/NotificationType.ts
+++ b/src/frontend/src/features/notifications/NotificationType.ts
@@ -16,4 +16,5 @@ export enum NotificationType {
   ScreenRecordingLimitReached = 'screenRecordingLimitReached',
   RecordingSaving = 'recordingSaving',
   PermissionsRemoved = 'permissionsRemoved',
+  RoleChanged = 'roleChanged',
 }

--- a/src/frontend/src/features/rooms/api/ApiRoom.ts
+++ b/src/frontend/src/features/rooms/api/ApiRoom.ts
@@ -10,15 +10,35 @@ export enum ApiAccessLevel {
   RESTRICTED = 'restricted',
 }
 
+export enum ApiAccessRole {
+  MEMBER = 'member',
+  ADMIN = 'administrator',
+  OWNER = 'owner',
+}
+
+export type ApiResourceAccess = {
+  id: string
+  user: {
+    id: string
+    email: string
+    full_name: string | null
+    short_name: string | null
+  }
+  resource: string
+  role: ApiAccessRole
+}
+
 export type ApiRoom = {
   id: string
   name: string
   slug: string
   pin_code: string
   is_administrable: boolean
+  is_owner: boolean
   access_level: ApiAccessLevel
   livekit?: ApiLiveKit
   configuration?: {
     [key: string]: string | number | boolean | string[]
   }
+  accesses?: ApiResourceAccess[]
 }

--- a/src/frontend/src/features/rooms/api/demoteParticipant.ts
+++ b/src/frontend/src/features/rooms/api/demoteParticipant.ts
@@ -1,0 +1,21 @@
+import { Participant } from 'livekit-client'
+import { useRoomData } from '../livekit/hooks/useRoomData'
+import { fetchApi } from '@/api/fetchApi'
+
+export const useDemoteParticipant = () => {
+  const data = useRoomData()
+
+  const demoteParticipant = async (participant: Participant) => {
+    if (!data?.id) {
+      throw new Error('Room id is not available')
+    }
+
+    return fetchApi(`rooms/${data.id}/demote-participant/`, {
+      method: 'POST',
+      body: JSON.stringify({
+        participant_identity: participant.identity,
+      }),
+    })
+  }
+  return { demoteParticipant }
+}

--- a/src/frontend/src/features/rooms/api/promoteParticipant.ts
+++ b/src/frontend/src/features/rooms/api/promoteParticipant.ts
@@ -1,0 +1,21 @@
+import { Participant } from 'livekit-client'
+import { useRoomData } from '../livekit/hooks/useRoomData'
+import { fetchApi } from '@/api/fetchApi'
+
+export const usePromoteParticipant = () => {
+  const data = useRoomData()
+
+  const promoteParticipant = async (participant: Participant) => {
+    if (!data?.id) {
+      throw new Error('Room id is not available')
+    }
+
+    return fetchApi(`rooms/${data.id}/promote-participant/`, {
+      method: 'POST',
+      body: JSON.stringify({
+        participant_identity: participant.identity,
+      }),
+    })
+  }
+  return { promoteParticipant }
+}

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/MakeOwnerMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/MakeOwnerMenuItem.tsx
@@ -1,0 +1,29 @@
+import { Participant } from 'livekit-client'
+import { menuRecipe } from '@/primitives/menuRecipe'
+import { HStack } from '@/styled-system/jsx'
+import { RiShieldUserLine } from '@remixicon/react'
+import { MenuItem } from 'react-aria-components'
+import { usePromoteParticipant } from '@/features/rooms/api/promoteParticipant'
+import { useTranslation } from 'react-i18next'
+
+export const MakeOwnerMenuItem = ({
+  participant,
+}: {
+  participant: Participant
+}) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'participantMenu.makeOwner' })
+  const { promoteParticipant } = usePromoteParticipant()
+
+  return (
+    <MenuItem
+      aria-label={t('ariaLabel', { name: participant.name })}
+      className={menuRecipe({ icon: true }).item}
+      onAction={() => promoteParticipant(participant)}
+    >
+      <HStack gap={0.25}>
+        <RiShieldUserLine size={20} aria-hidden />
+        {t('label')}
+      </HStack>
+    </MenuItem>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/ParticipantMenu.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/ParticipantMenu.tsx
@@ -1,8 +1,15 @@
 import { Menu as RACMenu } from 'react-aria-components'
 import { Participant } from 'livekit-client'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { useIsOwner } from '@/features/rooms/livekit/hooks/useIsOwner'
+import { useIsParticipantOwner } from '@/features/rooms/livekit/hooks/useIsParticipantOwner'
+import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
+import { getParticipantCanBePromoted } from '@/features/rooms/utils/getParticipantCanBePromoted'
+import { ApiAccessRole } from '@/features/rooms/api/ApiRoom'
 import { PinMenuItem } from './PinMenuItem'
 import { RemoveMenuItem } from './RemoveMenuItem'
+import { MakeOwnerMenuItem } from './MakeOwnerMenuItem'
+import { RemoveOwnerMenuItem } from './RemoveOwnerMenuItem'
 
 export const ParticipantMenu = ({
   participant,
@@ -10,7 +17,25 @@ export const ParticipantMenu = ({
   participant: Participant
 }) => {
   const isAdminOrOwner = useIsAdminOrOwner()
+  const isOwner = useIsOwner()
+  const isParticipantOwner = useIsParticipantOwner(participant)
+  const roomData = useRoomData()
+
   const canModerateParticipant = !participant.isLocal && isAdminOrOwner
+
+  // Check if participant can be promoted: current user must be owner,
+  // participant must be authenticated (not anonymous), and not already an owner
+  const canBePromoted = getParticipantCanBePromoted(participant)
+  const canPromote =
+    !participant.isLocal && isOwner && canBePromoted && !isParticipantOwner
+
+  // Check if participant can be demoted: current user must be owner,
+  // participant must be an owner, and there must be at least 2 owners
+  const ownerCount =
+    roomData?.accesses?.filter((a) => a.role === ApiAccessRole.OWNER).length ?? 0
+  const canDemote =
+    !participant.isLocal && isOwner && isParticipantOwner && ownerCount > 1
+
   return (
     <RACMenu
       style={{
@@ -18,6 +43,8 @@ export const ParticipantMenu = ({
       }}
     >
       <PinMenuItem participant={participant} />
+      {canPromote && <MakeOwnerMenuItem participant={participant} />}
+      {canDemote && <RemoveOwnerMenuItem participant={participant} />}
       {canModerateParticipant && <RemoveMenuItem participant={participant} />}
     </RACMenu>
   )

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/ParticipantMenuButton.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/ParticipantMenuButton.tsx
@@ -12,6 +12,7 @@ export const ParticipantMenuButton = ({
 }) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'participants' })
   const isAdminOrOwner = useIsAdminOrOwner()
+
   if (!isAdminOrOwner) return null
   return (
     <Menu>

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/RemoveOwnerMenuItem.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantMenu/RemoveOwnerMenuItem.tsx
@@ -1,0 +1,29 @@
+import { Participant } from 'livekit-client'
+import { menuRecipe } from '@/primitives/menuRecipe'
+import { HStack } from '@/styled-system/jsx'
+import { RiShieldLine } from '@remixicon/react'
+import { MenuItem } from 'react-aria-components'
+import { useDemoteParticipant } from '@/features/rooms/api/demoteParticipant'
+import { useTranslation } from 'react-i18next'
+
+export const RemoveOwnerMenuItem = ({
+  participant,
+}: {
+  participant: Participant
+}) => {
+  const { t } = useTranslation('rooms', { keyPrefix: 'participantMenu.removeOwner' })
+  const { demoteParticipant } = useDemoteParticipant()
+
+  return (
+    <MenuItem
+      aria-label={t('ariaLabel', { name: participant.name })}
+      className={menuRecipe({ icon: true }).item}
+      onAction={() => demoteParticipant(participant)}
+    >
+      <HStack gap={0.25}>
+        <RiShieldLine size={20} aria-hidden />
+        {t('label')}
+      </HStack>
+    </MenuItem>
+  )
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useIsOwner.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useIsOwner.ts
@@ -1,0 +1,11 @@
+import { useRoomData } from './useRoomData'
+
+/**
+ * Hook to check if the current user is an owner of the room.
+ * Uses the is_owner field from the room API response.
+ * @returns true if the current user is an owner, false otherwise
+ */
+export const useIsOwner = (): boolean => {
+  const apiRoomData = useRoomData()
+  return apiRoomData?.is_owner ?? false
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useIsParticipantOwner.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useIsParticipantOwner.ts
@@ -1,0 +1,12 @@
+import { Participant } from 'livekit-client'
+import { getParticipantIsRoomAdmin } from '@/features/rooms/utils/getParticipantIsRoomAdmin'
+
+/**
+ * Hook to check if a specific participant is an owner/admin of the room.
+ * Uses the room_admin attribute set by the backend on the LiveKit participant.
+ * @param participant The LiveKit participant to check
+ * @returns true if the participant is an owner/admin, false otherwise
+ */
+export const useIsParticipantOwner = (participant: Participant): boolean => {
+  return getParticipantIsRoomAdmin(participant)
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoleChangeNotification.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoleChangeNotification.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect } from 'react'
+import { useRoomContext } from '@livekit/components-react'
+import { RoomEvent } from 'livekit-client'
+import { useParams } from 'wouter'
+import { keys } from '@/api/queryKeys'
+import { queryClient } from '@/api/queryClient'
+import { decodeNotificationDataReceived } from '@/features/notifications/utils'
+import { NotificationType } from '@/features/notifications/NotificationType'
+
+/**
+ * Hook that listens for role change notifications and refetches room data.
+ * This ensures participants see updated permissions when they are promoted/demoted.
+ */
+export const useRoleChangeNotification = () => {
+  const room = useRoomContext()
+  const { roomId } = useParams()
+
+  const handleDataReceived = useCallback(
+    (payload: Uint8Array) => {
+      const notification = decodeNotificationDataReceived(payload)
+      if (notification?.type === NotificationType.RoleChanged) {
+        // Invalidate the room query to trigger a refetch
+        queryClient.invalidateQueries({ queryKey: [keys.room, roomId] })
+      }
+    },
+    [roomId]
+  )
+
+  useEffect(() => {
+    room.on(RoomEvent.DataReceived, handleDataReceived)
+    return () => {
+      room.off(RoomEvent.DataReceived, handleDataReceived)
+    }
+  }, [room, handleDataReceived])
+}

--- a/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/VideoConference.tsx
@@ -37,6 +37,7 @@ import { Subtitles } from '@/features/subtitle/component/Subtitles'
 import { CarouselLayout } from '../components/layout/CarouselLayout'
 import { GridLayout } from '../components/layout/GridLayout'
 import { IsIdleDisconnectModal } from '../components/IsIdleDisconnectModal'
+import { useRoleChangeNotification } from '../hooks/useRoleChangeNotification'
 
 const LayoutWrapper = styled(
   'div',
@@ -93,6 +94,7 @@ export function VideoConference({ ...props }: VideoConferenceProps) {
 
   useConnectionObserver()
   useVideoResolutionSubscription()
+  useRoleChangeNotification()
 
   const tracks = useTracks(
     [

--- a/src/frontend/src/features/rooms/utils/getParticipantCanBePromoted.ts
+++ b/src/frontend/src/features/rooms/utils/getParticipantCanBePromoted.ts
@@ -1,0 +1,13 @@
+import { Participant } from 'livekit-client'
+
+/**
+ * Checks if a participant can be promoted to owner.
+ * Anonymous participants cannot be promoted - only authenticated users can.
+ * @param participant The LiveKit participant to check
+ * @returns true if the participant can be promoted, false otherwise
+ */
+export const getParticipantCanBePromoted = (participant: Participant): boolean => {
+  // Check the 'authenticated' attribute set by the backend
+  // This attribute is 'true' for authenticated users, 'false' for anonymous
+  return participant.attributes?.authenticated === 'true'
+}

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -549,6 +549,14 @@
     "pin": {
       "label": "Pin",
       "ariaLabel": "Pin {{name}}"
+    },
+    "makeOwner": {
+      "label": "Make Owner",
+      "ariaLabel": "Make {{name}} an owner"
+    },
+    "removeOwner": {
+      "label": "Remove Owner",
+      "ariaLabel": "Remove {{name}} as owner"
     }
   },
   "recordingStateToast": {

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -549,6 +549,14 @@
     "pin": {
       "label": "Épingler",
       "ariaLabel": "Épingler {{name}}"
+    },
+    "makeOwner": {
+      "label": "Nommer organisateur",
+      "ariaLabel": "Nommer {{name}} organisateur"
+    },
+    "removeOwner": {
+      "label": "Retirer organisateur",
+      "ariaLabel": "Retirer {{name}} du rôle d'organisateur"
     }
   },
   "recordingStateToast": {


### PR DESCRIPTION
## Purpose

Allow room owners to promote other authenticated participants to owner role (and demote them) directly from the participants panel, without requiring them to leave the meeting.

This enables dynamic delegation of moderation powers during a meeting, which is useful when the original owner needs to leave or wants to share administrative responsibilities.

https://github.com/orgs/suitenumerique/projects/11?pane=issue&itemId=140746470

## Proposal

Add promote/demote functionality accessible via the 3-dot menu on participants:

  - [x] Backend: Add promote_participant and demote_participant endpoints with owner-only permissions
  - [x] Backend: Add is_owner field to room API response to distinguish owners from admins
  - [x] Backend: Add authenticated attribute to LiveKit tokens to identify authenticated vs anonymous users
  - [x] Backend: Send roleChanged notification to trigger real-time UI updates
  - [x] Frontend: Add "Make Owner" and "Remove Owner" menu items in participant menu
  - [x] Frontend: Add hooks to check owner status (useIsOwner, useIsParticipantOwner)
  - [x] Frontend: Listen for role change notifications to refresh permissions without page reload
  - [x] Tests: Add comprehensive test coverage for promote/demote endpoints (19 tests)
  
<img width="386" height="775" alt="Screenshot 2026-01-26 at 09-31-33 LaSuite Meet" src="https://github.com/user-attachments/assets/2f74166d-fc48-40a0-9bdb-b699d758419d" />
