### PR TITLE
🐛(frontend) fix hand icon and queue position aligment and position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 - ♿(frontend) improve chat toast a11y for screen readers #1109
 - ♿(frontend) improve ui and qria labels for help article links #1108
 
+### Fixed
+
+- 🐛(frontend) fix hand icon and queue position aligment and position #1119
+
 ## [1.10.0] - 2026-03-05
 
 ### Changed

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -183,7 +183,13 @@ export const ParticipantTile: (
                       }}
                     >
                       {isHandRaised && !isScreenShare && (
-                        <span>
+                        <span
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: '0.1rem',
+                          }}
+                        >
                           <span>{positionInQueue}</span>
                           <RiHand
                             color="black"


### PR DESCRIPTION
## Purpose

Fix vertical misalignment between the hand icon and the queue position number in the participant tile metadata (raised hand badge).

<img width="587" height="262" alt="iconposition" src="https://github.com/user-attachments/assets/e8e30ebc-37e6-40c2-8ae7-9bb56561aeb6" />


## Proposal

- [x] Use `display: inline-flex` and `alignItems: center` on the wrapper span