### PR TITLE
🐛(frontend) configure missing participants shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(frontend) expose Windows app web link #976
+- ✨(frontend) support additional shortcuts to broaden accessibility
 
 ### Changed
 

--- a/src/frontend/src/features/rooms/livekit/components/controls/Participants/ParticipantsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Participants/ParticipantsToggle.tsx
@@ -6,6 +6,7 @@ import { css } from '@/styled-system/css'
 import { useParticipants } from '@livekit/components-react'
 import { useSidePanel } from '../../../hooks/useSidePanel'
 import { ToggleButtonProps } from '@/primitives/ToggleButton'
+import { useRegisterKeyboardShortcut } from '@/features/shortcuts/useRegisterKeyboardShortcut'
 
 export const ParticipantsToggle = ({
   onPress,
@@ -26,6 +27,11 @@ export const ParticipantsToggle = ({
   const { isParticipantsOpen, toggleParticipants } = useSidePanel()
 
   const tooltipLabel = isParticipantsOpen ? 'open' : 'closed'
+
+  useRegisterKeyboardShortcut({
+    id: 'toggle-participants',
+    handler: toggleParticipants,
+  })
 
   return (
     <div


### PR DESCRIPTION
Configure the missing shortcut in the frontend for the participant side panel.
It was accidentally omitted while merging Cyril's changes.
