### PR TITLE
💄(frontend) truncate pinned participant name with ellipsis on overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(migrations) use settings in migrations #1058
+- 💄(frontend) truncate pinned participant name with ellipsis on overflow #1056
 
 ## [1.9.0] - 2026-03-02
 

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantName.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantName.tsx
@@ -1,7 +1,20 @@
+import type { CSSProperties } from 'react'
 import { Text } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import { useParticipantInfo } from '@livekit/components-react'
 import { Participant } from 'livekit-client'
+
+const participantNameStyles: CSSProperties = {
+  paddingBottom: '0.1rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
+
+const participantNameScreenShareStyles: CSSProperties = {
+  ...participantNameStyles,
+  marginLeft: '0.4rem',
+}
 
 export const ParticipantName = ({
   participant,
@@ -17,26 +30,14 @@ export const ParticipantName = ({
 
   if (isScreenShare) {
     return (
-      <Text
-        variant="sm"
-        style={{
-          paddingBottom: '0.1rem',
-          marginLeft: '0.4rem',
-        }}
-      >
+      <Text variant="sm" style={participantNameScreenShareStyles}>
         {t('screenShare', { name: displayedName })}
       </Text>
     )
   }
 
   return (
-    <Text
-      variant="sm"
-      style={{
-        paddingBottom: '0.1rem',
-      }}
-      aria-hidden="true"
-    >
+    <Text variant="sm" style={participantNameStyles} aria-hidden="true">
       {displayedName}
     </Text>
   )

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -183,7 +183,7 @@ export const ParticipantTile: (
                       }}
                     >
                       {isHandRaised && !isScreenShare && (
-                        <>
+                        <span>
                           <span>{positionInQueue}</span>
                           <RiHand
                             color="black"
@@ -197,7 +197,7 @@ export const ParticipantTile: (
                               animationIterationCount: '2',
                             }}
                           />
-                        </>
+                        </span>
                       )}
                       {isScreenShare && (
                         <ScreenShareIcon
@@ -210,10 +210,12 @@ export const ParticipantTile: (
                       {isEncrypted && !isScreenShare && (
                         <LockLockedIcon style={{ marginRight: '0.25rem' }} />
                       )}
-                      <ParticipantName
-                        isScreenShare={isScreenShare}
-                        participant={trackReference.participant}
-                      />
+                      <div className="lk-participant-name-wrapper">
+                        <ParticipantName
+                          isScreenShare={isScreenShare}
+                          participant={trackReference.participant}
+                        />
+                      </div>
                     </div>
                   </HStack>
                   <ConnectionQualityIndicator className="lk-participant-metadata-item" />

--- a/src/frontend/src/styles/livekit.css
+++ b/src/frontend/src/styles/livekit.css
@@ -151,3 +151,24 @@
 [data-lk-theme] .lk-participant-tile {
   box-shadow: var(--lk-box-shadow);
 }
+
+/* Participant name ellipsis: truncate when overflowing */
+.lk-participant-metadata {
+  width: 100%;
+}
+.lk-participant-metadata > *:first-child {
+  min-width: 0;
+}
+.lk-participant-metadata > *:first-child {
+  flex: 1;
+}
+.lk-participant-metadata > *:first-child .lk-participant-metadata-item,
+.lk-participant-metadata
+  .lk-participant-metadata-item
+  .lk-participant-name-wrapper {
+  min-width: 0;
+}
+.lk-participant-metadata > *:first-child .lk-participant-metadata-item {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
## Purpose

When a participant is pinned or displayed in a tile, long names can overflow and break the layout by wrapping or extending beyond the available space.

<img width="379" height="372" alt="Capture d&#39;écran 2026-03-02 161005" src="https://github.com/user-attachments/assets/412a5de5-b587-4869-878a-951f8cbc3a53" />

## Proposal

Apply text truncation with ellipsis when the participant name overflows its container.

- [x] Add overflow and ellipsis styles to ParticipantName
- [x] Adjust flex layout so ellipsis works correctly
- [x] Move layout rules into livekit.css