### PR TITLE
🔧(compose) configure LiveKit webhooks in the local Docker Compose stack

### DIFF
--- a/docker/livekit/config/livekit-server.yaml
+++ b/docker/livekit/config/livekit-server.yaml
@@ -3,3 +3,8 @@ redis:
   address: redis:6379
 keys:
   devkey: secret
+
+webhook:
+  api_key: devkey
+  urls:
+      - http://app-dev:8000/api/v1.0/rooms/webhooks-livekit/


### PR DESCRIPTION
Without this configuration, LiveKit does not notify the backend when a recording starts, leaving it stuck in a “starting recording” state.

Thanks to @leobouloc for spotting the issue.