### PR TITLE
🩹(frontend) disable subtitle settings when feature is unavailable

### DIFF
--- a/src/frontend/src/features/subtitle/component/CaptionsSettings.tsx
+++ b/src/frontend/src/features/subtitle/component/CaptionsSettings.tsx
@@ -10,6 +10,7 @@ import {
   CAPTION_TEXT_SIZE_OPTIONS,
   CAPTION_COLOR_OPTIONS,
 } from '@/stores/accessibility'
+import { useAreSubtitlesAvailable } from '../hooks/useAreSubtitlesAvailable'
 
 export const CaptionsSettings = () => {
   const { t } = useTranslation('settings', {
@@ -43,6 +44,9 @@ export const CaptionsSettings = () => {
       })),
     [t]
   )
+
+  const areSubtitlesAvailable = useAreSubtitlesAvailable()
+  if (!areSubtitlesAvailable) return null
 
   return (
     <li>


### PR DESCRIPTION
Hide or disable settings related to the subtitle feature when the feature flag is not enabled.

