### PR TITLE
✨(frontend) expose Windows app web link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(frontend) expose Windows app web link #976
+
 ### Changed
 
 - ✨(frontend) add clickable settings general link in idle modal #974

--- a/src/frontend/default.conf
+++ b/src/frontend/default.conf
@@ -5,6 +5,12 @@ server {
 
   root /usr/share/nginx/html;
 
+  location = /.wellknown/windows-app-web-link {
+      default_type application/json;
+      alias /usr/share/nginx/html/.wellknown/windows-app-web-link;
+      add_header Content-Disposition "attachment; filename=windows-app-web-link";
+  }
+
   # Serve static files with caching
   location ~* ^/assets/.*\.(css|js|json|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;

--- a/src/frontend/public/.wellknown/windows-app-web-link
+++ b/src/frontend/public/.wellknown/windows-app-web-link
@@ -1,0 +1,6 @@
+[
+{
+  "packageFamilyName" : "Visio_g3z6ba6vek6vg",
+  "paths" : [ "*" ]
+}
+]


### PR DESCRIPTION
Expose a Windows application web link requested by a partner who wraps Visio inside a containerized Chrome application due to security concerns and limited trust in video codecs.

This commit introduces a proof of concept implementation. We plan to iterate on this approach and likely generalize it under a more neutral lasuite meet naming in future revisions.
