### PR TITLE
🔧(build) update openssl and libssl3t64 versions to fix build

### DIFF
--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -1,13 +1,14 @@
 FROM python:3.13-slim AS base
 
 # Install system dependencies required by LiveKit
-RUN apt-get update && apt-get install -y \
-    libglib2.0-0 \
-    libgobject-2.0-0 \
-    "openssl=3.5.4-1~deb13u2" \
-    "libssl3t64=3.5.4-1~deb13u2" \
-    && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        libglib2.0-0 \
+        libgobject-2.0-0 \
+ && apt-get upgrade -y openssl libssl3t64 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+    
 FROM base AS builder
 
 WORKDIR /builder


### PR DESCRIPTION
Update OpenSSL and libssl3t64 package versions to resolve a [build failure](https://github.com/suitenumerique/meet/actions/runs/23191530819/job/67427263939?pr=1077). Error is due to pinned openssl and libssl versions, which are regressions (python image must have updated versions).