### PR TITLE
♻️(frontend) Use React Aria FocusScope for side panel accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♻️(frontend) Use React Aria FocusScope for side panel accessibility
+
 ## [1.7.0] - 2026-02-19
 
 ### Added

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -14,7 +14,6 @@ import { Admin } from './Admin'
 import { Tools } from './Tools'
 import { Info } from './Info'
 import { HStack } from '@/styled-system/jsx'
-import { FocusScope } from '@react-aria/focus'
 
 const SIDE_PANEL_HEADING_ID = 'side-panel-heading'
 const SIDE_PANEL_CLOSE_ID = 'side-panel-close'
@@ -73,8 +72,7 @@ const StyledSidePanel = ({
       transform: isClosed ? 'translateX(calc(360px + 1.5rem))' : 'none',
     }}
   >
-    <FocusScope contain={!isClosed}>
-      <HStack alignItems="center">
+    <HStack alignItems="center">
         {isSubmenu && (
           <Button
             variant="secondaryText"
@@ -124,7 +122,6 @@ const StyledSidePanel = ({
         </Button>
       </Div>
       {children}
-    </FocusScope>
   </aside>
 )
 
@@ -164,10 +161,8 @@ export const SidePanel = () => {
 
   const triggerRef = useRef<HTMLElement | null>(null)
 
-  //  FocusScope handles Tab containment, but autoFocus/restoreFocus rely on mount/unmount
-  //  lifecycle,  which never happens here because the aside stays mounted (CSS slide + keepAlive).
-  //  This effect manually captures the trigger on open and auto-focuses the close button.
-  //  Restore focus is handled in handleClose with a double RAF to let FocusScope release containment.
+  // The aside stays mounted (CSS slide + keepAlive), so we manually handle
+  // auto-focus on open and restore focus on close (via handleClose).
  
   useEffect(() => {
     if (!isSidePanelOpen) return

--- a/src/frontend/src/features/rooms/livekit/components/Tools.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/Tools.tsx
@@ -4,7 +4,6 @@ import { Button as RACButton } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
 import { ReactNode } from 'react'
 import { SubPanelId, useSidePanel } from '../hooks/useSidePanel'
-import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 import {
   useIsRecordingModeEnabled,
   RecordingMode,
@@ -95,25 +94,9 @@ const ToolButton = ({
 
 export const Tools = () => {
   const { data } = useConfig()
-  const { openTranscript, openScreenRecording, activeSubPanelId, isToolsOpen } =
+  const { openTranscript, openScreenRecording, activeSubPanelId } =
     useSidePanel()
   const { t } = useTranslation('rooms', { keyPrefix: 'moreTools' })
-
-  // Restore focus to the element that opened the Tools panel
-  // following the same pattern as Chat.
-  useRestoreFocus(isToolsOpen, {
-    // If the active element is a MenuItem (DIV) that will be unmounted when the menu closes,
-    // find the "more options" button ("Plus d'options") that opened the menu
-    resolveTrigger: (activeEl) => {
-      if (activeEl?.tagName === 'DIV') {
-        return document.querySelector<HTMLElement>('#room-options-trigger')
-      }
-      // For direct button clicks (e.g. "Plus d'outils"), use the active element as is
-      return activeEl
-    },
-    restoreFocusRaf: true,
-    preventScroll: true,
-  })
 
   const isTranscriptEnabled = useIsRecordingModeEnabled(
     RecordingMode.Transcript

--- a/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/chat/Input.tsx
@@ -80,10 +80,12 @@ export const ChatInput = ({
       <TextArea
         ref={inputRef}
         onKeyDown={(e) => {
-          e.stopPropagation()
+          if (e.key !== 'Escape') e.stopPropagation()
           submitOnEnter(e)
         }}
-        onKeyUp={(e) => e.stopPropagation()}
+        onKeyUp={(e) => {
+          if (e.key !== 'Escape') e.stopPropagation()
+        }}
         placeholder={t('textArea.placeholder')}
         value={text}
         onChange={(e) => {

--- a/src/frontend/src/features/rooms/livekit/prefabs/Chat.tsx
+++ b/src/frontend/src/features/rooms/livekit/prefabs/Chat.tsx
@@ -15,7 +15,6 @@ import { ChatEntry } from '../components/chat/Entry'
 import { useSidePanel } from '../hooks/useSidePanel'
 import { LocalParticipant, RemoteParticipant, RoomEvent } from 'livekit-client'
 import { css } from '@/styled-system/css'
-import { useRestoreFocus } from '@/hooks/useRestoreFocus'
 
 export interface ChatProps
   extends React.HTMLAttributes<HTMLDivElement>, ChatOptions {}
@@ -36,18 +35,12 @@ export function Chat({ ...props }: ChatProps) {
   const { isChatOpen } = useSidePanel()
   const chatSnap = useSnapshot(chatStore)
 
-  // Keep track of the element that opened the chat so we can restore focus
-  // when the chat panel is closed.
-  useRestoreFocus(isChatOpen, {
-    // Avoid layout "jump" during the side panel slide-in animation.
-    // Focusing can trigger scroll into view; preventScroll keeps the animation smooth.
-    onOpened: () => {
-      requestAnimationFrame(() => {
-        inputRef.current?.focus({ preventScroll: true })
-      })
-    },
-    preventScroll: true,
-  })
+  React.useEffect(() => {
+    if (!isChatOpen) return
+    requestAnimationFrame(() => {
+      inputRef.current?.focus({ preventScroll: true })
+    })
+  }, [isChatOpen])
 
   // Use useParticipants hook to trigger a re-render when the participant list changes.
   const participants = useParticipants()


### PR DESCRIPTION
## Purpose

Replace custom focus hooks with React Aria primitives for side panel accessibility.

## Proposal

- [x] Add `role="dialog"`, `aria-labelledby`, `aria-hidden` and Escape to close
- [x] Add `FocusScope contain` for Tab containment and focus restore on close
- [x] Centralize focus management in `SidePanel`, remove `useRestoreFocus` from `Chat` and `Tools`
- [x] Allow Escape key to propagate from ChatInput to close the side panel