### PR TITLE
🔒️(backend) add application validation when consuming external API JWT tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 ### Fixed
 
 - 🔐(backend) enforce object-level permission checks on room endpoint #959
+- 🔒️(backend) add application validation when consuming external JWT #963
 
 ## [1.5.0] - 2026-01-28
 


### PR DESCRIPTION
Token generation already verifies that the application is active, but this guarantee was not enforced when the token was used. This change adds a runtime check to ensure the client_id claim matches an existing and active application when evaluating permissions.

This also introduces an emergency revocation mechanism, allowing all previously issued tokens for a given application to be invalidated if the application is disabled.