### PR TITLE
♿️(a11y) fix focus ring on tab container components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 - 🚚(frontend) rename "wellknown" directory to "well-known" #1009
 - 🌐(frontend) localize SR modifier labels #1010
 - ⬆️(backend) update python dependencies #1011
+- ♿️(a11y) fix focus ring on tab container components
+
 
 ## [1.8.0] - 2026-02-20
 

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -41,6 +41,7 @@ const tabListContainerStyle = css({
   flexDirection: 'column',
   borderRight: '1px solid lightGray', // fixme poor color management
   paddingY: '1rem',
+  paddingLeft: '0.2rem',
   paddingRight: '1.5rem',
 })
 

--- a/src/frontend/src/primitives/Tabs.tsx
+++ b/src/frontend/src/primitives/Tabs.tsx
@@ -24,6 +24,9 @@ const StyledTabs = styled(RACTabs, {
       flexDirection: 'row',
       '--vertical': '3px',
     },
+    '&[data-focus-visible]': {
+      outline: 'none!',
+    },
   },
 })
 
@@ -102,6 +105,9 @@ const StyledTabList = styled(RACTabList, {
     '&[data-orientation=vertical]': {
       flexDirection: 'column',
     },
+    '&[data-focus-visible]': {
+      outline: 'none!',
+    },
   },
   variants: {
     border: {
@@ -147,9 +153,8 @@ const StyledTabPanel = styled(RACTabPanel, {
   base: {
     marginTop: '4px',
     borderRadius: '4px',
-    outline: 'none',
     '&[data-focus-visible]': {
-      outline: '2px solid red',
+      outline: 'none!',
     },
   },
   variants: {


### PR DESCRIPTION
## Purpose

The global CSS rule `[data-rac][data-focus-visible]` applies a focus ring to all react-aria components. Container components (`Tabs`, `TabList`, `TabPanel`) propagate `data-focus-visible` when any child has keyboard focus, causing a large double outline around the entire settings dialog.

<img width="1055" height="847" alt="focusringsettings" src="https://github.com/user-attachments/assets/0a2cf253-ae90-4738-98f3-aabe8512d5c3" />


## Proposal

Suppress the focus-visible outline on container components so only individual `Tab` elements show a focus ring.

- [x] Disable focus-visible outline on `StyledTabs`, `StyledTabList`, and `StyledTabPanel`
- [x] Remove debug `outline: 2px solid red` on `StyledTabPanel`
- [x] Add `paddingLeft` to prevent focus ring clipping