### PR TITLE
📝 Fix documentation and comment typos

### DIFF
--- a/docs/examples/helm/meet.values.yaml
+++ b/docs/examples/helm/meet.values.yaml
@@ -68,13 +68,13 @@ backend:
         python manage.py createsuperuser --email admin@example.com --password admin
     restartPolicy: Never
 
-  # Exra volume to manage our local custom CA and avoid to set ssl_verify: false
+  # Extra volume to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
       mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
-  # Exra volume to manage our local custom CA and avoid to set ssl_verify: false
+  # Extra volume to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumes:
     - name: certs
       configMap:

--- a/docs/installation/compose.md
+++ b/docs/installation/compose.md
@@ -87,12 +87,12 @@ If you are using an external service, you need to set `REDIS_URL` environment va
 
 Generate a secure key for `LIVEKIT_API_SECRET` in `env.d/common`.
 
-We provide a minimal recommanded config for production environment in `livekit-server.yaml`. Set the previously generated API secret key in the config file.
+We provide a minimal recommended config for production environment in `livekit-server.yaml`. Set the previously generated API secret key in the config file.
 
 To view other customization options, see [config-sample.yaml](https://github.com/livekit/livekit/blob/master/config-sample.yaml)
 
 > [!NOTE]
-> In this example, we configured multiplexing on a single UDP port. For better performances, you can configure a range of UDP ports. 
+> In this example, we configured multiplexing on a single UDP port. For better performance, you can configure a range of UDP ports. 
 
 ### Meet
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -944,7 +944,7 @@ class FileViewSet(
     filterset_class = ListFileFilter
 
     def get_queryset(self):
-        """Get queryset that defaults to the the current request user."""
+        """Get queryset that defaults to the current request user."""
         user = self.request.user
         queryset = super().get_queryset().select_related("creator")
 

--- a/src/backend/core/recording/services/recording_events.py
+++ b/src/backend/core/recording/services/recording_events.py
@@ -16,7 +16,7 @@ class RecordingEventsError(Exception):
 
 
 class RecordingEventsService:
-    """Handles recording-related Livekit webhook events."""
+    """Handles recording-related LiveKit webhook events."""
 
     @staticmethod
     def handle_update(recording, egress_status):

--- a/src/backend/core/services/lobby.py
+++ b/src/backend/core/services/lobby.py
@@ -129,7 +129,7 @@ class LobbyService:
     ) -> Tuple[LobbyParticipant, Optional[Dict]]:
         """Request entry to a room for a participant.
 
-        This usual status transitions is:
+        The usual status transitions are:
         UNKNOWN -> WAITING -> (ACCEPTED | DENIED)
 
         Flow:

--- a/src/backend/core/templatetags/extra_tags.py
+++ b/src/backend/core/templatetags/extra_tags.py
@@ -1,4 +1,4 @@
-"""Custom template tags for the core application of People."""
+"""Custom template tags for the core application of Meet."""
 
 import base64
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useGridLayout.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useGridLayout.ts
@@ -22,7 +22,7 @@ import { useSize } from '@/features/rooms/livekit/hooks/useResizeObserver'
 export function useGridLayout(
   /** HTML element that contains the grid. */
   gridElement: React.RefObject<HTMLDivElement>,
-  /** Count of tracks that should get layed out */
+  /** Count of tracks that should get laid out */
   trackCount: number,
   options: {
     gridLayouts?: GridLayoutDefinition[]

--- a/src/helm/meet/values.yaml
+++ b/src/helm/meet/values.yaml
@@ -37,7 +37,7 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingress.tls.secretName Secret name for TLS config
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
@@ -62,7 +62,7 @@ ingressWebhook:
   ## @param ingressWebhook.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressWebhook.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressWebhook.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressWebhook.tls.secretName Secret name for TLS config
   ## @skip ingressWebhook.tls.additional
   ## @extra ingressWebhook.tls.additional[].secretName Secret name for additional TLS config
@@ -88,7 +88,7 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressAdmin.tls.secretName Secret name for TLS config
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
@@ -110,7 +110,7 @@ ingressMedia:
   ## @param ingressMedia.hosts Additional host to configure for the Ingress
   hosts: [ ]
   #  - chart-example.local
-  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressMedia.tls.secretName Secret name for TLS config
   ## @skip ingressMedia.tls.additional
   ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
@@ -302,7 +302,7 @@ frontend:
   ## @param frontend.replicas Amount of frontend replicas
   replicas: 3
 
-  ## @param frontend.shareProcessNamespace Enable share process namefrontend between containers
+  ## @param frontend.shareProcessNamespace Enable share process namespace between containers
   shareProcessNamespace: false
 
   ## @param frontend.sidecars Add sidecars containers to frontend deployment


### PR DESCRIPTION
## Summary

Fix typos found in documentation and code comments across the codebase.

### Documentation
- `recommanded` → `recommended` (docs/installation/compose.md)
- `performances` → `performance` (docs/installation/compose.md)
- `Exra` → `Extra` (docs/examples/helm/meet.values.yaml)

### Helm chart comments
- `Weather` → `Whether` (src/helm/meet/values.yaml, 4 occurrences)
- `namefrontend` → `namespace` (src/helm/meet/values.yaml)

### Docstrings
- `the the` → `the` (viewsets.py)
- `This usual status transitions is:` → `The usual status transitions are:` (lobby.py)
- `Livekit` → `LiveKit` (recording_events.py)
- `People` → `Meet` (extra_tags.py)

### Code comments
- `layed` → `laid` (useGridLayout.ts)

All changes are in comments and docstrings only — no functional impact.

## Files changed
- 8 files
- 14 lines