### PR TITLE
💄(frontend) add focus ring to reaction emoji buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ♻️(frontend) replace custom reactions toolbar with react aria popover #985
 - 🔒️(frontend) uninstall curl from the frontend production image #987
+- 💄(frontend) add focus ring to reaction emoji buttons
 
 ## [1.8.0] - 2026-02-20
 
@@ -19,7 +20,7 @@ and this project adheres to
 
 - 🔒️(agents) uninstall pip from the agents image
 - 🔒️(summary) switch to Alpine base image
-- 🔒️(backend) uninstall pip in the production image 
+- 🔒️(backend) uninstall pip in the production image
 
 ### Fixed
 

--- a/src/frontend/src/primitives/buttonRecipe.ts
+++ b/src/frontend/src/primitives/buttonRecipe.ts
@@ -199,6 +199,11 @@ export const buttonRecipe = cva({
           backgroundColor: 'primaryDark.700',
           color: 'primaryDark.100',
         },
+        '&[data-focus-visible]': {
+          outline: '2px solid',
+          outlineColor: 'focusRing',
+          outlineOffset: '2px',
+        },
       },
       quaternaryText: {
         backgroundColor: 'transparent',


### PR DESCRIPTION
## Purpose

Add a visual focus indicator on emoji reaction buttons for keyboard navigation.

## Proposal

- [x] Add `data-focus-visible` outline style to the `primaryTextDark` button variant

Focus was set on the first emoji but invisible due to missing `data-focus-visible` style, especially noticeable with a screen reader active.