### PR TITLE
♿(frontend) Align the Settings dialog heading level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - ♿️(frontend) improve accessibility of the IntroSlider carousel #1026
 - ♿️(frontend) add skip link component for keyboard navigation #1019
 - ♿️(frontend) announce mic/camera state to SR on shortcut toggle #1052
+- ♿(frontend) Align the Settings dialog heading level #1051
 
 ### Fixed
 

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -21,7 +21,6 @@ import { AudioTab } from './tabs/AudioTab'
 import { VideoTab } from './tabs/VideoTab'
 import { TranscriptionTab } from './tabs/TranscriptionTab'
 import { ShortcutTab } from './tabs/ShortcutTab'
-import { useRef } from 'react'
 import { useMediaQuery } from '@/features/rooms/livekit/hooks/useMediaQuery'
 import { SettingsDialogExtendedKey } from '@/features/settings/type'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
@@ -63,13 +62,12 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
   // display only icon on small screen
   const { t } = useTranslation('settings')
 
-  const dialogEl = useRef<HTMLDivElement>(null)
   const isWideScreen = useMediaQuery('(min-width: 800px)') // fixme - hardcoded 50rem in pixel
 
   const isAdminOrOwner = useIsAdminOrOwner()
 
   return (
-    <Dialog innerRef={dialogEl} {...props} role="dialog" type="flex">
+    <Dialog {...props} role="dialog" type="flex">
       <Tabs
         orientation="vertical"
         className={tabsStyle}
@@ -84,11 +82,11 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
           }}
         >
           {isWideScreen && (
-            <Heading slot="title" level={1} className={text({ variant: 'h1' })}>
+            <Heading slot="title" level={2} className={text({ variant: 'h2' })}>
               {t('dialog.heading')}
             </Heading>
           )}
-          <TabList border={false}>
+          <TabList border={false} aria-label={t('dialog.tablistAriaLabel')}>
             <Tab icon highlight id={SettingsDialogExtendedKey.ACCOUNT}>
               <RiAccountCircleLine />
               {isWideScreen && t(`tabs.${SettingsDialogExtendedKey.ACCOUNT}`)}

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -106,7 +106,8 @@
     "columnShortcut": "Tastenkürzel"
   },
   "dialog": {
-    "heading": "Einstellungen"
+    "heading": "Einstellungen",
+    "tablistAriaLabel": "Einstellungskategorien"
   },
   "language": {
     "heading": "Sprache",

--- a/src/frontend/src/locales/en/settings.json
+++ b/src/frontend/src/locales/en/settings.json
@@ -106,7 +106,8 @@
     "columnShortcut": "Shortcut"
   },
   "dialog": {
-    "heading": "Settings"
+    "heading": "Settings",
+    "tablistAriaLabel": "Settings categories"
   },
   "language": {
     "heading": "Language",

--- a/src/frontend/src/locales/fr/settings.json
+++ b/src/frontend/src/locales/fr/settings.json
@@ -106,7 +106,8 @@
     "columnShortcut": "Raccourci"
   },
   "dialog": {
-    "heading": "Paramètres"
+    "heading": "Paramètres",
+    "tablistAriaLabel": "Catégories des paramètres"
   },
   "language": {
     "heading": "Langue",

--- a/src/frontend/src/locales/nl/settings.json
+++ b/src/frontend/src/locales/nl/settings.json
@@ -106,7 +106,8 @@
     "columnShortcut": "Sneltoets"
   },
   "dialog": {
-    "heading": "Instellingen"
+    "heading": "Instellingen",
+    "tablistAriaLabel": "Instellingcategorieën"
   },
   "language": {
     "heading": "Taal",


### PR DESCRIPTION
/////////////