### PR TITLE
🩹(devex) fix Makefile special character support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@
 # ==============================================================================
 # VARIABLES
 
-BOLD := \033[1m
-RESET := \033[0m
-GREEN := \033[1;32m
+ESC := $(shell printf '\033')
+BOLD := $(ESC)[1m
+RESET := $(ESC)[0m
+GREEN := $(ESC)[1;32m
 
 
 # -- Database


### PR DESCRIPTION
Under some shells echo doesn't work as expected with the special formatting.

Using printf when creating the variables make it work and should be more robust.

Before: 
<img width="1446" height="119" alt="image" src="https://github.com/user-attachments/assets/1a277c01-b6da-4c5b-af5a-9154740de19b" />

After:
<img width="1446" height="119" alt="image" src="https://github.com/user-attachments/assets/c686da4e-729f-4361-b4ce-b039900ea7b9" />
