### PR TITLE
♿️(frontend) fix more tools heading hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - ♿️(frontend) fix sidepanel accessibility aria-label #1182
+- ♿️(frontend) fix more tools heading hierarchy #1181
 
 ## [1.11.0] - 2026-03-19
 

--- a/src/frontend/src/features/rooms/livekit/components/Tools.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/Tools.tsx
@@ -65,7 +65,7 @@ const ToolButton = ({
       <div>
         <Text
           margin={false}
-          as="h3"
+          as="h2"
           className={css({
             display: 'flex',
             gap: 0.25,


### PR DESCRIPTION
Side panel title is an H1, but the hierarchy skips directly to H3. Fix the heading structure. It closes #1178.
