### PR TITLE
🌐(frontend) remove references to ProConnect from the login hint

### DIFF
--- a/src/frontend/src/locales/en/global.json
+++ b/src/frontend/src/locales/en/global.json
@@ -47,7 +47,7 @@
   },
   "loginHint": {
     "title": "Log in with your account",
-    "body": "Instead of waiting, log in with your ProConnect account.",
+    "body": "Instead of waiting, log in with your account.",
     "button": {
       "ariaLabel": "Close the suggestion",
       "label": "OK"

--- a/src/frontend/src/locales/fr/global.json
+++ b/src/frontend/src/locales/fr/global.json
@@ -47,7 +47,7 @@
   },
   "loginHint": {
     "title": "Connectez-vous avec votre compte",
-    "body": "Au lieu de patienter, connectez-vous avec votre compte ProConnect.",
+    "body": "Au lieu de patienter, connectez-vous avec votre compte.",
     "button": {
       "ariaLabel": "Fermer la suggestion",
       "label": "OK"

--- a/src/frontend/src/locales/nl/global.json
+++ b/src/frontend/src/locales/nl/global.json
@@ -46,7 +46,7 @@
   },
   "loginHint": {
     "title": "Log in met je account",
-    "body": "In plaats van te wachten, log in met je ProConnect-account.",
+    "body": "In plaats van te wachten, log in met je account.",
     "button": {
       "ariaLabel": "Sluit de suggestie",
       "label": "OK"


### PR DESCRIPTION
ProConnect (DINUM SSO) should not be mentioned in this context. Clean up the login hint to avoid confusion.