### PR TITLE
🔨(tilt) use default user in dev

### DIFF
--- a/bin/Tiltfile
+++ b/bin/Tiltfile
@@ -18,7 +18,6 @@ docker_build(
     'localhost:5001/meet-backend:latest',
     context='..',
     dockerfile='../Dockerfile',
-    build_args={'DOCKER_USER': '1001:127'},
     only=['./src/backend', './src/mail', './docker'],
     target = 'backend-production',
     live_update=[
@@ -34,7 +33,6 @@ clean_old_images('localhost:5001/meet-backend')
 docker_build(
     'localhost:5001/meet-frontend-dinum:latest',
     context='..',
-    build_args={'DOCKER_USER': '1001:127'},
     dockerfile='../docker/dinum-frontend/Dockerfile',
     only=['./src/frontend', './docker', './.dockerignore'],
     target = 'frontend-production',
@@ -59,7 +57,6 @@ clean_old_images('localhost:5001/meet-frontend-generic')
 docker_build(
     'localhost:5001/meet-summary:latest',
     context='../src/summary',
-    build_args={'DOCKER_USER': '1001:127'},
     dockerfile='../src/summary/Dockerfile',
     only=['.'],
     target = 'production',
@@ -72,7 +69,6 @@ clean_old_images('localhost:5001/meet-summary')
 docker_build(
     'localhost:5001/meet-agents:latest',
     context='../src/agents',
-    build_args={'DOCKER_USER': '1001:127'},
     dockerfile='../src/agents/Dockerfile',
     only=['.'],
     target = 'production',


### PR DESCRIPTION
This change avoids permission issues when syncing files with tilt.