### PR TITLE
🔨(docker) set file permissions to docker user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - ♿(frontend) improve chat toast a11y for screen readers #1109
 - ♿(frontend) improve ui and qria labels for help article links #1108
 - 🔨(python-env) migrate meet main app to UV #1120
+- 🔨(docker) set file permissions to docker user #1121
 
 ## [1.10.0] - 2026-03-05
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,8 @@ COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
 RUN chmod g=u /etc/passwd
 
 # Copy the application from the builder
-COPY --from=back-builder /app /app
+ARG DOCKER_USER
+COPY --chown=${DOCKER_USER} --from=back-builder /app /app
 
 WORKDIR /app
 

--- a/bin/Tiltfile
+++ b/bin/Tiltfile
@@ -14,11 +14,16 @@ if DEV_ENV == 'dev-keycloak':
 def clean_old_images(image_name):
     local('docker images -q %s | tail -n +2 | xargs -r docker rmi' % image_name)
 
+
+uid = str(local('id -u', quiet=True)).strip()
+gid = str(local('id -g', quiet=True)).strip()
+DOCKER_USER = uid + ":" + gid
+
 docker_build(
     'localhost:5001/meet-backend:latest',
     context='..',
     dockerfile='../Dockerfile',
-    build_args={'DOCKER_USER': '1001:127'},
+    build_args={'DOCKER_USER': DOCKER_USER},
     only=['./src/backend', './src/mail', './docker'],
     target = 'backend-production',
     live_update=[
@@ -34,7 +39,7 @@ clean_old_images('localhost:5001/meet-backend')
 docker_build(
     'localhost:5001/meet-frontend-dinum:latest',
     context='..',
-    build_args={'DOCKER_USER': '1001:127'},
+    build_args={'DOCKER_USER': DOCKER_USER},
     dockerfile='../docker/dinum-frontend/Dockerfile',
     only=['./src/frontend', './docker', './.dockerignore'],
     target = 'frontend-production',
@@ -59,7 +64,7 @@ clean_old_images('localhost:5001/meet-frontend-generic')
 docker_build(
     'localhost:5001/meet-summary:latest',
     context='../src/summary',
-    build_args={'DOCKER_USER': '1001:127'},
+    build_args={'DOCKER_USER': DOCKER_USER},
     dockerfile='../src/summary/Dockerfile',
     only=['.'],
     target = 'production',
@@ -72,7 +77,7 @@ clean_old_images('localhost:5001/meet-summary')
 docker_build(
     'localhost:5001/meet-agents:latest',
     context='../src/agents',
-    build_args={'DOCKER_USER': '1001:127'},
+    build_args={'DOCKER_USER': DOCKER_USER},
     dockerfile='../src/agents/Dockerfile',
     only=['.'],
     target = 'production',


### PR DESCRIPTION
Set the app related files as owned by the docker user the image was build with. This fixes a sync permission error in tilt.

Also improved tilt setup so that correct uid / gid are infered for the build args.
