### PR TITLE
🔒️(backend) avoid information exposure through exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - ♻️(backend) align Application model field with `is_active` convention #1133
 - 🔐(backend) avoids revealing the inactive status of an application #1135
 - ⚡️(helm) reduce initialDelaySeconds and add periods seconds #1139
+- 🔒️(backend) avoid information exposure through exception messages #1144
 
 ### Fixed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -488,9 +488,7 @@ class RoomViewSet(
             if status_code == drf_status.HTTP_500_INTERNAL_SERVER_ERROR:
                 raise e
 
-            return drf_response.Response(
-                {"status": "error", "message": str(e)}, status=status_code
-            )
+            return drf_response.Response({"status": "error"}, status=status_code)
 
     @decorators.action(
         detail=False,
@@ -757,10 +755,10 @@ class RecordingViewSet(
             recording_id = parser.get_recording_id(request.data)
 
         except ParsingEventDataError as e:
-            raise drf_exceptions.PermissionDenied(f"Invalid request data: {e}") from e
+            raise drf_exceptions.PermissionDenied("Invalid request data.") from e
 
         except InvalidBucketError as e:
-            raise drf_exceptions.PermissionDenied("Invalid bucket specified") from e
+            raise drf_exceptions.PermissionDenied("Invalid bucket specified.") from e
 
         except InvalidFilepathError:
             return drf_response.Response(

--- a/src/backend/core/tests/recording/test_api_recordings_storage_hook.py
+++ b/src/backend/core/tests/recording/test_api_recordings_storage_hook.py
@@ -95,7 +95,7 @@ def test_save_recording_parsing_error(recording_settings, mock_get_parser, clien
     )
 
     assert response.status_code == 403
-    assert response.json() == {"detail": "Invalid request data: Error message"}
+    assert response.json() == {"detail": "Invalid request data."}
 
 
 def test_save_recording_bucket_error(recording_settings, mock_get_parser, client):
@@ -112,7 +112,7 @@ def test_save_recording_bucket_error(recording_settings, mock_get_parser, client
     )
 
     assert response.status_code == 403
-    assert response.json() == {"detail": "Invalid bucket specified"}
+    assert response.json() == {"detail": "Invalid bucket specified."}
 
 
 def test_save_recording_filetype_error(recording_settings, mock_get_parser):

--- a/src/backend/core/tests/rooms/test_api_rooms_webhook.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_webhook.py
@@ -77,7 +77,6 @@ def test_missing_auth_header(client, serialized_event_data, mock_livekit_config)
     assert response.status_code == 401
     assert response.json() == {
         "status": "error",
-        "message": "Authorization header missing",
     }
 
 
@@ -91,7 +90,7 @@ def test_invalid_payload(client, auth_token, mock_livekit_config):
     )
 
     assert response.status_code == 400
-    assert response.json() == {"status": "error", "message": "Invalid webhook payload"}
+    assert response.json() == {"status": "error"}
 
 
 def test_unknown_event_type(client, mock_livekit_config):
@@ -116,7 +115,6 @@ def test_unknown_event_type(client, mock_livekit_config):
     assert response.status_code == 422
     assert response.json() == {
         "status": "error",
-        "message": "Unknown webhook type: unknown_event_type",
     }
 
 


### PR DESCRIPTION
Sanitize error handling to prevent leaking internal details when invalid or malicious requests are sent to the API.

Return generic error responses to reduce the risk of information disclosure during probing attempts.