### PR TITLE
♿️(frontend) improve MoreLink a11y and UX on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) sync html lang attribute with i18n for screen readers #1111
+- ♿️(frontend) improve MoreLink a11y and UX on home page #1112
 
 ## [1.10.0] - 2026-03-05
 

--- a/src/frontend/src/features/home/components/MoreLink.tsx
+++ b/src/frontend/src/features/home/components/MoreLink.tsx
@@ -2,23 +2,25 @@ import { A, Text } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import { useConfig } from '@/api/useConfig'
 
+const appTitle = import.meta.env.VITE_APP_TITLE ?? 'LaSuite Meet'
+
 export const MoreLink = () => {
   const { t } = useTranslation('home')
   const { data } = useConfig()
 
-  if (!data?.manifest_link) return
+  if (!data?.manifest_link) return null
 
   return (
-    <Text as={'p'} variant={'sm'} style={{ padding: '1rem 0' }}>
+    <Text as="p" variant="sm" style={{ padding: '1rem 0' }}>
       <A
         href={data?.manifest_link}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={t('moreLinkLabel')}
+        externalIcon
+        aria-label={t('moreLinkLabel', { appTitle })}
       >
-        {t('moreLink')}
-      </A>{' '}
-      {t('moreAbout', { appTitle: `${import.meta.env.VITE_APP_TITLE}` })}
+        {t('moreLink')} {t('moreAbout', { appTitle })}
+      </A>
     </Text>
   )
 }

--- a/src/frontend/src/features/home/routes/Home.tsx
+++ b/src/frontend/src/features/home/routes/Home.tsx
@@ -258,23 +258,10 @@ export const Home = () => {
               </DialogTrigger>
             </div>
             <Separator />
-            <div
-              className={css({
-                display: { base: 'none', lg: 'inline' },
-              })}
-            >
-              <MoreLink />
-            </div>
+            <MoreLink />
           </LeftColumn>
           <RightColumn>
             <IntroSlider />
-            <div
-              className={css({
-                display: { base: 'inline', lg: 'none' },
-              })}
-            >
-              <MoreLink />
-            </div>
           </RightColumn>
         </Columns>
         <LaterMeetingDialog

--- a/src/frontend/src/locales/de/home.json
+++ b/src/frontend/src/locales/de/home.json
@@ -10,7 +10,7 @@
   "joinMeetingTipContent": "Sie können einem Meeting beitreten, indem Sie den vollständigen Link in die Adressleiste Ihres Browsers einfügen.",
   "joinMeetingTipHeading": "Wussten Sie schon?",
   "loginToCreateMeeting": "Melden Sie sich an, um ein Meeting zu erstellen",
-  "moreLinkLabel": "Mehr erfahren – neues Tab",
+  "moreLinkLabel": "Mehr erfahren über {{appTitle}} – neues Tab",
   "moreLink": "Mehr erfahren",
   "moreAbout": "über {{appTitle}}",
   "createMenu": {

--- a/src/frontend/src/locales/en/home.json
+++ b/src/frontend/src/locales/en/home.json
@@ -10,7 +10,7 @@
   "joinMeetingTipContent": "You can join a meeting by pasting its full link in the browser's address bar.",
   "joinMeetingTipHeading": "Did you know?",
   "loginToCreateMeeting": "Login to create a meeting",
-  "moreLinkLabel": "Learn more - new tab",
+  "moreLinkLabel": "Learn more about {{appTitle}} - new tab",
   "moreLink": "Learn more",
   "moreAbout": "about {{appTitle}}",
   "createMenu": {

--- a/src/frontend/src/locales/fr/home.json
+++ b/src/frontend/src/locales/fr/home.json
@@ -10,7 +10,7 @@
   "joinMeetingTipContent": "Vous pouvez rejoindre une réunion en copiant directement son lien complet dans la barre d'adresse du navigateur.",
   "joinMeetingTipHeading": "Astuce",
   "loginToCreateMeeting": "Connectez-vous pour créer une réunion",
-  "moreLinkLabel": "En savoir plus - nouvelle fenêtre",
+  "moreLinkLabel": "En savoir plus sur {{appTitle}} - nouvelle fenêtre",
   "moreLink": "En savoir plus",
   "moreAbout": "sur {{appTitle}}",
   "createMenu": {

--- a/src/frontend/src/locales/nl/home.json
+++ b/src/frontend/src/locales/nl/home.json
@@ -10,7 +10,7 @@
   "joinMeetingTipContent": "U kunt deelnemen aan een vergadering door de volledige link in de adresbalk van de browser te plakken.",
   "joinMeetingTipHeading": "Wist u dat?",
   "loginToCreateMeeting": "Log in om een vergadering te maken",
-  "moreLinkLabel": "Meer informatie - nieuw tabblad",
+  "moreLinkLabel": "Meer informatie over {{appTitle}} - nieuw tabblad",
   "moreLink": "Meer informatie",
   "moreAbout": "over {{appTitle}}",
   "createMenu": {


### PR DESCRIPTION
## Purpose

Improve the accessibility of the "Learn more" link on the home page. Screen readers did not announce the full context, and only part of the text was clickable. Below 1024px, the link was placed under the carousel in a second column and was sometimes hard to find or hidden by `overflow: hidden`.

This PR aligns with [#1108](https://github.com/suitenumerique/meet/pull/1108) (addressing [issue #1045 – External link indication](https://github.com/suitenumerique/meet/issues/1045)): make the entire phrase clickable so the context is clearer and consistent with other "Learn more" links (Tools, Transcript, ScreenRecording).

## Proposal

- [x] Remove the duplicate MoreLink; render it once in LeftColumn for all viewport sizes
- [x] Place the link above the carousel for viewports below 1024px (no longer under it)
- [x] Make the entire phrase clickable ("Learn more about LaSuite Meet")
- [x] Add external link icon (`externalIcon`)
- [x] Extend `aria-label` with app name ("Learn more about {{appTitle}} - new tab")