### PR TITLE
📝(doc) fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to
 
 - 🐛(frontend) fix hand icon and queue position alignment and position #1119
 - 🩹(backend) add page_size to pagination for room endpoints #1131
-- 🐛(backend) refactor lobby throttling using participant id instead of IP #1129
+- 🐛(backend) refactor lobby throttling to use participant id #1129
 
 ## [1.10.0] - 2026-03-05
 


### PR DESCRIPTION
Wrap lines that were excessively long to improve readability.
