### PR TITLE
feat: allow users to upload custom background images

### DIFF
--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -268,6 +268,8 @@
     "virtual": {
       "title": "Virtual background",
       "selectedLabel": "Background applied:",
+      "customLabel": "Select your background",
+      "customBackgroundTooLarge": "Selected file is too large. Maximum allowed size is {{maxSize}}MB.",
       "apply": "Replace your background:",
       "descriptions": {
         "0": "Fluted wooden furniture",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -268,6 +268,8 @@
     "virtual": {
       "title": "Arrière-plan virtuel",
       "selectedLabel": "Arrière-plan appliqué :",
+      "customLabel": "Sélectionner votre arrière-plan",
+      "customBackgroundTooLarge": "Le fichier sélectionné est trop volumineux. La taille maximale autorisée est de {{maxSize}} Mo.",
       "apply": "Remplacer votre arrière plan :",
       "descriptions": {
         "0": "Meuble cannelé en bois",


### PR DESCRIPTION
## Description

Implements the feature requested in #924.

Users can now upload a custom background image from their local machine directly in the **Effects** panel.

## Changes

### `EffectsConfiguration.tsx`
- Hidden `<input type="file">` + upload handler that triggers on the new button
- Object URL created via `URL.createObjectURL()` and applied as virtual background
- URL stored in a `ref` and revoked on component unmount to prevent memory leaks
- 10 MB file size validation before creating the object URL

### Locales (`en/rooms.json`, `fr/rooms.json`)
- Added `customLabel` translation key for the new button tooltip / aria-label

## How to test

1. Join a room with camera enabled
2. Open **Effects** panel → Virtual background section
3. Click the **`+`** button (`Select your background` / `Sélectionner votre arrière-plan`)
4. Pick any image from your PC (≤ 10 MB)
5. Verify the image is applied as a virtual background

Closes #924