### PR TITLE
🐛(frontend) allow mic test while muted in audio settings

### DIFF
--- a/src/frontend/src/features/rooms/livekit/hooks/useLocalAudioLevel.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useLocalAudioLevel.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Monitors audio level from a specific input device using the Web Audio API.
+ * Unlike LiveKit's useIsSpeaking (which requires a published track),
+ * this hook captures audio directly from getUserMedia, so it works
+ * even when the microphone track is muted/unpublished.
+ */
+export const useLocalAudioLevel = (
+  deviceId: string | undefined
+): boolean => {
+  const [isSpeaking, setIsSpeaking] = useState(false)
+
+  useEffect(() => {
+    if (!deviceId) return
+
+    let audioContext: AudioContext | undefined
+    let analyser: AnalyserNode | undefined
+    let stream: MediaStream | undefined
+    let animationFrameId: number | undefined
+    let cancelled = false
+
+    const start = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { deviceId },
+        })
+      } catch {
+        return
+      }
+
+      if (cancelled) {
+        stream.getTracks().forEach((t) => t.stop())
+        return
+      }
+
+      try {
+        audioContext = new AudioContext()
+        const source = audioContext.createMediaStreamSource(stream)
+        analyser = audioContext.createAnalyser()
+        analyser.fftSize = 256
+        source.connect(analyser)
+      } catch {
+        stream.getTracks().forEach((t) => t.stop())
+        return
+      }
+
+      const dataArray = new Uint8Array(analyser.fftSize)
+
+      const poll = () => {
+        if (cancelled) return
+
+        analyser!.getByteTimeDomainData(dataArray)
+
+        // Compute RMS volume from time-domain data (values centered at 128)
+        let sum = 0
+        for (let i = 0; i < dataArray.length; i++) {
+          const normalized = (dataArray[i] - 128) / 128
+          sum += normalized * normalized
+        }
+        const rms = Math.sqrt(sum / dataArray.length)
+
+        setIsSpeaking(rms > 0.01)
+
+        animationFrameId = requestAnimationFrame(poll)
+      }
+
+      poll()
+    }
+
+    start()
+
+    return () => {
+      cancelled = true
+      if (animationFrameId != null) {
+        cancelAnimationFrame(animationFrameId)
+      }
+      stream?.getTracks().forEach((t) => t.stop())
+      void audioContext?.close()
+    }
+  }, [deviceId])
+
+  return isSpeaking
+}

--- a/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AudioTab.tsx
@@ -1,15 +1,12 @@
 import { DialogProps, Field, Switch, Text } from '@/primitives'
 
 import { TabPanel, TabPanelProps } from '@/primitives/Tabs'
-import {
-  useIsSpeaking,
-  useMediaDeviceSelect,
-  useRoomContext,
-} from '@livekit/components-react'
+import { useMediaDeviceSelect } from '@livekit/components-react'
 import { isSafari } from '@/utils/livekit'
 import { useTranslation } from 'react-i18next'
 import { SoundTester } from '@/components/SoundTester'
 import { ActiveSpeaker } from '@/features/rooms/components/ActiveSpeaker'
+import { useLocalAudioLevel } from '@/features/rooms/livekit/hooks/useLocalAudioLevel'
 import { usePersistentUserChoices } from '@/features/rooms/livekit/hooks/usePersistentUserChoices'
 import { useNoiseReductionAvailable } from '@/features/rooms/livekit/hooks/useNoiseReductionAvailable'
 import posthog from 'posthog-js'
@@ -22,7 +19,6 @@ type DeviceItems = Array<{ value: string; label: string }>
 
 export const AudioTab = ({ id }: AudioTabProps) => {
   const { t } = useTranslation('settings')
-  const { localParticipant } = useRoomContext()
 
   const {
     userChoices: { noiseReductionEnabled, audioDeviceId, audioOutputDeviceId },
@@ -31,7 +27,7 @@ export const AudioTab = ({ id }: AudioTabProps) => {
     saveAudioOutputDeviceId,
   } = usePersistentUserChoices()
 
-  const isSpeaking = useIsSpeaking(localParticipant)
+  const isLocalSpeaking = useLocalAudioLevel(audioDeviceId)
 
   const { devices: devicesOut, setActiveMediaDevice: setActiveMediaDeviceOut } =
     useMediaDeviceSelect({ kind: 'audiooutput' })
@@ -81,13 +77,7 @@ export const AudioTab = ({ id }: AudioTabProps) => {
             width: '100%',
           }}
         />
-        <>
-          {localParticipant.isMicrophoneEnabled ? (
-            <ActiveSpeaker isSpeaking={isSpeaking} />
-          ) : (
-            <span>{t('audio.microphone.disabled')}</span>
-          )}
-        </>
+        <ActiveSpeaker isSpeaking={isLocalSpeaking} />
       </RowWrapper>
       {/* Safari has a known limitation where its implementation of 'enumerateDevices' does not include audio output devices.
         To prevent errors or an empty selection list, we only render the speakers selection field on non-Safari browsers. */}


### PR DESCRIPTION
## Summary

Fixes #804

When a user is muted in a call, the mic test indicator in **Settings > Audio** showed "Microphone disabled" instead of the `ActiveSpeaker` animation. This made it impossible to verify the mic works without unmuting to the call.

**Root cause:** `AudioTab.tsx` used LiveKit's `useIsSpeaking` hook, which relies on the SFU detecting audio from a *published* track. When muted, the track isn't published, so there's nothing to detect.

**Fix:**
- Added a `useLocalAudioLevel` hook that uses the Web Audio API (`getUserMedia` + `AnalyserNode`) to monitor the selected input device directly, independent of LiveKit's publish state
- Replaced the conditional muted/unmuted rendering in `AudioTab` — the `ActiveSpeaker` indicator now always shows and responds to audio input regardless of mute state


https://github.com/user-attachments/assets/b9c6d72b-236d-4c69-94e8-300089920155



## Test plan

- [x] Join a room and mute your microphone
- [x] Open Settings > Audio tab
- [x] Speak into mic — ActiveSpeaker dots should animate even while muted
- [x] Switch mic input device in the dropdown — indicator should respond to the new device
- [x] Unmute — indicator should still work correctly
- [x] Close settings dialog — verify no lingering mic access (browser tab mic icon should disappear)