### PR TITLE
♿(frontend) prevent focus ring clipping on invite dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 - 🐛(migrations) use settings in migrations #1058
 - 💄(frontend) truncate pinned participant name with ellipsis on overflow #1056
+- ♿(frontend) prevent focus ring clipping on invite dialog #1078
 
 ## [1.9.0] - 2026-03-02
 

--- a/src/frontend/src/features/rooms/components/InviteDialog.tsx
+++ b/src/frontend/src/features/rooms/components/InviteDialog.tsx
@@ -65,7 +65,7 @@ export const InviteDialog = (props: Omit<DialogProps, 'title'>) => {
           alignItems="left"
           justify="start"
           gap={0}
-          style={{ maxWidth: '100%', overflow: 'hidden' }}
+          style={{ maxWidth: '100%', overflow: 'visible' }}
         >
           <Heading slot="title" level={2} className={text({ variant: 'h2' })}>
             {t('heading')}
@@ -93,7 +93,7 @@ export const InviteDialog = (props: Omit<DialogProps, 'title'>) => {
                 flexDirection: 'column',
                 marginTop: '0.5rem',
                 gap: '1rem',
-                overflow: 'hidden',
+                overflow: 'visible',
               })}
             >
               <div


### PR DESCRIPTION
## Purpose

The focus ring was visually cropped within the Invite dialog. When interactive elements received keyboard focus


https://github.com/user-attachments/assets/bd501651-4a6b-40d1-a74b-7601b7b438b7


## Proposal

- [x] Change `overflow: hidden` to `overflow: visible` on the main VStack container
- [x] Change `overflow: hidden` to `overflow: visible` on the telephony section container
- [x] Ensure focus outlines render fully without being clipped