### PR TITLE
🥅(summary) catch unexpected file-related exceptions when handling recording objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - ♿️(frontend) sr pin/unpin announcements with dedicated messages #898
 - ♿(frontend) adjust sr announcements for idle disconnect timer #908
 - ♿️(frontend) add global screen reader announcer#922
+- 🥅(summary) catch file-related exceptions when handling recording #944
 
 ### Fixed
 

--- a/src/summary/summary/core/file_service.py
+++ b/src/summary/summary/core/file_service.py
@@ -8,10 +8,17 @@ from pathlib import Path
 
 import mutagen
 from minio import Minio
+from minio.error import MinioException, S3Error
 
 from summary.core.config import get_settings
 
 settings = get_settings()
+
+
+class FileServiceException(Exception):
+    """Base exception for file service operations."""
+
+    pass
 
 
 class FileService:
@@ -78,6 +85,11 @@ class FileService:
                 self._logger.debug("Recording local file path: %s", local_path)
 
                 return local_path
+
+        except (MinioException, S3Error) as e:
+            raise FileServiceException(
+                "Unexpected error while downloading object."
+            ) from e
 
         finally:
             if response:


### PR DESCRIPTION
Previously, if a recording file was not found in the bucket, the code would crash. This adds proper error handling to avoid unhandled failures.