### PR TITLE
📌(agents) unpin OpenSSL and related dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - ⚡️(helm) reduce initialDelaySeconds and add periods seconds #1139
 - 🔒️(backend) avoid information exposure through exception messages #1144
 - ⬆️(dependencies) update PyJWT to v2.12.0 [SECURITY] #1151
+- 📌(agents) unpin OpenSSL and related dependencies #1167
 
 ### Fixed
 

--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -4,8 +4,6 @@ FROM python:3.13-slim AS base
 RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     libgobject-2.0-0 \
-    "openssl=3.5.4-1~deb13u2" \
-    "libssl3t64=3.5.4-1~deb13u2" \
     && rm -rf /var/lib/apt/lists/*
 
 FROM base AS builder


### PR DESCRIPTION
The base image now includes OpenSSL 3.5.5, which resolves CVE-2025-15467.

Remove explicit pinning of OpenSSL and its dependencies.
