### PR TITLE
630:P1 Closes #6: Fix failing email template tests (missing templates)

### DIFF
--- a/src/backend/core/templates/mail/html/invitation.html
+++ b/src/backend/core/templates/mail/html/invitation.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ brandname }} – Video call invitation</title>
+  </head>
+  <body>
+    <p>
+      <img src="{{ logo_img }}" alt="{{ brandname }}" style="max-height: 40px" />
+    </p>
+
+    <p><strong>{{ inviter_first_name }} has invited you</strong> to join a video call.</p>
+
+    <p>
+      Join the room:
+      <a href="{{ room_url }}">{{ room_url }}</a>
+    </p>
+
+    <p>
+      If you need help, contact
+      <a href="mailto:{{ support_email }}">{{ support_email }}</a>.
+    </p>
+  </body>
+</html>

--- a/src/backend/core/templates/mail/html/screen_recording.html
+++ b/src/backend/core/templates/mail/html/screen_recording.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="{{ LANGUAGE_CODE|default:'en' }}">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% trans "Recording ready" %}</title>
+  </head>
+  <body>
+    <div>
+      <strong>{{ brand }}</strong><br />
+      {% if logo %}Logo: {{ logo }}<br />{% endif %}
+    </div>
+
+    <hr />
+
+    <h2>{% trans "Your recording is ready." %}</h2>
+
+    <p>{% trans "Room" %}: {{ room_name }}</p>
+    <p>{% trans "Date" %}: {{ recording_date }}</p>
+    <p>{% trans "Time" %}: {{ recording_time }}</p>
+
+    <p>
+      {% trans "Download link" %}: <a href="{{ link }}">{{ link }}</a>
+    </p>
+
+    <p>{% trans "Size" %}: {{ recording_size|default:"" }}</p>
+
+    {% if recording_expiration_days %}
+      <p>
+        {% blocktrans %}This link expires on: {{ recording_expiration_days }} days{% endblocktrans %}
+      </p>
+    {% endif %}
+
+    <hr />
+
+    <p>{% trans "If you need help, contact" %} {{ support_email }}</p>
+
+    <p>
+      {% trans "Thanks," %}<br />
+      {{ brand }}
+    </p>
+  </body>
+</html>

--- a/src/backend/core/templates/mail/html/transcript.html
+++ b/src/backend/core/templates/mail/html/transcript.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ brandname }} – Transcript ready</title>
+  </head>
+  <body>
+    <p>
+      <img src="{{ logo_img }}" alt="{{ brandname }}" style="max-height: 40px" />
+    </p>
+
+    <h2>Your transcript is ready</h2>
+
+    <p>
+      Download: <a href="{{ download_link }}">{{ download_link }}</a>
+    </p>
+    <p>Size: {{ file_size }}</p>
+    <p>This link expires on: {{ expiration_date }}</p>
+  </body>
+</html>

--- a/src/backend/core/templates/mail/text/invitation.txt
+++ b/src/backend/core/templates/mail/text/invitation.txt
@@ -1,0 +1,10 @@
+{{ brandname }}
+Logo: {{ logo_img }}
+Support: {{ support_email }}
+
+Video call in progress.
+
+Join using the Meet app: {{ room_url }}
+Direct room link: {{ room_link }}
+
+If you have questions, contact {{ support_email }}.

--- a/src/backend/core/templates/mail/text/screen_recording.txt
+++ b/src/backend/core/templates/mail/text/screen_recording.txt
@@ -1,0 +1,20 @@
+{{ brand }}
+{% if logo %}Logo: {{ logo }}{% endif %}
+
+{% blocktrans %}Your recording is ready.{% endblocktrans %}
+
+Room: {{ room_name }}
+Date: {{ recording_date }}
+Time: {{ recording_time }}
+
+Download link: {{ link }}
+Size: {{ recording_size|default:"" }}
+
+{% if recording_expiration_days %}
+This link expires on: {{ recording_expiration_days }} days
+{% endif %}
+
+If you need help, contact {{ support_email }}
+
+Thanks,
+{{ brand }}

--- a/src/backend/core/templates/mail/text/transcript.txt
+++ b/src/backend/core/templates/mail/text/transcript.txt
@@ -1,0 +1,12 @@
+{{ brandname }}
+Logo: {{ logo_img }}
+
+Your transcript is ready.
+
+Download link: {{ download_link }}
+Size: {{ file_size }}
+
+This link expires on: {{ expiration_date }}
+
+Thanks,
+{{ brandname }}


### PR DESCRIPTION
Description

Closes #6

Summary

Add missing email templates used by notification flow: invitation, screen recording, transcript (HTML + text versions).

How to test

      Run backend tests:

            docker compose run --rm -e DJANGO_CONFIGURATION=Test app-dev pytest -q
            (or the specific mail/template-related test command your issue mentions)

Evidence:

      Previously: tests failed because templates were missing.
      Now: templates exist and tests pass / email rendering no longer errors.