### PR TITLE
🩹(frontend) remove incorrect reference to ProConnect on the prejoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🩹(frontend) remove incorrect reference to ProConnect on the prejoin #1080
+- ✨(frontend) add Ctrl+Shift+/ to open shortcuts settings #1050
+
 ### Changed
 
 - 🔒️(backend) enhance API input validation to strengthen security #1053
@@ -42,7 +47,6 @@ and this project adheres to
 - ♿️(frontend) improve accessibility of the IntroSlider carousel #1026
 - ♿️(frontend) add skip link component for keyboard navigation #1019
 - ♿️(frontend) announce mic/camera state to SR on shortcut toggle #1052
-- ✨(frontend) add Ctrl+Shift+/ to open shortcuts settings #1050
 
 ### Fixed
 

--- a/src/frontend/src/locales/de/global.json
+++ b/src/frontend/src/locales/de/global.json
@@ -45,7 +45,7 @@
     "license": "Etalab 2.0 Lizenz"
   },
   "loginHint": {
-    "title": "Melden Sie sich mit Ihrem ProConnect-Konto an",
+    "title": "Melden Sie sich mit Ihrem Konto an",
     "body": "Statt zu warten, melden Sie sich mit Ihrem ProConnect-Konto an.",
     "button": {
       "ariaLabel": "Hinweis schließen",

--- a/src/frontend/src/locales/en/global.json
+++ b/src/frontend/src/locales/en/global.json
@@ -45,7 +45,7 @@
     "license": "etalab 2.0 license"
   },
   "loginHint": {
-    "title": "Log in with your ProConnect account",
+    "title": "Log in with your account",
     "body": "Instead of waiting, log in with your ProConnect account.",
     "button": {
       "ariaLabel": "Close the suggestion",

--- a/src/frontend/src/locales/fr/global.json
+++ b/src/frontend/src/locales/fr/global.json
@@ -45,7 +45,7 @@
     "license": "licence etalab 2.0"
   },
   "loginHint": {
-    "title": "Connectez-vous avec votre compte ProConnect",
+    "title": "Connectez-vous avec votre compte",
     "body": "Au lieu de patienter, connectez-vous avec votre compte ProConnect.",
     "button": {
       "ariaLabel": "Fermer la suggestion",

--- a/src/frontend/src/locales/nl/global.json
+++ b/src/frontend/src/locales/nl/global.json
@@ -44,7 +44,7 @@
     "license": "etalab 2.0 licentie"
   },
   "loginHint": {
-    "title": "Log in met je ProConnect-account",
+    "title": "Log in met je account",
     "body": "In plaats van te wachten, log in met je ProConnect-account.",
     "button": {
       "ariaLabel": "Sluit de suggestie",


### PR DESCRIPTION
Remove incorrect reference to ProConnect (DINUM SSO) from content literals, where it should not be mentioned by default in the white labeled version.

It closes #1075 