### PR TITLE
🌐(frontend) add missing DE translation for accessibility settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - 🥅(summary) catch file-related exceptions when handling recording #944
 - 📝(frontend) update legal terms #956
 - ⚡️(backend) enhance django admin's loading performance #954
+- 🌐(frontend) add missing DE translation for accessibility settings
 
 ## [1.5.0] - 2026-01-28
 

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -108,12 +108,18 @@
     "label": "Sprache"
   },
   "settingsButtonLabel": "Einstellungen",
+  "accessibility": {
+    "announceReactions": {
+      "label": "Reaktionen vorlesen"
+    }
+  },
   "tabs": {
     "account": "Profil",
     "audio": "Audio",
     "video": "Video",
     "general": "Allgemein",
     "notifications": "Benachrichtigungen",
+    "accessibility": "Barrierefreiheit",
     "transcription": "Transkription"
   }
 }


### PR DESCRIPTION
## Purpose

Add missing German translation strings for accessibility settings in the frontend.
