### PR TITLE
🐛(frontend) fix dimension mismatch in BackgroundCustomProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 - ♿️(frontend) improve MoreLink a11y and UX on home page #1112
 - ♿(frontend) improve chat toast a11y for screen readers #1109
 
+### Fixed
+
+- 🐛(frontend) fix dimension mismatch in BackgroundCustomProcessor getImageData #1116
+
 ## [1.10.0] - 2026-03-05
 
 ### Changed

--- a/src/frontend/src/features/rooms/livekit/components/blur/BackgroundCustomProcessor.ts
+++ b/src/frontend/src/features/rooms/livekit/components/blur/BackgroundCustomProcessor.ts
@@ -187,7 +187,7 @@ export class BackgroundCustomProcessor implements BackgroundProcessorInterface {
       0,
       0,
       PROCESSING_WIDTH,
-      PROCESSING_WIDTH
+      PROCESSING_HEIGHT
     )
   }
 


### PR DESCRIPTION
## Summary
- Fix dimension mismatch in `BackgroundCustomProcessor.sizeSource()` where `getImageData()` was using `PROCESSING_WIDTH` for both dimensions instead of `PROCESSING_WIDTH` and `PROCESSING_HEIGHT`

## Problem
The code was drawing to the canvas at 256×144 but reading back at 256×256:
```typescript
// drawImage: 256×144
drawImage(..., PROCESSING_WIDTH, PROCESSING_HEIGHT)

// getImageData: 256×256 ← BUG
getImageData(..., PROCESSING_WIDTH, PROCESSING_WIDTH)
```

This caused:
1. `sourceImageData` to be 256×256 (65,536 pixels) instead of 256×144 (36,864 pixels)
2. The ML segmenter returned a 256×256 mask
3. The loop in `blur()` and `drawVirtualBackground()` iterated over 65,536 elements
4. But `segmentationMask` was only 256×144 = 36,864 pixels
5. Writing beyond index 36,864 caused buffer overflow / corrupted pixels

## Fix
Changed line 190 from `PROCESSING_WIDTH` to `PROCESSING_HEIGHT` for consistency with the rest of the codebase.

## Test plan
- Manual test on Firefox with background blur/virtual background enabled
- Verify no visual artifacts appear
- Verify background effect works correctly