### PR TITLE
🩹(backend) add page_size to pagination for room endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ and this project adheres to
 - ♿️(frontend) sync html lang attribute with i18n for screen readers #1111
 - ♿️(frontend) improve MoreLink a11y and UX on home page #1112
 - ♿(frontend) improve chat toast a11y for screen readers #1109
-- ♿(frontend) improve ui and qria labels for help article links #1108
+- ♿(frontend) improve ui and aria labels for help article links #1108
 - 🌐(frontend) improve German translation #1125
 
 ### Fixed
 
-- 🐛(frontend) fix hand icon and queue position aligment and position #1119
+- 🐛(frontend) fix hand icon and queue position alignment and position #1119
+- 🩹(backend) add page_size to pagination for room endpoints #1131
 
 ## [1.10.0] - 2026-03-05
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -224,6 +224,7 @@ class RoomViewSet(
     API endpoints to access and perform actions on rooms.
     """
 
+    pagination_class = Pagination
     permission_classes = [permissions.RoomPermissions]
     queryset = models.Room.objects.all()
     serializer_class = serializers.RoomSerializer

--- a/src/backend/core/tests/rooms/test_api_rooms_list.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_list.py
@@ -120,3 +120,39 @@ def test_api_rooms_list_authenticated_distinct():
     content = response.json()
     assert len(content["results"]) == 1
     assert content["results"][0]["id"] == str(room.id)
+
+
+def test_api_rooms_list_pagination_page_size():
+    """Users should be able to customize the number of results per page via page_size param."""
+    user = UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    RoomFactory.create_batch(11, users=[user])
+
+    response = client.get("/api/v1.0/rooms/?page_size=2")
+
+    assert response.status_code == 200
+    content = response.json()
+    assert content["count"] == 11
+    assert len(content["results"]) == 2
+    assert content["next"] == "http://testserver/api/v1.0/rooms/?page=2&page_size=2"
+    assert content["previous"] is None
+
+    response = client.get("/api/v1.0/rooms/?page=6&page_size=2")
+
+    assert response.status_code == 200
+    content = response.json()
+    assert content["count"] == 11
+    assert len(content["results"]) == 1
+    assert content["next"] is None
+    assert content["previous"] == "http://testserver/api/v1.0/rooms/?page=5&page_size=2"
+
+    response = client.get("/api/v1.0/rooms/?page_size=3")
+
+    assert response.status_code == 200
+    content = response.json()
+    assert content["count"] == 11
+    assert len(content["results"]) == 3
+    assert content["next"] == "http://testserver/api/v1.0/rooms/?page=2&page_size=3"
+    assert content["previous"] is None


### PR DESCRIPTION
Align room endpoints with the pagination behavior used across other API endpoints and resolve issue #1055.