### PR TITLE
feat: pass session ID to native apps via OIDC redirect URL

### DIFF
--- a/src/backend/core/authentication/views.py
+++ b/src/backend/core/authentication/views.py
@@ -1,0 +1,47 @@
+"""Custom OIDC authentication views for native app support.
+
+When a native app (iOS, Android, Desktop) initiates OIDC login, it sets
+`returnTo` to a custom URL scheme (e.g. `visio://auth-callback`). After
+the OIDC flow completes, Django sets the session cookie and redirects to
+that URL. However, native apps cannot read browser cookies — they need
+the session ID passed explicitly in the redirect URL.
+
+This module overrides the OIDC callback view to append the session ID as
+a query parameter when the redirect target uses a non-HTTPS scheme.
+"""
+
+from urllib.parse import urlencode, urlparse
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+
+from lasuite.oidc_login.views import (
+    OIDCAuthenticationCallbackView as BaseCallbackView,
+)
+
+
+class OIDCAuthenticationCallbackView(BaseCallbackView):
+    """Callback view that passes session ID to native app deep links."""
+
+    def login_success(self):
+        """After successful login, append session ID for custom-scheme redirects."""
+        response = super().login_success()
+
+        # Only modify redirects to custom URL schemes (native apps).
+        # Standard HTTPS redirects (web browser) work fine with cookies.
+        if isinstance(response, HttpResponseRedirect):
+            redirect_url = response.url
+            parsed = urlparse(redirect_url)
+            if parsed.scheme and parsed.scheme not in ("http", "https", ""):
+                session_key = self.request.session.session_key
+                cookie_name = getattr(
+                    settings, "SESSION_COOKIE_NAME", "sessionid"
+                )
+                separator = "&" if parsed.query else "?"
+                new_url = (
+                    f"{redirect_url}{separator}"
+                    f"{urlencode({cookie_name: session_key})}"
+                )
+                return HttpResponseRedirect(new_url)
+
+        return response

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -460,7 +460,7 @@ class Base(Configuration):
 
     # OIDC - Authorization Code Flow
     OIDC_AUTHENTICATE_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationRequestView"
-    OIDC_CALLBACK_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationCallbackView"
+    OIDC_CALLBACK_CLASS = "core.authentication.views.OIDCAuthenticationCallbackView"
     OIDC_CREATE_USER = values.BooleanValue(
         default=True, environ_name="OIDC_CREATE_USER", environ_prefix=None
     )


### PR DESCRIPTION
## Summary

- When native apps (iOS, Android, Desktop) use OIDC login with a custom URL scheme as `returnTo` (e.g. `visio://auth-callback`), they cannot access the `sessionid` cookie set by Django because the system browser and the native app run in separate processes
- This adds a custom OIDC callback view that detects non-HTTPS redirect schemes and appends the session ID as a query parameter to the redirect URL
- Standard HTTPS redirects (web browser) are not affected — they continue using cookies as before

## Changes

- `src/backend/core/authentication/views.py` — New `OIDCAuthenticationCallbackView` that overrides `login_success()` to append session ID for custom-scheme redirects
- `src/backend/meet/settings.py` — Point `OIDC_CALLBACK_CLASS` to the new view

## Context

Native mobile/desktop apps (Visio Mobile) need to authenticate via OIDC. On iOS (`ASWebAuthenticationSession`) and Android (`Chrome Custom Tabs`), the system browser handles OIDC but cannot share cookies back to the app. With this change, the redirect URL becomes `visio://auth-callback?meet_sessionid=<session_key>`, allowing the app to extract the session ID directly.

## Test plan

- [ ] Web browser OIDC login still works (returnTo=https://...) — cookie-based, no change
- [ ] Native app OIDC login with returnTo=visio://auth-callback receives session ID in URL
- [ ] Session ID in URL is valid and can be used for API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)