### PR TITLE
♿️(frontend) fix form labels and autocomplete wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) fix form labels and autocomplete wiring #932
+
 ## [1.5.0] - 2026-01-28
 
 ### Changed

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -446,16 +446,14 @@ export const Join = ({
                 type="text"
                 onChange={saveUsername}
                 label={t('usernameLabel')}
-                aria-label={t('usernameLabel')}
+                id="input-name"
                 defaultValue={username}
                 validate={(value) => !value && t('errors.usernameEmpty')}
                 wrapperProps={{
                   noMargin: true,
                   fullWidth: true,
                 }}
-                labelProps={{
-                  center: true,
-                }}
+                autoComplete="name"
                 maxLength={50}
               />
             </VStack>

--- a/src/frontend/src/primitives/Field.tsx
+++ b/src/frontend/src/primitives/Field.tsx
@@ -138,7 +138,9 @@ export const Field = <T extends object>({
   const LabelAndDescription = (
     <>
       <StyledLabel {...props.labelProps}>{label}</StyledLabel>
-      <FieldDescription slot="description">{description}</FieldDescription>
+      {description ? (
+        <FieldDescription slot="description">{description}</FieldDescription>
+      ) : null}
     </>
   )
   const RACFieldErrors = (


### PR DESCRIPTION
## Purpose

Ensure visible label is associated with the
input, reducing redundant ARIA, aligning labels per DSFR guidance, and
preventing empty `aria-describedby` output.

issue : [481](https://github.com/suitenumerique/meet/issues/481)

## Proposal

Update the join form field wiring and the shared Field component so screen
readers announce the correct label and only reference helper text when it
exists.

- [x] Link label and input with a stable `id` and remove `aria-label`
- [x] Add `autocomplete="name"` and keep label left-aligned
- [x] Render `FieldDescription` only when a description is provided