### PR TITLE
♻️(devex) run service as part of make bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ bootstrap: \
 	demo \
 	back-i18n-compile \
 	mails-install \
-	mails-build
+	mails-build \
+	run
 .PHONY: bootstrap
 
 # -- Docker/compose


### PR DESCRIPTION
Add run to `make bootstrap`, thus starting the service. This fixes a mismatch with [development documentation](https://github.com/suitenumerique/meet/blob/main/docs/developping_locally.md#project-bootstrap).