### PR TITLE
💄(fix) add consistent bottom spacing to participant name label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🩹(frontend) remove incorrect reference to ProConnect on the prejoin #1080
 - ✨(frontend) add Ctrl+Shift+/ to open shortcuts settings #1050
+- 💄(fix) add consistent bottom spacing to participant name label #1087
 
 ### Changed
 

--- a/src/frontend/src/styles/livekit.css
+++ b/src/frontend/src/styles/livekit.css
@@ -150,6 +150,7 @@
 
 [data-lk-theme] .lk-participant-tile {
   box-shadow: var(--lk-box-shadow);
+  gap: 0;
 }
 
 /* Participant name ellipsis: truncate when overflowing */


### PR DESCRIPTION
## Purpose

On certain window sizes, the space below the participant name label disappears, and the label sits flush against the bottom edge of the video tile. A default `gap` on `.lk-participant-tile` was causing inconsistent spacing and a black strip in some layouts.

## Proposal

Override LiveKit's default `gap` on `.lk-participant-tile` so the layout stays consistent at all window sizes.

- [x] Add `gap: 0` to `.lk-participant-tile` in `livekit.css`