### PR TITLE
🔒️(helm) introduce a dedicated Kubernetes Ingress for webhook-livekit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - 🔒️(backend) enhance API input validation to strengthen security #1053
 - 🦺(backend) strengthen API validation for recording options #1063
 - ⚡️(frontend) optimize few performance caveats #1073
+- 🔒️(helm) introduce a dedicated Kubernetes Ingress for webhook-livekit #1066
 
 ### Fixed
 

--- a/src/helm/env.d/dev-dinum/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-dinum/values.meet.yaml.gotmpl
@@ -128,6 +128,10 @@ ingressAdmin:
   enabled: true
   host: meet.127.0.0.1.nip.io
 
+ingressWebhook:
+  enabled: true
+  host: meet.127.0.0.1.nip.io
+
 posthog:
   ingress:
     enabled: false

--- a/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev-keycloak/values.meet.yaml.gotmpl
@@ -141,6 +141,10 @@ ingressAdmin:
   enabled: true
   host: meet.127.0.0.1.nip.io
 
+ingressWebhook:
+  enabled: true
+  host: meet.127.0.0.1.nip.io
+
 posthog:
   ingress:
     enabled: false

--- a/src/helm/env.d/dev/values.meet.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.meet.yaml.gotmpl
@@ -156,6 +156,10 @@ ingressAdmin:
   enabled: true
   host: meet.127.0.0.1.nip.io
 
+ingressWebhook:
+  enabled: true
+  host: meet.127.0.0.1.nip.io
+
 posthog:
   ingress:
     enabled: false

--- a/src/helm/meet/Chart.yaml
+++ b/src/helm/meet/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: meet
-version: 0.0.15
+version: 0.0.16

--- a/src/helm/meet/templates/ingress_webhook.yaml
+++ b/src/helm/meet/templates/ingress_webhook.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.ingressWebhook.enabled -}}
+{{- $fullName := include "meet.fullname" . -}}
+{{- if and .Values.ingressWebhook.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingressWebhook.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingressWebhook.annotations "kubernetes.io/ingress.class" .Values.ingressWebhook.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-webhook
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "meet.labels" . | nindent 4 }}
+  {{- with .Values.ingressWebhook.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingressWebhook.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingressWebhook.className }}
+  {{- end }}
+  {{- if .Values.ingressWebhook.tls.enabled }}
+  tls:
+    {{- if .Values.ingressWebhook.host }}
+    - secretName: {{ .Values.ingressWebhook.tls.secretName | default (printf "%s-tls" $fullName) | quote }}
+      hosts:
+        - {{ .Values.ingressWebhook.host | quote }}
+    {{- end }}
+    {{- range .Values.ingressWebhook.tls.additional }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingressWebhook.host }}
+    - host: {{ .Values.ingressWebhook.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingressWebhook.path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Exact
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "meet.backend.fullname" . }}
+                port:
+                  number: {{ .Values.backend.service.port }}
+              {{- else }}
+              serviceName: {{ include "meet.backend.fullname" . }}
+              servicePort: {{ .Values.backend.service.port }}
+            {{- end }}
+          {{- with .Values.ingressWebhook.customBackends }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+    {{- end }}
+    {{- range .Values.ingressWebhook.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingressWebhook.path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Exact
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "meet.backend.fullname" $ }}
+                port:
+                  number: {{ $.Values.backend.service.port }}
+              {{- else }}
+              serviceName: {{ include "meet.backend.fullname" $ }}
+              servicePort: {{ $.Values.backend.service.port }}
+            {{- end }}
+          {{- with $.Values.ingressWebhook.customBackends }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+

--- a/src/helm/meet/values.yaml
+++ b/src/helm/meet/values.yaml
@@ -50,6 +50,31 @@ ingress:
   ## @param ingress.customBackends Add custom backends to ingress
   customBackends: []
 
+## @param ingressWebhook.enabled whether to enable the Ingress or not
+## @param ingressWebhook.className IngressClass to use for the Ingress
+## @param ingressWebhook.host Host for the Ingress
+## @param ingressWebhook.path Path to use for the Ingress
+ingressWebhook:
+  enabled: false
+  className: null
+  host: meet.example.com
+  path: /api/v1.0/rooms/webhooks-livekit/
+  ## @param ingressWebhook.hosts Additional host to configure for the Ingress
+  hosts: []
+  #  - chart-example.local
+  ## @param ingressWebhook.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressWebhook.tls.secretName Secret name for TLS config
+  ## @skip ingressWebhook.tls.additional
+  ## @extra ingressWebhook.tls.additional[].secretName Secret name for additional TLS config
+  ## @extra ingressWebhook.tls.additional[].hosts[] Hosts for additional TLS config
+  tls:
+    secretName: null
+    enabled: true
+    additional: []
+
+  ## @param ingressWebhook.customBackends Add custom backends to ingress
+  customBackends: []
+
 
 ## @param ingressAdmin.enabled whether to enable the Ingress or not
 ## @param ingressAdmin.className IngressClass to use for the Ingress


### PR DESCRIPTION
Create a separate Ingress resource to isolate traffic targeting the webhook-livekit endpoint and allow applying specific NGINX annotations to this route.

Use an exact path match to take precedence over the default /api regex rule defined in the base Ingress.

No similar change is made for the S3 webhook endpoint, as this dependency will be removed from the project.