### PR TITLE
✨(frontend) add clickable settings general link in idle modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ✨(frontend) add clickable settings general link in idle modal #974
+
 ## [1.6.0] - 2026-02-10
 
 ### Added

--- a/src/frontend/src/features/rooms/livekit/components/IsIdleDisconnectModal.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/IsIdleDisconnectModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, H, P, ScreenReaderAnnouncer } from '@/primitives'
+import { A, Button, Dialog, H, P, ScreenReaderAnnouncer } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import { css } from '@/styled-system/css'
 import { useSnapshot } from 'valtio'
@@ -9,6 +9,8 @@ import { navigateTo } from '@/navigation/navigateTo'
 import humanizeDuration from 'humanize-duration'
 import i18n from 'i18next'
 import { useScreenReaderAnnounce } from '@/hooks/useScreenReaderAnnounce'
+import { useSettingsDialog } from '@/features/settings/hook/useSettingsDialog'
+import { SettingsDialogExtendedKey } from '@/features/settings/type'
 
 const IDLE_DISCONNECT_TIMEOUT_MS = 120000 // 2 minutes
 const COUNTDOWN_ANNOUNCEMENT_SECONDS = [90, 60, 30]
@@ -18,6 +20,7 @@ export const IsIdleDisconnectModal = () => {
   const connectionObserverSnap = useSnapshot(connectionObserverStore)
   const [timeRemaining, setTimeRemaining] = useState(IDLE_DISCONNECT_TIMEOUT_MS)
   const lastAnnouncementRef = useRef<number | null>(null)
+  const { openSettingsDialog } = useSettingsDialog()
 
   const { t } = useTranslation('rooms', { keyPrefix: 'isIdleDisconnectModal' })
   const announce = useScreenReaderAnnounce()
@@ -117,7 +120,19 @@ export const IsIdleDisconnectModal = () => {
                 }),
               })}
             </P>
-            <P>{t('settings')}</P>
+            <P>
+              {t('settingsPrefix')}{' '}
+              <A
+                color="primary"
+                onPress={() => {
+                  connectionObserverStore.isIdleDisconnectModalOpen = false
+                  openSettingsDialog(SettingsDialogExtendedKey.GENERAL)
+                }}
+              >
+                {t('settingsLink')}
+              </A>
+              {t('settingsSuffix')}
+            </P>
             <HStack marginTop="2rem">
               <Button
                 onPress={() => {

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -154,7 +154,9 @@
   "isIdleDisconnectModal": {
     "title": "Bist du noch da?",
     "body": "Du bist der einzige Teilnehmer. Dieses Gespräch endet in {{duration}}. Möchtest du das Gespräch fortsetzen?",
-    "settings": "Um diese Nachricht nicht mehr zu sehen, gehe zu Einstellungen > Allgemein.",
+    "settingsPrefix": "Um diese Nachricht nicht mehr zu sehen, gehe zu",
+    "settingsLink": "Einstellungen > Allgemein",
+    "settingsSuffix": ".",
     "stayButton": "Gespräch fortsetzen",
     "leaveButton": "Jetzt verlassen",
     "countdownAnnouncement": "Das Gespräch endet in {{duration}}."

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -154,7 +154,9 @@
   "isIdleDisconnectModal": {
     "title": "Are you still there?",
     "body": "You are the only participant. This call will end in {{duration}}. Would you like to continue the call?",
-    "settings": "To stop seeing this message, go to Settings > General.",
+    "settingsPrefix": "To stop seeing this message, go to",
+    "settingsLink": "Settings > General",
+    "settingsSuffix": ".",
     "stayButton": "Continue the call",
     "leaveButton": "Leave now",
     "countdownAnnouncement": "Call ends in {{duration}}."

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -154,7 +154,9 @@
   "isIdleDisconnectModal": {
     "title": "Êtes-vous toujours là ?",
     "body": "Vous êtes le seul participant. Cet appel va donc se terminer dans {{duration}}. Voulez-vous poursuivre l'appel ?",
-    "settings": "Pour ne plus voir ce message, accèder à Paramètres > Général.",
+    "settingsPrefix": "Pour ne plus voir ce message, allez dans",
+    "settingsLink": "Paramètres > Général",
+    "settingsSuffix": ".",
     "stayButton": "Poursuivre l'appel",
     "leaveButton": "Quitter maintenant",
     "countdownAnnouncement": "L'appel se termine dans {{duration}}."

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -154,7 +154,9 @@
   "isIdleDisconnectModal": {
     "title": "Ben je er nog?",
     "body": "Je bent de enige deelnemer. Dit gesprek wordt over {{duration}} beëindigd. Wil je het gesprek voortzetten?",
-    "settings": "Om dit bericht niet meer te zien, ga naar Instellingen > Algemeen.",
+    "settingsPrefix": "Om dit bericht niet meer te zien, ga naar",
+    "settingsLink": "Instellingen > Algemeen",
+    "settingsSuffix": ".",
     "stayButton": "Gesprek voortzetten",
     "leaveButton": "Nu verlaten",
     "countdownAnnouncement": "Het gesprek eindigt over {{duration}}."


### PR DESCRIPTION
## Purpose

Improve accessibility and keyboard continuity when settings are opened
from the idle disconnect modal.

https://github.com/user-attachments/assets/dc7af109-b8b4-4f18-aaee-8cbaeb767b96

## Proposal

- [x] capture active element before opening `Settings > General`
- [x] restore focus on settings close, fallback to a control-bar target
