### PR TITLE
🔧(backend) trigger webhook only for recording file uploads

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -58,7 +58,7 @@ services:
       /usr/bin/mc admin config set meet notify_webhook:meet-webhook endpoint='http://app-dev:8000/api/v1.0/recordings/storage-hook/' auth_token='Bearer password' &&
       /usr/bin/mc admin service restart meet --wait --json &&
       sleep 15 &&
-      /usr/bin/mc event add meet/meet-media-storage arn:minio:sqs::meet-webhook:webhook --event put &&
+      /usr/bin/mc event add meet/meet-media-storage arn:minio:sqs::meet-webhook:webhook --event put --prefix "recordings" &&
       exit 0;"
 
   app-dev:

--- a/src/helm/extra/templates/minio.yaml
+++ b/src/helm/extra/templates/minio.yaml
@@ -132,7 +132,7 @@ spec:
             /usr/bin/mc admin config set meet notify_webhook:meet-webhook endpoint="https://meet.127.0.0.1.nip.io/api/v1.0/recordings/storage-hook/" auth_token="Bearer password" && \
             /usr/bin/mc admin service restart meet --wait --json && \
             sleep 15 && \
-            /usr/bin/mc event add meet/meet-media-storage arn:minio:sqs::meet-webhook:webhook --event put && \
+            /usr/bin/mc event add meet/meet-media-storage arn:minio:sqs::meet-webhook:webhook --event put --prefix "recordings" && \
             exit 0
       restartPolicy: Never
   backoffLimit: 1


### PR DESCRIPTION
With the introduction of file background uploads, only trigger the webhook for files related to recordings.

Avoid firing the "recording saved" event for other file uploads, preventing unnecessary queries and false triggers.