### PR TITLE
♻️(backend) refactor uploaded file's key format

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -85,7 +85,7 @@ UUID_REGEX = (
 FILE_EXT_REGEX = r"[\d\w]+"
 MEDIA_STORAGE_URL_PATTERN = re.compile(
     f"{settings.MEDIA_URL:s}"
-    rf"(?P<key>{FILE_FOLDER:s}/(?P<pk>{UUID_REGEX:s})/\.{FILE_EXT_REGEX:s})$"
+    rf"(?P<key>{FILE_FOLDER:s}/(?P<pk>{UUID_REGEX:s})\.{FILE_EXT_REGEX:s})$"
 )
 
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -952,7 +952,7 @@ class File(BaseModel):
         _, extension = splitext(self.filename)
         # We store only the extension in the storage system to avoid
         # leaking Personal Information in logs, etc.
-        return f"{self.key_base}/{extension!s}"
+        return f"{self.key_base}{extension!s}"
 
     def get_abilities(self, user):
         """

--- a/src/backend/core/tests/files/test_api_files_create.py
+++ b/src/backend/core/tests/files/test_api_files_create.py
@@ -118,7 +118,7 @@ def test_api_files_create_file_authenticated_success():
 
     assert policy_parsed.scheme == "http"
     assert policy_parsed.netloc == "localhost:9000"
-    assert policy_parsed.path == f"/meet-media-storage/files/{file.id!s}/.png"
+    assert policy_parsed.path == f"/meet-media-storage/files/{file.id!s}.png"
 
     query_params = parse_qs(policy_parsed.query)
 

--- a/src/backend/core/tests/files/test_api_files_update.py
+++ b/src/backend/core/tests/files/test_api_files_update.py
@@ -39,7 +39,7 @@ def test_api_files_update_anonymous_forbidden():
 
 def test_api_files_update_description_and_title():
     """
-    Test the description and title of an file can be updated.
+    Test the description and title of a file can be updated.
     """
     user = factories.UserFactory()
 


### PR DESCRIPTION
Remove the user-provided filename while preserving the extension, and switch to the format `uuid.extension`.

This is more natural than the previous `uuid/.extension` format and avoids confusion.

Update related tests accordingly.