### PR TITLE
♻️(backend) refactor ApplicationViewSet to use a basic ViewSet

### DIFF
--- a/src/backend/core/external_api/viewsets.py
+++ b/src/backend/core/external_api/viewsets.py
@@ -28,7 +28,7 @@ from . import authentication, permissions, serializers
 logger = getLogger(__name__)
 
 
-class ApplicationViewSet(viewsets.GenericViewSet):
+class ApplicationViewSet(viewsets.ViewSet):
     """API endpoints for application authentication and token generation."""
 
     @decorators.action(


### PR DESCRIPTION
This endpoint only exposes a custom action for token generation and does not rely on serializers or querysets. Using ViewSet is more appropriate here, as it provides routing without enforcing standard CRUD patterns or requiring a serializer_class.

This removes unnecessary constraints and avoids warnings related to missing serializer configuration, while better reflecting the actual responsibility of this view.

I noticed this bug from Sentry issue [241308](https://sentry.incubateur.net/organizations/betagouv/issues/241308/?alert_rule_id=176&alert_timestamp=1769595122485&alert_type=email&environment=sandbox&notification_uuid=10bdc759-d8a8-44cf-96b6-974443fe8f46&project=202&referrer=alert_email)

