### PR TITLE
🐛(backend) add link to "Open" text in recording email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to
 - ♻(frontend) standardize role terminology across localizations
 - 🐛(backend) make start-recording atomic and fault-tolerant
 - 🔒️(frontend) room ids are generated with non-cryptographic rand
-- ⬆️(mail) fix dependencies not having resolved or integrity field by updating #1321
+- ⬆️(mail) fix dependencies not having resolved or integrity field #1321
 - 🐛(summary) complete webm support #1328
+- 🐛(backend) add link to "Open" text in recording email
 
 ## [1.15.0] - 2026-04-30
 

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -576,8 +576,8 @@ msgstr "So speichern Sie diese Aufzeichnung dauerhaft:"
 
 #: core/templates/mail/html/screen_recording.html:208
 #: core/templates/mail/text/screen_recording.txt:13
-msgid "Click the \"Open\" button below "
-msgstr "Klicken Sie auf den Button „Öffnen“ unten "
+msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
+msgstr "Klicken Sie auf den Link „<a href=\"%(link)s\">Öffnen</a>\" unten "
 
 #: core/templates/mail/html/screen_recording.html:209
 #: core/templates/mail/text/screen_recording.txt:14

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -572,8 +572,8 @@ msgstr "To keep this recording permanently:"
 
 #: core/templates/mail/html/screen_recording.html:208
 #: core/templates/mail/text/screen_recording.txt:13
-msgid "Click the \"Open\" button below "
-msgstr "Click the \"Open\" button below "
+msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
+msgstr "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
 
 #: core/templates/mail/html/screen_recording.html:209
 #: core/templates/mail/text/screen_recording.txt:14

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -578,8 +578,8 @@ msgstr "Pour conserver cet enregistrement de façon permanente :"
 
 #: core/templates/mail/html/screen_recording.html:208
 #: core/templates/mail/text/screen_recording.txt:13
-msgid "Click the \"Open\" button below "
-msgstr "Cliquez sur le bouton \"Ouvrir\" ci-dessous "
+msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
+msgstr "Cliquez sur le lien \"<a href=\"%(link)s\">Ouvrir</a>\" ci-dessous "
 
 #: core/templates/mail/html/screen_recording.html:209
 #: core/templates/mail/text/screen_recording.txt:14

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -571,8 +571,8 @@ msgstr "Om deze opname permanent te bewaren:"
 
 #: core/templates/mail/html/screen_recording.html:208
 #: core/templates/mail/text/screen_recording.txt:13
-msgid "Click the \"Open\" button below "
-msgstr "Klik op de \"Openen\"-knop hieronder "
+msgid "Click the \"<a href=\"%(link)s\">Open</a>\" link below "
+msgstr "Klik op de \"<a href=\"%(link)s\">Openen</a>\"-link hieronder "
 
 #: core/templates/mail/html/screen_recording.html:209
 #: core/templates/mail/text/screen_recording.txt:14

--- a/src/mail/mjml/screen_recording.mjml
+++ b/src/mail/mjml/screen_recording.mjml
@@ -37,7 +37,7 @@
           <mj-text>
             <p>{% trans "To keep this recording permanently:" %}</p>
             <ol>
-              <li>{% blocktrans %}Click the "Open" button below {% endblocktrans %}</li>
+              <li>{% blocktrans %}Click the "<a href="{{link}}">Open</a>" link below {% endblocktrans %}</li>
               <li>{% blocktrans %}Use the "Download" button in the interface {% endblocktrans %}</li>
               <li>{% blocktrans %}Save the file to your preferred location{% endblocktrans %}</li>
             </ol>


### PR DESCRIPTION
## Purpose

The "Open" text in step 1 of the recording notification email instructions was plain text — not a clickable link. Users whose email clients didn't properly render the button below had no way to access their recording from the instructions.

Fixes the issue where the email says "Click the Open button below" but "Open" itself wasn't linked.

## Proposal

- Wrapped "Open" in step 1 with an `<a href="{{link}}">` tag in the MJML source template
- Changed wording from "button" to "link" to reflect the new behavior
- Updated all 4 locale translation files (en, fr, de, nl)
- Rebuilt compiled HTML and plain text templates

- [x] MJML source template updated
- [x] Locale files updated (en, fr, de, nl)
- [x] Templates rebuilt via `npm run build`
- [x] Changelog entry added
