### PR TITLE
add arm64 Docker image support

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -25,6 +25,12 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -48,11 +54,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           target: backend-production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-frontend-generic:
     runs-on: ubuntu-latest
@@ -60,6 +69,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -85,11 +100,14 @@ jobs:
         with:
           context: .
           file: ./src/frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: frontend-production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-frontend-dinum:
     runs-on: ubuntu-latest
@@ -97,6 +115,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -122,11 +146,14 @@ jobs:
         with:
           context: .
           file: ./docker/dinum-frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: frontend-production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-summary:
     runs-on: ubuntu-latest
@@ -134,6 +161,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -161,11 +194,14 @@ jobs:
         with:
           context: ./src/summary
           file: ./src/summary/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-and-push-agents:
     runs-on: ubuntu-latest
@@ -173,6 +209,12 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       -
         name: Docker meta
         id: meta
@@ -200,11 +242,14 @@ jobs:
         with:
           context: ./src/agents
           file: ./src/agents/Dockerfile
+          platforms: linux/amd64,linux/arm64
           target: production
           build-args: DOCKER_USER=${{ env.DOCKER_USER }}:-1000
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   notify-argocd:
     needs:


### PR DESCRIPTION
## Purpose

This PR adds multi-architecture (`amd64` and `arm64`) support to the following Docker images:

- `lasuite/meet-backend`
- `lasuite/meet-frontend`
- `lasuite/meet-frontend-dinum`
- `lasuite/meet-summary`
- `lasuite/meet-agents`

## Changes

- Added QEMU setup for cross-platform emulation
- Added Docker Buildx configuration for multi-platform builds
- Configured all build jobs to produce both `linux/amd64` and `linux/arm64` images
- Enabled GitHub Actions cache to optimize build performance