### PR TITLE
🐛(frontend) fix device selection not applying during conference

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/SelectDevice.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/SelectDevice.tsx
@@ -69,10 +69,10 @@ const SelectDevicePermissions = <T extends string | number>({
       iconComponent={iconComponent}
       placeholder={items.length === 0 ? t('loading') : t('select')}
       selectedKey={selectedKey}
-      onSelectionChange={(key) => {
+      onSelectionChange={async (key) => {
         if (key === selectedKey) return
+        await setActiveMediaDevice(key as string)
         onSubmit?.(key as string)
-        setActiveMediaDevice(key as string)
       }}
       {...props}
     />


### PR DESCRIPTION
## Summary

- Fix audio/video device selection not being applied when changed during a conference
- The `setActiveMediaDevice` call in `SelectDevice.tsx` was not `await`ed and was called after saving to store, potentially causing race conditions with re-renders
- Align the behavior with the working pattern from `AudioTab.tsx` (settings): `await setActiveMediaDevice` first, then persist the choice

**Root cause**: In `SelectDevice.tsx`, `onSubmit` (which saves to the persistent store and may trigger re-renders) was called before `setActiveMediaDevice` (which switches the actual device via LiveKit SDK), and the SDK call was not awaited.

Closes #212

## Test plan

- [ ] Join a meeting with audio/video enabled
- [ ] Open the device selection popover (arrow button next to mic/camera)
- [ ] Switch to a different microphone → verify the active microphone changes immediately
- [ ] Switch to a different speaker → verify audio output changes
- [ ] Switch to a different camera → verify the video feed changes
- [ ] Open Settings and verify device selection still works there (no regression)