### PR TITLE
♻️(backend) make SESSION_ENGINE configurable via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- ♻️(backend) configurable SESSION_ENGINE #1038 #1154
 - ♿️(frontend) fix sidepanel accessibility aria-label #1182
 - ♿️(frontend) fix more tools heading hierarchy #1181
 - ♿️(fronted) improve button descriptions for More tools actions #1184

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -452,7 +452,11 @@ class Base(Configuration):
     CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({}, environ_prefix=None)
 
     # Session
-    SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+    SESSION_ENGINE = values.Value(
+        default="django.contrib.sessions.backends.cache",
+        environ_name="SESSION_ENGINE",
+        environ_prefix=None,
+    )
     SESSION_CACHE_ALIAS = "default"
     SESSION_COOKIE_AGE = values.PositiveIntegerValue(
         default=60 * 60 * 12, environ_name="SESSION_COOKIE_AGE", environ_prefix=None


### PR DESCRIPTION
## Summary

- Make `SESSION_ENGINE` configurable through environment variable, following the same `values.Value()` pattern already used for `SESSION_COOKIE_AGE`
- Default remains `django.contrib.sessions.backends.cache` so behavior is unchanged for existing deployments
- Enables OIDC backchannel-logout by allowing users to set `SESSION_ENGINE=django.contrib.sessions.backends.db`

Closes #1037

## Test plan

- [ ] Deploy with no `SESSION_ENGINE` env var set → verify default behavior (cache-backed sessions) is unchanged
- [ ] Set `SESSION_ENGINE=django.contrib.sessions.backends.db` → verify database-backed sessions work
- [ ] With `db` backend, verify backchannel-logout endpoint works correctly