### PR TITLE
🩹(frontend) fix German language preference update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to
 - ⬆️(backend) update python dependencies #1011
 - ♿️(a11y) fix focus ring on tab container components
 
+### Fixed
+
+- 🩹(frontend) fix German language preference update #1021
+
 
 ## [1.8.0] - 2026-02-20
 

--- a/src/frontend/src/utils/languages.ts
+++ b/src/frontend/src/utils/languages.ts
@@ -1,12 +1,13 @@
 // Map frontend language codes to backend language codes
 
-export type BackendLanguage = 'en-us' | 'fr-fr' | 'nl-nl'
-export type FrontendLanguage = 'en' | 'fr' | 'nl'
+export type BackendLanguage = 'en-us' | 'fr-fr' | 'nl-nl' | 'de-de'
+export type FrontendLanguage = 'en' | 'fr' | 'nl' | 'de'
 
 const frontendToBackendMap: Record<FrontendLanguage, BackendLanguage> = {
   en: 'en-us',
   fr: 'fr-fr',
   nl: 'nl-nl',
+  de: 'de-de',
 }
 
 export const convertToBackendLanguage = (


### PR DESCRIPTION
German was missing from the frontend/backend language list in the sync hook, causing user preference updates to be ignored.

Add the language to ensure preference changes are properly applied.
