### PR TITLE
🌐(frontend) improve German translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - ♿️(frontend) improve MoreLink a11y and UX on home page #1112
 - ♿(frontend) improve chat toast a11y for screen readers #1109
 - ♿(frontend) improve ui and qria labels for help article links #1108
+- 🌐(frontend) improve German translation #1125
 
 ### Fixed
 

--- a/src/frontend/src/locales/de/accessibility.json
+++ b/src/frontend/src/locales/de/accessibility.json
@@ -8,12 +8,12 @@
     },
     "scope": "Diese Erklärung zur Barrierefreiheit gilt für die Website visio.numerique.gouv.fr",
     "complianceStatus": {
-      "title": "Stand der Vereinbarkeit",
+      "title": "Stand der Gesetzeskonformität",
       "body": "visio.numerique.gouv.fr ist nicht konform mit RGAA 4.1. Die Website wurde noch nicht geprüft. Das Team bemüht sich jedoch, eine für alle zugängliche Seite gemäß den Empfehlungen des RGAA zu erstellen."
     },
     "improvement": {
       "title": "Verbesserung und Kontakt",
-      "body": "Wenn Sie auf Inhalte oder Dienste nicht zugreifen können, können Sie die verantwortliche Person von lasuite.numerique.gouv.fr kontaktieren, um eine barrierefreie Alternative zu erhalten oder die Inhalte in einer anderen Form zu bekommen.",
+      "body": "Wenn du auf Inhalte oder Dienste nicht zugreifen können, kannst du die verantwortliche Person von lasuite.numerique.gouv.fr kontaktieren, um eine barrierefreie Alternative zu erhalten oder die Inhalte in einer anderen Form zu bekommen.",
       "contact": {
         "email": "E-Mail: visio@numerique.gouv.fr",
         "address": "Adresse: DINUM, 20 avenue de Ségur, 75007 Paris"
@@ -22,11 +22,11 @@
     },
     "recourse": {
       "title": "Rechtsbehelfe",
-      "introduction": "Dieses Verfahren ist in folgendem Fall zu verwenden: Sie haben der für die Website zuständigen Stelle ein Problem mit der Barrierefreiheit gemeldet, das Sie daran hindert, auf Inhalte oder Dienste des Portals zuzugreifen, und keine zufriedenstellende Antwort erhalten.",
+      "introduction": "Dieses Verfahren ist in folgendem Fall zu verwenden: Du hast der für die Website zuständigen Stelle ein Problem mit der Barrierefreiheit gemeldet, das dich daran hindert, auf Inhalte oder Dienste des Portals zuzugreifen, und keine zufriedenstellende Antwort erhalten.",
       "options": {
-        "intro": "Sie können:",
-        "option1": "Dem*der Beauftragten für Rechte eine Nachricht schreiben",
-        "option2": "Den*die Vertreter*in des*der Beauftragten für Rechte in Ihrer Region kontaktieren",
+        "intro": "Du kannst:",
+        "option1": "Dem*der Rechtsbeauftragten eine Nachricht schreiben",
+        "option2": "Den*die Vertreter*in des*der Rechtsbeauftragten in Ihrer Region kontaktieren",
         "option3": "Einen Brief per Post senden (kostenfrei, ohne Briefmarke): </br> Défenseur des droits, Libre réponse 71120, 75342 Paris CEDEX 07"
       }
     }

--- a/src/frontend/src/locales/de/global.json
+++ b/src/frontend/src/locales/de/global.json
@@ -6,8 +6,8 @@
     "heading": "Beim Laden der Seite ist ein Fehler aufgetreten"
   },
   "feedback": {
-    "context": "Ihr Feedback prägt das Produkt!",
-    "cta": "Teilen Sie uns Ihre Meinung mit - neues Fenster"
+    "context": "Dein Feedback gestaltet das Produkt!",
+    "cta": "Teile uns deine Meinung mit – neuer Tab"
   },
   "forbidden": {
     "heading": "Zugriff verweigert"
@@ -17,13 +17,13 @@
   "login": {
     "buttonLabel": "Anmelden",
     "proconnectButtonLabel": "Mit ProConnect anmelden",
-    "proconnectLinkLabel": "Was ist ProConnect? – neues Fenster",
+    "proconnectLinkLabel": "Was ist ProConnect? – neuer Tab",
     "proconnectLink": "Was ist ProConnect?"
   },
   "logout": "Abmelden",
   "notFound": {
-    "heading": "Überprüfen Sie Ihren Meeting-Code",
-    "body": "Stellen Sie sicher, dass Sie den richtigen Meeting-Code in der URL eingegeben haben. Beispiel:"
+    "heading": "Überprüfe deinen Meeting-Code",
+    "body": "Stelle sicher, dass du den richtigen Meeting-Code in der URL eingegeben haben. Beispiel:"
   },
   "selected": "ausgewählt",
   "submit": "OK",
@@ -38,16 +38,16 @@
       "accessibility": "Barrierefreiheit: nicht konform",
       "ariaLabel": "neues Fenster",
       "codeAnnotation": "Unser Code ist offen und verfügbar in diesem",
-      "code": "Open-Source-Code-Repository",
-      "technicalDetails": "Technisches Datenblatt",
+      "code": "Open-Source-Repository",
+      "technicalDetails": "Technische Angaben",
       "termsOfService": "Nutzungsbedingungen"
     },
     "mentions": "Sofern nicht anders angegeben, sind die Inhalte dieser Website verfügbar unter der",
     "license": "Etalab 2.0 Lizenz"
   },
   "loginHint": {
-    "title": "Melden Sie sich mit Ihrem Konto an",
-    "body": "Statt zu warten, melden Sie sich mit Ihrem ProConnect-Konto an.",
+    "title": "Melde dich mit deinem Konto an",
+    "body": "Melde dich mit deinem Konto an, statt zu warten.",
     "button": {
       "ariaLabel": "Hinweis schließen",
       "label": "OK"
@@ -55,7 +55,7 @@
   },
   "skipLink": "Zum Hauptinhalt springen",
   "clipboardContent": {
-    "url": "Um an der Videokonferenz teilzunehmen, klicken Sie auf diesen Link: {{roomUrl}}",
-    "numberAndPin": "Um telefonisch teilzunehmen, wählen Sie {{phoneNumber}} und geben Sie diesen Code ein: {{pinCode}}"
+    "url": "Um an der Videokonferenz teilzunehmen, folge diesem Link: {{roomUrl}}",
+    "numberAndPin": "Um per Telefon teilzunehmen, wähle {{phoneNumber}} und gib diesen Code ein: {{pinCode}}"
   }
 }

--- a/src/frontend/src/locales/de/home.json
+++ b/src/frontend/src/locales/de/home.json
@@ -1,31 +1,31 @@
 {
   "createMeeting": "Meeting erstellen",
   "heading": "Einfache und sichere Videokonferenzen",
-  "intro": "Kommunizieren und arbeiten Sie mühelos, ohne Ihre digitale Souveränität zu gefährden",
-  "joinInputError": "Verwenden Sie einen Meeting-Link oder -Code. Beispiele:",
+  "intro": "Kommuniziere und arbeite mühelos, ohne deine digitale Souveränität zu gefährden",
+  "joinInputError": "Verwende einen Meeting-Link oder -Code. Beispiele:",
   "joinInputExample": "URL oder 10-stelliger Code",
   "joinInputLabel": "Meeting-Link",
   "joinInputSubmit": "Meeting beitreten",
   "joinMeeting": "Meeting beitreten",
-  "joinMeetingTipContent": "Sie können einem Meeting beitreten, indem Sie den vollständigen Link in die Adressleiste Ihres Browsers einfügen.",
-  "joinMeetingTipHeading": "Wussten Sie schon?",
-  "loginToCreateMeeting": "Melden Sie sich an, um ein Meeting zu erstellen",
-  "moreLinkLabel": "Mehr erfahren über {{appTitle}} – neues Tab",
+  "joinMeetingTipContent": "Du kannst einem Meeting beitreten, indem du den vollständigen Link in die Adressleiste deines Browsers einfügst.",
+  "joinMeetingTipHeading": "Wusstest du schon?",
+  "loginToCreateMeeting": "Melde dich an, um ein Meeting zu erstellen",
+  "moreLinkLabel": "Mehr über {{appTitle}} erfahren – neuer Tab",
   "moreLink": "Mehr erfahren",
   "moreAbout": "über {{appTitle}}",
   "createMenu": {
     "laterOption": "Meeting für später planen",
-    "instantOption": "Sofort-Meeting starten"
+    "instantOption": "Meeting sofort starten"
   },
   "laterMeetingDialog": {
-    "heading": "Ihre Zugangsdaten",
-    "description": "Teilen Sie diese Informationen mit den Gästen. Sie können dem Meeting beitreten, ohne sich anmelden zu müssen. Dieses Meeting ist dauerhaft und kann wiederverwendet werden.",
+    "heading": "Zugangsdaten",
+    "description": "Teile diese Informationen mit den Gästen. Sie können dem Meeting beitreten, ohne sich anmelden zu müssen. Dieses Meeting ist dauerhaft und kann wiederverwendet werden.",
     "permissions": "Personen mit diesem Link benötigen keine Genehmigung, um diesem Meeting beizutreten.",
     "copy": "Informationen kopieren",
     "copied": "Informationen kopiert",
     "copyUrl": "Meeting-Link kopieren",
     "phone": {
-      "call": "Rufen Sie an:",
+      "call": "Ruf an:",
       "pinCode": "Code:"
     }
   },
@@ -45,16 +45,16 @@
       "tooltip": "Formular ausfüllen"
     },
     "slide1": {
-      "title": "Wechseln Sie zur Einfachheit. Testen Sie uns jetzt!",
-      "body": "Entdecken Sie eine intuitive und zugängliche Lösung, entwickelt für alle Mitarbeitenden im öffentlichen Dienst, ihre Partner und viele weitere."
+      "title": "Mach Schluss mit kompliziert – probier uns jetzt aus!",
+      "body": "Entdecke eine intuitive und leicht zugängliche Lösung, entwickelt für alle Mitarbeitenden im öffentlichen Dienst, ihre Partner und viele weitere."
     },
     "slide2": {
-      "title": "Gruppenanrufe ohne Einschränkungen",
-      "body": "Unbegrenzte Meeting-Dauer mit flüssiger, hochwertiger Kommunikation – unabhängig von der Gruppengröße."
+      "title": "Gruppenmeetings ohne Einschränkungen",
+      "body": "Unbegrenzte Meeting-Dauer mit flüssiger Kommunikation in hoher Qualität – unabhängig von der Gruppengröße."
     },
     "slide3": {
-      "title": "Verwandeln Sie Ihre Meetings mit KI",
-      "body": "Erhalten Sie präzise und verwertbare Transkripte zur Steigerung Ihrer Produktivität. Funktion in der Beta – jetzt testen!"
+      "title": "Verwandele deine Meetings mit KI",
+      "body": "Erhalte präzise und verwertbare Transkripte zur Steigerung deiner Produktivität. Beta-Funktion – jetzt testen!"
     },
     "carouselLabel": "Einführungs-Diashow",
     "slidePosition": "Folie {{current}} von {{total}}"

--- a/src/frontend/src/locales/de/legals.json
+++ b/src/frontend/src/locales/de/legals.json
@@ -1,8 +1,8 @@
 {
   "title": "Rechtliche Hinweise",
   "creator": {
-    "title": "Herausgeber",
-    "body": "Der Visio-Dienst wird herausgegeben von der Interministeriellen Digitaldirektion des Staates (DINUM) mit Sitz:",
+    "title": "Herausgebende",
+    "body": "Der Visio-Dienst wird herausgegeben von der Interministeriellen Digitaldirektion Frankreichs (DINUM) mit Sitz:",
     "contact": {
       "title": "Kontaktdaten",
       "address": "20 avenue de Ségur",
@@ -31,7 +31,7 @@
     "title": "Wiederverwendung von Inhalten und Links",
     "body1": "Sofern nicht ausdrücklich anders angegeben und geistige Eigentumsrechte Dritter betroffen sind, werden die Inhalte dieser Website unter der ",
     "license": "offenen Lizenz Etalab 2.0",
-    "body2": "bereitgestellt. Insbesondere dürfen Sie diese Inhalte frei vervielfältigen, kopieren, ändern, extrahieren, umwandeln, verbreiten, weiterleiten, veröffentlichen, übertragen und nutzen – unter der Bedingung, dass die Quelle und das Datum der letzten Aktualisierung genannt werden und Dritte nicht durch die Informationen in die Irre geführt werden.",
-    "body3": "Jede öffentliche oder private Website ist berechtigt, ohne vorherige Genehmigung, einen Link (einschließlich eines Deep Links) zu den auf dieser Website veröffentlichten Informationen zu setzen."
+    "body2": "bereitgestellt. Insbesondere dürfen diese Inhalte frei vervielfältigt, kopiert, geändert, extrahiert, umgewandelt, verbreitet, weitergeleitet, veröffentlicht, übertragen und genutzt werden – unter der Bedingung, dass die Quelle und das Datum der letzten Aktualisierung genannt werden und Dritte nicht durch die Informationen in die Irre geführt werden.",
+    "body3": "Jede öffentliche oder private Website ist berechtigt, ohne vorherige Genehmigung, Links (einschließlich Deep Links) zu den auf dieser Website veröffentlichten Informationen zu setzen."
   }
 }

--- a/src/frontend/src/locales/de/notifications.json
+++ b/src/frontend/src/locales/de/notifications.json
@@ -1,5 +1,5 @@
 {
-  "defaultName": "Ein Mitwirkender",
+  "defaultName": "Eine Person",
   "joined": {
     "description": "{{name}} ist dem Raum beigetreten"
   },
@@ -7,47 +7,47 @@
     "description": "{{name}} hat die Hand gehoben.",
     "cta": "Warteliste öffnen"
   },
-  "muted": "{{name}} hat dein Mikrofon stummgeschaltet. Kein Teilnehmer kann dich hören.",
+  "muted": "{{name}} hat dein Mikrofon stummgeschaltet.",
   "openChat": "Chat öffnen",
   "chatMessageReceived": "{{name}} sagt: {{message}}",
   "lowerHand": {
-    "auto": "Es scheint, dass du angefangen hast zu sprechen, daher wird deine Hand gesenkt.",
+    "auto": "Du hast begonnen zu sprechen – deine Hand wird daher automatisch gesenkt.",
     "dismiss": "Hand oben lassen"
   },
   "reaction": {
     "description": "{{name}} hat mit {{emoji}} reagiert"
   },
   "permissionsRemoved": {
-    "camera": "Der Organisator hat das Video für alle Teilnehmer deaktiviert.",
-    "microphone": "Der Organisator hat das Mikrofon für alle Teilnehmer deaktiviert.",
-    "screen_share": "Der Organisator hat die Bildschirmfreigabe für alle Teilnehmer deaktiviert."
+    "camera": "Die Moderation hat das Video für alle Teilnehmenden deaktiviert.",
+    "microphone": "Die Moderation hat das Mikrofon für alle Teilnehmenden deaktiviert.",
+    "screen_share": "Die Moderation hat die Bildschirmfreigabe für alle Teilnehmenden deaktiviert."
   },
   "waitingParticipants": {
-    "one": "Eine Person möchte diesem Anruf beitreten.",
-    "several": "Mehrere Personen möchten diesem Anruf beitreten.",
+    "one": "Eine Person möchte diesem Meeting beitreten.",
+    "several": "Mehrere Personen möchten diesem Meeting beitreten.",
     "open": "Öffnen",
-    "accept": "Annehmen"
+    "accept": "Hereinlassen"
   },
   "transcript": {
-    "started": "{{name}} hat die Transkription des Treffens gestartet.",
-    "stopped": "{{name}} hat die Transkription des Treffens gestoppt.",
+    "started": "{{name}} hat die Meeting-Transkription gestartet.",
+    "stopped": "{{name}} hat die Meeting-Transkription gestoppt.",
     "limitReached": "Die Transkription hat die maximal zulässige Dauer überschritten und wird automatisch gespeichert.",
-    "requested": "{{name}} will die Transkription starten."
+    "requested": "{{name}} möchte die Meeting-Transkription starten."
   },
   "screenRecording": {
-    "started": "{{name}} hat die Aufzeichnung des Treffens gestartet.",
-    "stopped": "{{name}} hat die Aufzeichnung des Treffens gestoppt.",
+    "started": "{{name}} hat die Meeting-Aufzeichnung gestartet.",
+    "stopped": "{{name}} hat die Meeting-Aufzeichnung gestoppt.",
     "limitReached": "Die Aufzeichnung hat die maximal zulässige Dauer überschritten und wird automatisch gespeichert.",
-    "requested": "{{name}} will die Aufnahme starten."
+    "requested": "{{name}} möchte die Meeting-Aufzeichnung starten."
   },
   "recordingSave": {
     "transcript": {
-      "message": "Wir finalisieren Ihre Aufnahme! Sie erhalten eine E-Mail an <strong>{{email}}</strong>, sobald die Transkription fertig ist.",
-      "default": "Wir finalisieren Ihre Aufnahme! Sie erhalten eine E-Mail, sobald die Transkription fertig ist."
+      "message": "Deine Transkription wird gespeichert! Du erhältst eine E-Mail auf <strong>{{email}}</strong>, sobald die Transkription bereit ist.",
+      "default": "Deine Transkription wird gespeichert! Du erhältst das Transkript per E-Mail, sobald es bereit ist."
     },
     "screenRecording": {
-      "message": "Wir finalisieren Ihre Aufnahme! Sie erhalten eine E-Mail an <strong>{{email}}</strong>, sobald sie fertig ist.",
-      "default": "Wir finalisieren Ihre Aufnahme! Sie erhalten eine E-Mail, sobald sie fertig ist."
+      "message": "Deine Aufzeichnung wird gespeichert! Du erhältst eine E-Mail auf <strong>{{email}}</strong>, sobald sie bereit ist.",
+      "default": "Deine Aufzeichnung wird gespeichert! Du erhältst eine E-Mail, sobald sie bereit ist."
     }
   },
   "openMenu": "Menü öffnen"

--- a/src/frontend/src/locales/de/recording.json
+++ b/src/frontend/src/locales/de/recording.json
@@ -1,7 +1,7 @@
 {
   "error": {
     "title": "Aufzeichnung nicht verfügbar",
-    "body": "Die Aufzeichnung ist nicht verfügbar oder wurde möglicherweise gelöscht. Nur der Organisator der Besprechung hat Zugriff darauf. Wenden Sie sich bei Bedarf gerne an ihn."
+    "body": "Die Aufzeichnung ist nicht verfügbar oder wurde möglicherweise gelöscht. Nur die*der Organisator:in der Besprechung hat Zugriff darauf. Wende dich bei Bedarf gerne an die Person."
   },
   "expired": {
     "title": "Aufzeichnung abgelaufen",
@@ -9,20 +9,20 @@
   },
   "authentication": {
     "title": "Authentifizierung erforderlich",
-    "body": "Bitte melden Sie sich an, um auf diese Aufzeichnung zuzugreifen."
+    "body": "Bitte melde dich sich an, um auf diese Aufzeichnung zuzugreifen."
   },
   "unsaved": {
     "title": "Download nicht verfügbar",
-    "body": "Diese Aufzeichnung ist noch nicht zum Herunterladen bereit. Bitte versuchen Sie es später erneut."
+    "body": "Diese Aufzeichnung ist noch nicht zum Herunterladen bereit. Bitte versuche es später erneut."
   },
   "success": {
-    "title": "Ihre Aufzeichnung ist bereit!",
-    "body": "Aufzeichnung des Treffens {{room}} vom {{created_at}}.",
+    "title": "Deine Aufzeichnung ist bereit!",
+    "body": "Aufzeichnung des Meetings {{room}} vom {{created_at}}.",
     "expiration": "Achtung, diese Aufzeichnung wird nach {{expiration_days}} Tag(en) gelöscht.",
     "button": "Herunterladen",
     "warning": {
       "title": "Linkfreigabe deaktiviert",
-      "body": "Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur Organisatoren können sie herunterladen."
+      "body": "Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur Organisator:innen können sie herunterladen."
     }
   }
 }

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -1,17 +1,17 @@
 {
   "feedback": {
     "heading": {
-      "normal": "Sie haben das Meeting verlassen",
-      "duplicateIdentity": "Sie haben dem Meeting von einem anderen Gerät aus beigetreten",
-      "participantRemoved": "Sie wurden von einem Administrator aus dem Anruf entfernt"
+      "normal": "Du hast das Meeting verlassen",
+      "duplicateIdentity": "Du bist dem Meeting von einem anderen Gerät aus beigetreten",
+      "participantRemoved": "Du wurdest von der*dem Organisator:in aus dem Meeting entfernt"
     },
     "home": "Zur Startseite zurückkehren",
     "back": "Dem Meeting erneut beitreten"
   },
   "selectDevice": {
     "loading": "Laden…",
-    "select": "Wählen Sie einen Wert",
-    "permissionsNeeded": "Genehmigung erforderlich",
+    "select": "Wähle einen Wert",
+    "permissionsNeeded": "Berechtigung erforderlich",
     "settings": {
       "audio": "Audioeinstellungen",
       "video": "Videoeinstellungen"
@@ -19,7 +19,7 @@
     "effects": "Effekte anwenden",
     "videoinput": {
       "choose": "Kamera auswählen",
-      "permissionsNeeded": "Kamera auswählen - genehmigung erforderlich",
+      "permissionsNeeded": "Kamera auswählen – Berechtigung erforderlich",
       "disable": "Kamera deaktivieren",
       "enable": "Kamera aktivieren",
       "turnedOff": "Kamera deaktiviert",
@@ -29,7 +29,7 @@
     },
     "audioinput": {
       "choose": "Mikrofon auswählen",
-      "permissionsNeeded": "Mikrofon auswählen - genehmigung erforderlich",
+      "permissionsNeeded": "Mikrofon auswählen – Berechtigung erforderlich",
       "disable": "Mikrofon deaktivieren",
       "enable": "Mikrofon aktivieren",
       "turnedOff": "Mikrofon deaktiviert",
@@ -37,30 +37,30 @@
       "label": "Mikrofon"
     },
     "audiooutput": {
-      "choose": "Lautsprecher auswählen",
-      "permissionsNeeded": "Lautsprecher auswählen - genehmigung erforderlich"
+      "choose": "Audioausgabe auswählen",
+      "permissionsNeeded": "Audioausgabe auswählen – Berechtigung erforderlich"
     }
   },
   "join": {
     "effects": {
       "description": "Effekte anwenden",
       "title": "Effekte",
-      "subTitle": "Konfigurieren Sie die Effekte Ihrer Kamera."
+      "subTitle": "Konfiguriere die Effekte deiner Kamera."
     },
     "heading": "Dem Meeting beitreten?",
     "joinLabel": "Beitreten",
     "joinMeeting": "Meeting beitreten",
     "toggleOff": "Klicken, um auszuschalten",
     "toggleOn": "Klicken, um einzuschalten",
-    "usernameHint": "Wird anderen Teilnehmern angezeigt",
-    "usernameLabel": "Ihr Name",
+    "usernameHint": "Wird anderen Teilnehmenden angezeigt",
+    "usernameLabel": "Dein Name",
     "errors": {
-      "usernameEmpty": "Ihr Name darf nicht leer sein"
+      "usernameEmpty": "Dein Name darf nicht leer sein"
     },
     "cameraDisabled": "Kamera ist deaktiviert.",
     "cameraStarting": "Kamera wird gestartet…",
-    "cameraNotGranted": "Möchten Sie, dass andere Sie während der Besprechung sehen können?",
-    "cameraAndMicNotGranted": "Möchten Sie, dass andere Sie während der Besprechung sehen und hören können?",
+    "cameraNotGranted": "Möchtest du, dass andere dich während des Meetings sehen können?",
+    "cameraAndMicNotGranted": "Möchtest du, dass andere dich während des Meetings sehen und hören können?",
     "permissionsButton": {
       "cameraAndMicNotGranted": "Zugriff auf Kamera und Mikrofon erlauben",
       "cameraNotGranted": "Zugriff auf Kamera erlauben"
@@ -71,28 +71,28 @@
     },
     "waiting": {
       "title": "Beitrittsanfrage wird gesendet...",
-      "body": "Sie können diesem Anruf beitreten, sobald jemand Sie autorisiert"
+      "body": "Du kannst diesem Meeting beitreten, sobald deine Anfrage angenommen wird"
     },
     "denied": {
-      "title": "Sie können diesem Anruf nicht beitreten",
-      "body": "Ihre Beitrittsanfrage wurde abgelehnt."
+      "title": "Du kannst diesem Meeting nicht beitreten",
+      "body": "Deine Beitrittsanfrage wurde abgelehnt."
     },
     "timeoutInvite": {
-      "title": "Sie können diesem Anruf nicht beitreten",
-      "body": "Niemand hat auf Ihre Anfrage reagiert"
+      "title": "Du kannst diesem Meeting nicht beitreten",
+      "body": "Niemand hat auf deine Anfrage reagiert"
     }
   },
-  "leaveRoomPrompt": "Dadurch verlassen Sie das Meeting.",
+  "leaveRoomPrompt": "Hiermit verlässt du das Meeting.",
   "shareDialog": {
-    "copy": "Informationen kopieren",
+    "copy": "Infos kopieren",
     "copyUrl": "Link kopieren",
-    "copied": "Informationen kopiert",
-    "heading": "Ihr Meeting ist bereit",
-    "description": "Teilen Sie diesen Link mit Personen, die Sie zum Meeting einladen möchten.",
+    "copied": "Infos kopiert",
+    "heading": "Dein Meeting ist bereit",
+    "description": "Teile diesen Link mit Personen, die du zum Meeting einladen möchten.",
     "permissions": "Personen mit diesem Link benötigen keine Erlaubnis, um diesem Meeting beizutreten.",
     "closeDialog": "Dialogfenster schließen",
     "phone": {
-      "call": "Rufen Sie an:",
+      "call": "Ruf an:",
       "pinCode": "Code:"
     }
   },
@@ -108,62 +108,62 @@
         "videoinput": "Kamera konnte nicht aktiviert werden"
       },
       "body": {
-        "audioinput": "Ihr Mikrofon wird bereits in einem anderen Tab oder von einer anderen Anwendung verwendet, was die Aktivierung in diesem Videoanruf verhindert. Wenn Sie möchten, schließen Sie den anderen Tab oder die Anwendung, um es hier zu verwenden.",
-        "videoinput": "Ihre Kamera wird bereits in einem anderen Tab oder von einer anderen Anwendung verwendet, was die Aktivierung in diesem Videoanruf verhindert. Wenn Sie möchten, schließen Sie den anderen Tab oder die Anwendung, um sie hier zu verwenden."
+        "audioinput": "Dein Mikrofon wird bereits in einem anderen Tab oder von einer anderen App verwendet. Dies verhindert die Aktivierung in diesem Meeting. Wenn du dein Mikrofon hier verwenden möchtest, schließe den anderen Tab oder die App.",
+        "videoinput": "Deine Kamera wird bereits in einem anderen Tab oder von einer anderen App verwendet. Dies verhindert die Aktivierung in diesem Meeting. Wenn du deine Kamera hier verwenden möchtest, schließe den anderen Tab oder die App."
       }
     },
     "close": "OK"
   },
   "permissionErrorDialog": {
     "heading": {
-      "camera": "{{appTitle}} darf Ihre Kamera nicht verwenden",
-      "microphone": "{{appTitle}} darf Ihr Mikrofon nicht verwenden",
-      "cameraAndMicrophone": "{{appTitle}} darf weder Ihr Mikrofon noch Ihre Kamera verwenden",
+      "camera": "{{appTitle}} hat keine Berechtigung, um deine Kamera zu verwenden",
+      "microphone": "{{appTitle}} hat keine Berechtigung, um dein Mikrofon zu verwenden",
+      "cameraAndMicrophone": "{{appTitle}} hat keine Berechtigung, um dein Mikrofon und deine Kamera zu verwenden",
       "default": "{{appTitle}} hat keine Berechtigung für bestimmte Zugriffe"
     },
     "body": {
       "openMenu": {
-        "others": "Klicken Sie auf das Einstellungen-Symbol ICON_PLACEHOLDER in der Adressleiste Ihres Browsers",
-        "safari": "Klicken Sie auf das Menü 'Safari' und öffnen Sie 'Einstellungen für {{appDomain}}'."
+        "others": "Klicke das Einstellungs-Symbol ICON_PLACEHOLDER in der Adressleiste deines Browsers",
+        "safari": "Klicke auf das Menü 'Safari' und öffne 'Einstellungen für {{appDomain}}'."
       },
       "details": {
         "camera": "Zugriff auf die Kamera erlauben",
         "microphone": "Zugriff auf das Mikrofon erlauben",
         "cameraAndMicrophone": "Zugriff auf Kamera und Mikrofon erlauben",
-        "default": "Aktivieren Sie die erforderlichen Berechtigungen."
+        "default": "Erlaube die erforderlichen Berechtigungen."
       }
     }
   },
   "permissionsButton": {
     "tooltip": "Mehr Infos",
-    "ariaLabel": "Berechtigungsproblem. Mehr Infos anzeigen"
+    "ariaLabel": "Problem mit Berechtigungen. Mehr Infos anzeigen"
   },
   "error": {
     "createRoom": {
       "heading": "Authentifizierung erforderlich",
-      "body": "Dieser Raum wurde noch nicht erstellt. Bitte authentifizieren Sie sich, um ihn zu erstellen, oder warten Sie, bis ein authentifizierter Benutzer dies tut."
+      "body": "Dieser Raum wurde noch nicht erstellt. Bitte authentifiziere dich, um ihn zu erstellen, oder warte, bis eine authentifizierte Person dies tut."
     },
     "screenShare": {
       "title": "Bildschirmfreigabe nicht möglich",
       "ariaLabel": "Bildschirmfreigabe nicht möglich",
-      "message": "Ihr Browser darf möglicherweise den Bildschirm Ihres Computers nicht aufzeichnen.",
-      "macInstructions": "Gehen Sie zu Ihren",
+      "message": "Deinem Browser fehlt möglicherweise die Berechtigung, den Bildschirm deines Geräts abzugreifen.",
+      "macInstructions": "Gehe zu den",
       "macSystemPreferences": "Systemeinstellungen",
-      "helpLinkText": "Weitere Informationen finden Sie unter",
-      "helpLinkLabel": "Präsentationsproblem",
+      "helpLinkText": "Weitere Informationen findest du unter",
+      "helpLinkLabel": "Bildschirmfreigabeproblem",
       "closeButton": "Schließen",
-      "newTab": "Neues Fenster"
+      "newTab": "Neuer Tab"
     }
   },
   "isIdleDisconnectModal": {
     "title": "Bist du noch da?",
-    "body": "Du bist der einzige Teilnehmer. Dieses Gespräch endet in {{duration}}. Möchtest du das Gespräch fortsetzen?",
+    "body": "Du bist die*der einzige Teilnehmende. Diese Meeting endet in {{duration}}. Möchtest du das Meeting fortsetzen?",
     "settingsPrefix": "Um diese Nachricht nicht mehr zu sehen, gehe zu",
     "settingsLink": "Einstellungen > Allgemein",
     "settingsSuffix": ".",
-    "stayButton": "Gespräch fortsetzen",
+    "stayButton": "Meeting fortsetzen",
     "leaveButton": "Jetzt verlassen",
-    "countdownAnnouncement": "Das Gespräch endet in {{duration}}."
+    "countdownAnnouncement": "Das Meeting endet in {{duration}}."
   },
   "controls": {
     "microphone": "Mikrofon",
@@ -201,8 +201,8 @@
     "participants": {
       "open": "Alle ausblenden",
       "closed": "Alle anzeigen",
-      "count_one": "{{count}} Teilnehmer",
-      "count_other": "{{count}} Teilnehmer"
+      "count_one": "{{count}} Teilnehmende",
+      "count_other": "{{count}} Teilnehmende"
     },
     "tools": {
       "open": "Weitere Tools ausblenden",
@@ -217,16 +217,16 @@
       "button": "Reaktion senden",
       "send": "Reaktion {{emoji}} senden",
       "announce": "{{name}} : {{emoji}}",
-      "you": "Sie",
+      "you": "du",
       "emojis": {
         "thumbs-up": "Daumen hoch",
         "thumbs-down": "Daumen runter",
         "clapping-hands": "Klatschende Hände",
-        "red-heart": "rotes Herz",
+        "red-heart": "Rotes Herz",
         "face-with-tears-of-joy": "Gesicht mit Freudentränen",
-        "face-with-open-mouth": "überraschter Gesichtsausdruck",
-        "party-popper": "Party-Popper",
-        "folded-hands": "gefaltete Hände"
+        "face-with-open-mouth": "Überraschter Gesichtsausdruck",
+        "party-popper": "Konfettikanone",
+        "folded-hands": "Gefaltete Hände"
       }
     }
   },
@@ -237,7 +237,7 @@
       "settings": "Einstellungen",
       "screenRecording": "Aufzeichnung",
       "transcript": "Transkription",
-      "username": "Ihren Namen aktualisieren",
+      "username": "Deinen Namen aktualisieren",
       "effects": "Effekte anwenden",
       "switchCamera": "Kamera wechseln",
       "fullscreen": {
@@ -248,9 +248,9 @@
     }
   },
   "effects": {
-    "activateCamera": "Ihre Kamera ist deaktiviert. Wählen Sie eine Option, um sie zu aktivieren.",
-    "cameraDisabled": "Ihre Kamera ist deaktiviert.",
-    "notAvailable": "Videoeffekte werden bald in Ihrem Browser verfügbar sein. Wir arbeiten daran! In der Zwischenzeit können Sie Google Chrome für die beste Leistung oder Firefox verwenden :(",
+    "activateCamera": "Deine Kamera ist deaktiviert. Wähle eine Option, um sie zu aktivieren.",
+    "cameraDisabled": "Deine Kamera ist deaktiviert.",
+    "notAvailable": "Videoeffekte werden bald in deinem Browser verfügbar sein. Wir arbeiten daran! In der Zwischenzeit kannst du Google Chrome für die beste Leistung oder Firefox verwenden :(",
     "heading": "Unschärfe",
     "clear": "Effekt deaktivieren",
     "blur": {
@@ -300,8 +300,8 @@
     "ariaLabel": "Seitenleiste",
     "backToTools": "Zurück zu den Meeting-Tools",
     "heading": {
-      "participants": "Teilnehmer",
-      "effects": "Effekte",
+      "participants": "Teilnehmende",
+      "effects": "Hintergrund & Effekte",
       "chat": "Nachrichten im Chat",
       "transcript": "Transkribieren",
       "screenRecording": "Aufzeichnen",
@@ -310,8 +310,8 @@
       "info": "Meeting-Informationen"
     },
     "content": {
-      "participants": "Teilnehmer",
-      "effects": "Effekte",
+      "participants": "Teilnehmende",
+      "effects": "Hintergrund & Effekte",
       "chat": "Nachrichten",
       "transcript": "transkribieren",
       "screenRecording": "aufzeichnen",
@@ -322,12 +322,12 @@
     "closeButton": "{{content}} ausblenden"
   },
   "chat": {
-    "disclaimer": "Die Nachrichten sind nur für Teilnehmer zum Zeitpunkt des Sendens sichtbar. Alle Nachrichten werden am Ende des Anrufs gelöscht.",
+    "disclaimer": "Die Nachrichten sind nur für Teilnehmende zum Zeitpunkt des Sendens sichtbar. Alle Nachrichten werden am Ende des Meetings gelöscht.",
     "messagesLog": "Chat-Nachrichten"
   },
   "moreTools": {
-    "body": "Greifen Sie auf weitere Tools zu, um Ihre Meetings zu verbessern.",
-    "linkAriaLabel": "Dokumentation zu den Tools öffnen - öffnet in neuem Fenster",
+    "body": "Nutze weitere Tools, um deine Meetings zu verbessern.",
+    "linkAriaLabel": "Dokumentation zu den Tools öffnen – öffnet in neuem Tab",
     "moreLink": "Dokumentation öffnen",
     "tools": {
       "transcript": {
@@ -344,77 +344,77 @@
     "roomInformation": {
       "title": "Verbindungsinformationen",
       "button": {
-        "ariaLabel": "Kopieren Sie die Informationen aus Ihrer Besprechung",
+        "ariaLabel": "Kopiere die Informationen aus dem Meeting",
         "copy": "Informationen kopieren",
         "copied": "Informationen kopiert"
       },
       "phone": {
-        "call": "Rufen Sie an:",
+        "call": "Ruf an:",
         "pinCode": "Code:"
       }
     }
   },
   "transcript": {
-    "heading": "Transkribieren Sie Ihr Meeting mit dem KI-Assistenten",
-    "body": "Transkribieren Sie bis zu {{max_duration}} Meetingdauer.",
-    "bodyWithoutMaxDuration": "Transkribieren Sie Ihr Meeting ohne Begrenzung.",
+    "heading": "Transkribiere dein Meeting mithilfe von KI",
+    "body": "Transkribiere bis zu {{max_duration}} Meetingdauer.",
+    "bodyWithoutMaxDuration": "Transkribieren dein Meeting ohne Zeitbegrenzung.",
     "details": {
-      "receiver": "Das Transkript wird an den Organisator und die Mitorganisatoren gesendet.",
+      "receiver": "Das Transkript wird an die*den Organisator:in und die Mitorganisierenden gesendet.",
       "destination": "Ein neues Dokument wird erstellt auf",
       "destinationUnknown": "Ein neues Dokument wird erstellt",
       "language": "Meeting-Sprache:",
       "recording": "Auch eine Aufzeichnung starten"
     },
     "button": {
-      "start": "Meeting transkribieren starten",
-      "stop": "Meeting transkribieren beenden",
+      "start": "Meeting-Transkription starten",
+      "stop": "Meeting-Transkription beenden",
       "saving": "Speichern…",
       "starting": "Wird gestartet…",
-      "anotherModeStarted": "Eine Aufnahme läuft. <br/> Wechseln Sie das Menü und stoppen Sie sie."
+      "anotherModeStarted": "Eine Aufnahme läuft. <br/> Wechsele das Menü und stoppe sie."
     },
     "linkMore": "Dokumentation öffnen",
-    "linkAriaLabel": "Dokumentation zur Transkription öffnen - öffnet in neuem Fenster",
+    "linkAriaLabel": "Dokumentation zur Transkription öffnen – öffnet in neuem Tab",
     "notAdminOrOwner": {
       "heading": "Zugriff eingeschränkt",
-      "body": "Aus Sicherheitsgründen kann nur der Ersteller oder ein Administrator des Meetings eine Transkription (Beta) starten.",
+      "body": "Aus Sicherheitsgründen kann nur die*der Ersteller:in bzw. Admin des Meetings eine Transkription (Beta) starten.",
       "linkMore": "Dokumentation öffnen",
-      "linkAriaLabel": "Dokumentation zum Transkriptionszugang öffnen - öffnet in neuem Fenster",
+      "linkAriaLabel": "Dokumentation zum Transkriptionszugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",
-        "body": "Nur der Ersteller des Meetings oder ein Administrator kann die Transkription starten. Melden Sie sich an, um Ihre Berechtigungen zu überprüfen."
+        "body": "Nur die*der Ersteller:in bzw. Admin kann die Transkription starten. Melde dich an, um deine Berechtigungen zu überprüfen."
       },
       "request": {
-        "heading": "Anfrage an Moderator",
-        "body": "Der Moderator wird benachrichtigt und kann die Transkription starten.",
-        "buttonLabel": "Anfordern"
+        "heading": "Transkription anfragen",
+        "body": "Die Moderation wird benachrichtigt und kann die Transkription starten.",
+        "buttonLabel": "Anfragen"
       }
     },
     "premium": {
       "heading": "Premium-Funktion",
-      "body": "Diese Funktion ist öffentlichen Bediensteten vorbehalten. Wenn Ihre E-Mail-Adresse nicht autorisiert ist, kontaktieren Sie bitte den Support, um Zugriff zu erhalten.",
+      "body": "Diese Funktion ist öffentlichen Bediensteten vorbehalten. Wenn deine E-Mail-Adresse nicht autorisiert ist, kontaktiere bitte den Support, um Zugriff zu erhalten.",
       "linkMore": "Dokumentation öffnen",
-      "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen - öffnet in neuem Fenster",
+      "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",
-        "body": "Nur der Ersteller des Meetings oder ein Administrator kann die Transkription starten. Melden Sie sich an, um Ihre Berechtigungen zu überprüfen."
+        "body": "Nur die*der Ersteller:in bzw. Admin kann die Transkription starten. Melde dich an, um deine Berechtigungen zu überprüfen."
       },
       "request": {
-        "heading": "Anfrage an Moderator",
-        "body": "Der Moderator wird benachrichtigt und kann die Transkription starten.",
+        "heading": "Transkription anfragen",
+        "body": "Die Moderation wird benachrichtigt und kann die Transkription starten.",
         "buttonLabel": "Anfordern"
       }
     }
   },
   "screenRecording": {
-    "heading": "Diesen Anruf für später aufzeichnen",
-    "body": "Zeichnen Sie bis zu {{max_duration}} des Meetings auf.",
-    "bodyWithoutMaxDuration": "Zeichnen Sie Ihr Meeting unbegrenzt auf.",
+    "heading": "Dieses Meeting für später aufzeichnen",
+    "body": "Zeichne bis zu {{max_duration}} des Meetings auf.",
+    "bodyWithoutMaxDuration": "Zeichne dein Meeting ohne Zeitbegrenzung auf.",
     "linkMore": "Dokumentation öffnen",
-    "linkAriaLabel": "Dokumentation zur Aufzeichnung öffnen - öffnet in neuem Fenster",
+    "linkAriaLabel": "Dokumentation zur Aufzeichnung öffnen – öffnet in neuem Tab",
     "details": {
-      "receiver": "Die Aufzeichnung wird an den Organisator und die Mitorganisatoren gesendet.",
+      "receiver": "Die Aufzeichnung wird an die*den Organisator:in und die Mitorganisierenden gesendet.",
       "destination": "Diese Aufzeichnung wird vorübergehend auf unseren Servern gespeichert",
       "loading": "Aufzeichnung wird gestartet",
       "linkMore": "Mehr erfahren",
@@ -425,21 +425,21 @@
       "stop": "Meeting-Aufzeichnung beenden",
       "saving": "Wird gespeichert…",
       "starting": "Wird gestartet…",
-      "anotherModeStarted": "Eine Transkription läuft. <br/> Wechseln Sie das Menü und stoppen Sie sie."
+      "anotherModeStarted": "Eine Transkription läuft. <br/> Wechsele das Menü und stoppen sie."
     },
     "notAdminOrOwner": {
       "heading": "Zugriff eingeschränkt",
-      "body": "Aus Sicherheitsgründen kann nur der Ersteller oder ein Administrator des Meetings eine Videoaufnahme (Beta) starten.",
+      "body": "Aus Sicherheitsgründen kann nur die*der Ersteller:in bzw. Admin des Meetings eine Videoaufnahme (Beta) starten.",
       "linkMore": "Dokumentation öffnen",
-      "linkAriaLabel": "Dokumentation zum Aufzeichnungszugang öffnen - öffnet in neuem Fenster",
+      "linkAriaLabel": "Dokumentation zum Aufzeichnungszugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",
-        "body": "Nur der Ersteller der Besprechung oder ein Administrator kann die Aufzeichnung starten. Melden Sie sich an, um Ihre Berechtigungen zu überprüfen."
+        "body": "Nur die*der Ersteller:in bzw. Admin kann die Aufzeichnung starten. Melde dich an, um deine Berechtigungen zu überprüfen."
       },
       "request": {
-        "heading": "Aufnahme anfordern",
-        "body": "Der Moderator wird benachrichtigt und kann die Aufnahme für Sie starten.",
+        "heading": "Aufnahme anfragen",
+        "body": "Die Moderation wird benachrichtigt und kann die Aufnahme starten.",
         "buttonLabel": "Anfrage senden"
       }
     },
@@ -454,10 +454,10 @@
     "button": "OK"
   },
   "admin": {
-    "description": "Diese Einstellungen für Organisatoren ermöglichen dir die Kontrolle über dein Meeting. Nur Organisatoren haben Zugriff auf diese Optionen.",
+    "description": "Diese Einstellungen für Organisierende ermöglichen dir die Kontrolle über dein Meeting. Nur Organisierende haben Zugriff auf diese Optionen.",
     "access": {
       "title": "Raumzugang",
-      "description": "Diese Einstellungen gelten auch für zukünftige Ausgaben dieses Meetings.",
+      "description": "Diese Einstellungen gelten auch für zukünftige Meetings in diesem Raum.",
       "type": "Zugangsarten für Meetings",
       "levels": {
         "public": {
@@ -475,28 +475,28 @@
       }
     },
     "moderation": {
-      "title": "Moderation des Meetings",
-      "description": "Diese Einstellungen beschränken die Aktionen, die Mitwirkende während des Meetings durchführen können.",
+      "title": "Meeting-Moderation",
+      "description": "Diese Einstellungen beschränken die Aktionen, die Teilnehmende während des Meetings durchführen können.",
       "microphone": {
         "label": "Mikrofon einschalten",
         "description": ""
       },
       "camera": {
-        "label": "Video aktivieren",
+        "label": "Video einschalten",
         "description": ""
       },
       "screenshare": {
-        "label": "Ihren Bildschirm teilen",
-        "description": "Wenn Sie diese Option deaktivieren, können Teilnehmer ihren Bildschirm nicht mehr teilen, und laufende Bildschirmfreigaben werden sofort beendet."
+        "label": "Bildschirm teilen",
+        "description": "Wenn du diese Option deaktivierst, können Teilnehmende ihren Bildschirm nicht mehr teilen. Laufende Bildschirmfreigaben werden sofort beendet."
       }
     }
   },
   "rating": {
     "submit": "Absenden",
-    "question": "Wie bewertest du die Qualität deines Gesprächs?",
+    "question": "Wie bewertest du die Qualität dieses Meetings?",
     "levels": {
       "min": "sehr schlecht",
-      "max": "ausgezeichnet"
+      "max": "hervorragend"
     }
   },
   "openFeedback": {
@@ -506,7 +506,7 @@
     "skip": "Überspringen"
   },
   "confirmationMessage": {
-    "heading": "Vielen Dank für deine Rückmeldung",
+    "heading": "Vielen Dank für dein Feedback",
     "body": "Unser Produktteam nimmt sich Zeit, dein Feedback sorgfältig zu prüfen. Wir melden uns so bald wie möglich bei dir."
   },
   "authenticationMessage": {
@@ -518,9 +518,9 @@
   "participants": {
     "subheading": "Im Raum",
     "you": "Du",
-    "unknown": "Unbekannter Teilnehmer",
+    "unknown": "Unbekannte Person",
     "host": "Host",
-    "contributors": "Mitwirkende",
+    "contributors": "Teilnehmende",
     "collapsable": {
       "open": "{{name}}-Liste öffnen",
       "close": "{{name}}-Liste schließen"
@@ -529,7 +529,7 @@
     "muteParticipant": "{{name}}’s Mikrofon ausschalten",
     "muteParticipantAlert": {
       "heading": "{{name}} stummschalten",
-      "description": "{{name}} für alle Teilnehmer stummschalten? {{name}} kann sich nur selbst wieder einschalten.",
+      "description": "{{name}} für alle Teilnehmenden stummschalten? {{name}} kann sich nur selbst wieder einschalten.",
       "confirm": "Stummschalten",
       "cancel": "Abbrechen"
     },
@@ -554,8 +554,8 @@
   },
   "participantMenu": {
     "remove": {
-      "label": "Vom Anruf ausschließen",
-      "ariaLabel": "{{name}} vom Anruf ausschließen"
+      "label": "Vom Meeting ausschließen",
+      "ariaLabel": "{{name}} vom Meeting ausschließen"
     },
     "unpin": {
       "label": "Lösen",
@@ -589,8 +589,8 @@
       "started": "Aufzeichnung läuft"
     },
     "limitReachedAlert": {
-      "title": "Aufnahmelimit überschritten",
-      "description": "Die Aufnahme hat die zulässige Höchstdauer{{duration_message}} überschritten. Sie wird jetzt automatisch gespeichert.",
+      "title": "Aufzeichnungslimit überschritten",
+      "description": "Die Aufzeichnung hat die zulässige Höchstdauer{{duration_message}} überschritten. Sie wird jetzt automatisch gespeichert.",
       "durationMessage": " von {{duration}}",
       "button": "OK"
     }
@@ -602,12 +602,12 @@
       "enable": "Anheften",
       "disable": "Lösen"
     },
-    "effects": "Visuelle Effekte anwenden",
+    "effects": "Hintergründe und Effekte anwenden",
     "muteParticipant": "{{name}} stummschalten",
     "fullScreen": "Vollbild"
   },
   "shortcutsPanel": {
-    "title": "Tastenkombinationen",
+    "title": "Tastenkürzel",
     "categories": {
       "navigation": "Navigation",
       "media": "Medien",
@@ -618,13 +618,13 @@
       "focus-toolbar": "Fokus auf die untere Symbolleiste",
       "toggle-microphone": "Mikrofon umschalten",
       "toggle-camera": "Kamera umschalten",
-      "push-to-talk": "Push-to-talk (gedrückt halten zum Einschalten)",
+      "push-to-talk": "Push-to-talk",
       "reaction": "Reaktionspanel",
       "fullscreen": "Vollbild umschalten",
       "recording": "Aufnahmepanel umschalten",
       "raise-hand": "Hand heben oder senken",
       "toggle-chat": "Chat anzeigen/ausblenden",
-      "toggle-participants": "Teilnehmer anzeigen/ausblenden",
+      "toggle-participants": "Teilnehmende anzeigen/ausblenden",
       "open-shortcuts-settings": "Tastenkürzel-Einstellungen öffnen"
     },
     "sr": {
@@ -642,8 +642,8 @@
     }
   },
   "fullScreenWarning": {
-    "message": "Um eine Endlosschleife zu vermeiden, teile nicht deinen gesamten Bildschirm. Teile stattdessen einen Tab oder ein anderes Fenster.",
-    "stop": "Präsentation beenden",
+    "message": "Damit dein Bildschirm nicht unendlich gespiegelt wird, teile nicht deinen gesamten Bildschirm. Teile stattdessen einen Tab oder ein anderes Fenster.",
+    "stop": "Teilen beenden",
     "ignore": "Ignorieren"
   },
   "participantTile": {

--- a/src/frontend/src/locales/de/sdk.json
+++ b/src/frontend/src/locales/de/sdk.json
@@ -4,7 +4,7 @@
     "joinButton": "Mit Visio beitreten",
     "copyLinkTooltip": "Link kopieren",
     "resetLabel": "Zurücksetzen",
-    "participantLimit": "Bis zu 150 Teilnehmer.",
-    "popupBlocked": "Popup wurde blockiert. Bitte erlauben Sie Popups für diese Website."
+    "participantLimit": "Bis zu 150 Teilnehmende.",
+    "popupBlocked": "Popup wurde blockiert. Bitte erlaube Popups für diese Website."
   }
 }

--- a/src/frontend/src/locales/de/settings.json
+++ b/src/frontend/src/locales/de/settings.json
@@ -1,46 +1,46 @@
 {
   "account": {
-    "currentlyLoggedAs": "Sie sind derzeit angemeldet als <0>{{user}}</0>",
+    "currentlyLoggedAs": "Du bist derzeit angemeldet als <0>{{user}}</0>",
     "heading": "Konto",
-    "youAreNotLoggedIn": "Sie sind nicht angemeldet.",
-    "nameLabel": "Ihr Name",
+    "youAreNotLoggedIn": "Du bist nicht angemeldet.",
+    "nameLabel": "Dein Name",
     "authentication": "Authentifizierung",
-    "nameError": "Ihr Name darf nicht leer sein"
+    "nameError": "Dein Name darf nicht leer sein"
   },
   "preferences": {
     "title": "Einstellungen",
     "idleDisconnectModal": {
-      "label": "Anrufe ohne Teilnehmer verlassen",
-      "description": "Verlässt automatisch einen Anruf nach einigen Minuten, wenn kein anderer Teilnehmer beitritt"
+      "label": "Meetings ohne Teilnehmende verlassen",
+      "description": "Meetings nach einigen Minuten automatisch verlassen, wenn keine andere Person beitritt"
     }
   },
   "audio": {
     "microphone": {
       "heading": "Mikrofon",
-      "label": "Wählen Sie Ihre Audioeingabe",
+      "label": "Audioeingabe wählen",
       "disabled": "Mikrofon deaktiviert"
     },
     "noiseReduction": {
-      "label": "Rauschunterdrückung",
-      "heading": "Rauschunterdrückung",
+      "label": "Geräuschunterdrückung",
+      "heading": "Geräuschunterdrückung",
       "ariaLabel": {
-        "enable": "Rauschunterdrückung aktivieren",
-        "disable": "Rauschunterdrückung deaktivieren"
+        "enable": "Geräuschunterdrückung aktivieren",
+        "disable": "Geräuschunterdrückung deaktivieren"
       }
     },
     "speakers": {
       "heading": "Lautsprecher",
-      "label": "Wählen Sie Ihre Audioausgabe",
+      "label": "Audioausgabe wählen",
       "test": "Testen",
       "ongoingTest": "Soundtest läuft…",
-      "safariWarning": "Die Lautsprecherauswahl ist auf Safari aufgrund von Browser-Einschränkungen noch nicht verfügbar."
+      "safariWarning": "Die Audioausgabeauswahl ist auf Safari aufgrund von Browser-Einschränkungen noch nicht verfügbar."
     },
     "permissionsRequired": "Berechtigungen erforderlich"
   },
   "video": {
     "camera": {
       "heading": "Kamera",
-      "label": "Wählen Sie Ihre Videoeingabe aus",
+      "label": "Videoeingabe wählen",
       "disabled": "Kamera deaktiviert",
       "previewAriaLabel": {
         "enabled": "Videovorschau aktiviert",
@@ -50,18 +50,18 @@
     "resolution": {
       "heading": "Auflösung",
       "publish": {
-        "label": "Wählen Sie Ihre maximale Sendeauflösung (max.)",
+        "label": "Wähle die maximale Auflösung beim Senden",
         "items": {
           "high": "Hohe Auflösung",
-          "medium": "Standardauflösung",
+          "medium": "Mittlere Auflösung",
           "low": "Niedrige Auflösung"
         }
       },
       "subscribe": {
-        "label": "Wählen Sie Ihre Empfangsauflösung (max.)",
+        "label": "Wähle die maximale Auflösung beim Empfangen",
         "items": {
           "high": "Hohe Auflösung (automatisch)",
-          "medium": "Standardauflösung",
+          "medium": "Mittlere Auflösung",
           "low": "Niedrige Auflösung"
         }
       }
@@ -82,15 +82,15 @@
     }
   },
   "notifications": {
-    "heading": "Tonbenachrichtigungen",
-    "label": "Tonbenachrichtigungen für",
+    "heading": "Benachrichtigungen mit Ton",
+    "label": "Benachrichtigungen mit Ton für",
     "actions": {
       "disable": "Deaktivieren",
       "enable": "Aktivieren"
     },
     "items": {
       "participantJoined": {
-        "label": "Teilnehmer beigetreten"
+        "label": "Person beigetreten"
       },
       "handRaised": {
         "label": "Hand gehoben"


### PR DESCRIPTION
## Purpose

As far as I understand, the German localization was mostly machine-translated so far. I went through all the text by hand and refined lots of words and phrases to raise the German language quality in the Meet app.

This PR also consistently uses the German "du" form of address, it was a mix of "du" and "Sie" before. When machine-translating future lines, the following text added to the AI prompt can help to make them consistent with the existing translation:

```
1) Use the "du" form of address throughout the translation. If a phrase allows for neutral language that doesn't compromise its meaning, prefer using that over direct address.
2) Incorporate inclusive and gender-neutral language.
3) Maintain the original meaning and context of the text.
```

## Proposal

Enhancements to the German localization include:

- [x] Refine phrases to sound more natural
- [x] Ensure consistency in words usage
- [x] Adapt phrases to be inclusive and gender-neutral
- [x] Standardize to the "du" form of address, aligning with modern practices and other open-source projects like GitLab and the Android Open Source Project

