### PR TITLE
💄(fix) truncate long names with ellipsis in reaction overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - 🩹(frontend) remove incorrect reference to ProConnect on the prejoin #1080
 - ✨(frontend) add Ctrl+Shift+/ to open shortcuts settings #1050
 - ♿(frontend) announce selected state to screen readers #1081
+- 💄(frontend) truncate long names with ellipsis in reaction overlay #1099
 
 ### Changed
 

--- a/src/frontend/src/features/rooms/livekit/components/ReactionPortal.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ReactionPortal.tsx
@@ -102,6 +102,11 @@ export function FloatingReaction({
             paddingTop: '0.15rem',
             boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
             lineHeight: '16px',
+            maxWidth: '12rem',
+            display: 'inline-block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           })}
         >
           {name}


### PR DESCRIPTION
## Purpose

Add ellipsis truncation to the name label in the reaction overlay.

<img width="582" height="510" alt="Capture d&#39;écran 2026-03-05 103441" src="https://github.com/user-attachments/assets/eae72257-be42-4dd0-b25e-7e2bd4a12c08" />

## Proposal

- [x] Add `maxWidth`, `overflow`, `textOverflow`, `whiteSpace` on the name `Text` in `FloatingReaction`