### PR TITLE
♻️(frontend) replace custom reactions toolbar with react aria popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♻️(frontend) replace custom reactions toolbar with react aria popover #985
+
 ## [1.8.0] - 2026-02-20
 
 ### Changed


### PR DESCRIPTION
## Purpose

Use react aria primitives for escape, focus containment and restore
Replace custom animation and focus code in the reactions toolbar with React Aria primitives.

## Proposal

- [x] Use `DialogTrigger` + `Popover` + `Dialog` for escape-to-close and positioning
- [x] Use `FocusScope contain` to keep Tab within emoji buttons
- [x] Use `shouldCloseOnInteractOutside={() => false}` to keep toolbar open on outside click