### PR TITLE
✨(summary) add localization support for transcription context text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - 👷(docker) add arm64 platform support for image builds
+- ✨(summary) add localization support for transcription context text
 
 ### Changed
 

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -2,6 +2,7 @@
 Gitlint extra rule to validate that the message title is of the form
 "<gitmoji>(<scope>) <subject>"
 """
+
 from __future__ import unicode_literals
 
 import re

--- a/src/backend/core/recording/event/notification.py
+++ b/src/backend/core/recording/event/notification.py
@@ -167,6 +167,7 @@ class NotificationService:
                 owner_access.user.timezone
             ).strftime("%H:%M"),
             "download_link": f"{get_recording_download_base_url()}/{recording.id}",
+            "context_language": owner_access.user.language,
         }
 
         headers = {

--- a/src/summary/summary/api/route/tasks.py
+++ b/src/summary/summary/api/route/tasks.py
@@ -15,8 +15,8 @@ from summary.core.config import get_settings
 settings = get_settings()
 
 
-class TaskCreation(BaseModel):
-    """Task data."""
+class TranscribeSummarizeTaskCreation(BaseModel):
+    """Transcription and summarization parameters."""
 
     owner_id: str
     filename: str
@@ -28,6 +28,7 @@ class TaskCreation(BaseModel):
     recording_time: Optional[str]
     language: Optional[str]
     download_link: Optional[str]
+    context_language: Optional[str] = None
 
     @field_validator("language")
     @classmethod
@@ -45,8 +46,8 @@ router = APIRouter(prefix="/tasks")
 
 
 @router.post("/")
-async def create_task(request: TaskCreation):
-    """Create a task."""
+async def create_transcribe_summarize_task(request: TranscribeSummarizeTaskCreation):
+    """Create a transcription and summarization task."""
     task = process_audio_transcribe_summarize_v2.apply_async(
         args=[
             request.owner_id,
@@ -59,6 +60,7 @@ async def create_task(request: TaskCreation):
             request.recording_time,
             request.language,
             request.download_link,
+            request.context_language,
         ],
         queue=settings.transcribe_queue,
     )

--- a/src/summary/summary/core/config.py
+++ b/src/summary/summary/core/config.py
@@ -1,7 +1,7 @@
 """Application configuration and settings."""
 
 from functools import lru_cache
-from typing import Annotated, List, Optional, Set
+from typing import Annotated, List, Literal, Optional, Set
 
 from fastapi import Depends
 from pydantic import SecretStr
@@ -51,7 +51,6 @@ class Settings(BaseSettings):
 
     # Transcription processing
     hallucination_patterns: List[str] = ["Vap'n'Roll Thierry"]
-    hallucination_replacement_text: str = "[Texte impossible à transcrire]"
 
     # Webhook-related settings
     webhook_max_retries: int = 2
@@ -60,11 +59,10 @@ class Settings(BaseSettings):
     webhook_api_token: SecretStr
     webhook_url: str
 
+    # Locale
+    default_context_language: Literal["de", "en", "fr", "nl"] = "fr"
+
     # Output related settings
-    document_default_title: Optional[str] = "Transcription"
-    document_title_template: Optional[str] = (
-        'Réunion "{room}" du {room_recording_date} à {room_recording_time}'
-    )
     summary_title_template: Optional[str] = "Résumé de {title}"
 
     # Summary related settings

--- a/src/summary/summary/core/locales/__init__.py
+++ b/src/summary/summary/core/locales/__init__.py
@@ -1,0 +1,30 @@
+"""Locale support for the summary service."""
+
+from typing import Optional
+
+from summary.core.config import get_settings
+from summary.core.locales import de, en, fr, nl
+from summary.core.locales.strings import LocaleStrings
+
+_LOCALES = {"fr": fr, "en": en, "de": de, "nl": nl}
+
+
+def get_locale(*languages: Optional[str]) -> LocaleStrings:
+    """Return locale strings for the first matching language candidate.
+
+    Accept language codes in decreasing priority order and return the
+    locale for the first one that matches a known locale.
+    Fall back to the configured default_context_language.
+    """
+    for lang in languages:
+        if not lang:
+            continue
+        if lang in _LOCALES:
+            return _LOCALES[lang].STRINGS
+
+        # Provide fallback for longer formats of ISO 639-1 (e.g. "en-au" -> "en")
+        base_lang = lang.split("-")[0]
+        if base_lang in _LOCALES:
+            return _LOCALES[base_lang].STRINGS
+
+    return _LOCALES[get_settings().default_context_language].STRINGS

--- a/src/summary/summary/core/locales/de.py
+++ b/src/summary/summary/core/locales/de.py
@@ -1,0 +1,34 @@
+"""German locale strings."""
+
+from summary.core.locales.strings import LocaleStrings
+
+STRINGS = LocaleStrings(
+    empty_transcription="""
+**In Ihrer Transkription wurde kein Audioinhalt erkannt.**
+
+*Wenn Sie glauben, dass es sich um einen Fehler handelt, zögern Sie nicht,
+unseren technischen Support zu kontaktieren: visio@numerique.gouv.fr*
+
+.
+
+.
+
+.
+
+Einige Punkte, die wir Ihnen empfehlen zu überprüfen:
+- War ein Mikrofon aktiviert?
+- Waren Sie nah genug am Mikrofon?
+- Ist das Mikrofon von guter Qualität?
+- Dauert die Aufnahme länger als 30 Sekunden?
+
+""",
+    download_header_template=(
+        "\n*Laden Sie Ihre Aufnahme herunter, "
+        "indem Sie [diesem Link folgen]({download_link})*\n"
+    ),
+    hallucination_replacement_text="[Text konnte nicht transkribiert werden]",
+    document_default_title="Transkription",
+    document_title_template=(
+        'Besprechung "{room}" am {room_recording_date} um {room_recording_time}'
+    ),
+)

--- a/src/summary/summary/core/locales/en.py
+++ b/src/summary/summary/core/locales/en.py
@@ -1,0 +1,33 @@
+"""English locale strings."""
+
+from summary.core.locales.strings import LocaleStrings
+
+STRINGS = LocaleStrings(
+    empty_transcription="""
+**No audio content was detected in your transcription.**
+
+*If you believe this is an error, please do not hesitate to contact
+our technical support: visio@numerique.gouv.fr*
+
+.
+
+.
+
+.
+
+A few things we recommend you check:
+- Was a microphone enabled?
+- Were you close enough to the microphone?
+- Is the microphone of good quality?
+- Is the recording longer than 30 seconds?
+
+""",
+    download_header_template=(
+        "\n*Download your recording by [following this link]({download_link})*\n"
+    ),
+    hallucination_replacement_text="[Unable to transcribe text]",
+    document_default_title="Transcription",
+    document_title_template=(
+        'Meeting "{room}" on {room_recording_date} at {room_recording_time}'
+    ),
+)

--- a/src/summary/summary/core/locales/fr.py
+++ b/src/summary/summary/core/locales/fr.py
@@ -1,0 +1,33 @@
+"""French locale strings (default)."""
+
+from summary.core.locales.strings import LocaleStrings
+
+STRINGS = LocaleStrings(
+    empty_transcription="""
+**Aucun contenu audio n'a été détecté dans votre transcription.**
+
+*Si vous pensez qu'il s'agit d'une erreur, n'hésitez pas à contacter
+notre support technique : visio@numerique.gouv.fr*
+
+.
+
+.
+
+.
+
+Quelques points que nous vous conseillons de vérifier :
+- Un micro était-il activé ?
+- Étiez-vous suffisamment proche ?
+- Le micro est-il de bonne qualité ?
+- L'enregistrement dure-t-il plus de 30 secondes ?
+
+""",
+    download_header_template=(
+        "\n*Télécharger votre enregistrement en [suivant ce lien]({download_link})*\n"
+    ),
+    hallucination_replacement_text="[Texte impossible à transcrire]",
+    document_default_title="Transcription",
+    document_title_template=(
+        'Réunion "{room}" du {room_recording_date} à {room_recording_time}'
+    ),
+)

--- a/src/summary/summary/core/locales/nl.py
+++ b/src/summary/summary/core/locales/nl.py
@@ -1,0 +1,33 @@
+"""Dutch locale strings."""
+
+from summary.core.locales.strings import LocaleStrings
+
+STRINGS = LocaleStrings(
+    empty_transcription="""
+**Er is geen audio-inhoud gedetecteerd in uw transcriptie.**
+
+*Als u denkt dat dit een fout is, aarzel dan niet om contact op te nemen
+met onze technische ondersteuning: visio@numerique.gouv.fr*
+
+.
+
+.
+
+.
+
+Een paar punten die wij u aanraden te controleren:
+- Was er een microfoon ingeschakeld?
+- Was u dicht genoeg bij de microfoon?
+- Is de microfoon van goede kwaliteit?
+- Duurt de opname langer dan 30 seconden?
+
+""",
+    download_header_template=(
+        "\n*Download uw opname door [deze link te volgen]({download_link})*\n"
+    ),
+    hallucination_replacement_text="[Tekst kon niet worden getranscribeerd]",
+    document_default_title="Transcriptie",
+    document_title_template=(
+        'Vergadering "{room}" op {room_recording_date} om {room_recording_time}'
+    ),
+)

--- a/src/summary/summary/core/locales/strings.py
+++ b/src/summary/summary/core/locales/strings.py
@@ -1,0 +1,15 @@
+"""Locale types for the summary service."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LocaleStrings:
+    """All translatable output strings for the summary pipeline."""
+
+    # transcript_formatter.py
+    empty_transcription: str
+    download_header_template: str
+    hallucination_replacement_text: str
+    document_default_title: str
+    document_title_template: str


### PR DESCRIPTION
## Purpose

Currently, transcription/summarization results use French structure text ("Réunion du..."), independently of user preference and/or meeting language. This PR aims to provide localization for this microservice.

## Proposal

- Add new parameter `context_language` to summary endpoint 
- Select context language by order of priority: `context_language` parameter > `language` parameter (language of meeting specified by user) > `default_context_language`
- If language is not supported, fallback to default
- Given the small number of strings to translate, it seems acceptable to stay within python, and not introduce additional dependencies (poedit, etc.).

## TODO:
- [x] Test run
