### PR TITLE
♿️(frontend) fix sidepanel accessibility aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♿️(frontend) fix sidepanel accessibility aria-label #1182
+
 ## [1.11.0] - 2026-03-19
 
 ### Added

--- a/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/SidePanel.tsx
@@ -149,11 +149,12 @@ export const SidePanel = () => {
     activeSubPanelId,
   } = useSidePanel()
   const { t } = useTranslation('rooms', { keyPrefix: 'sidePanel' })
+  const title = t(`heading.${activeSubPanelId || activePanelId}`)
 
   return (
     <StyledSidePanel
-      title={t(`heading.${activeSubPanelId || activePanelId}`)}
-      ariaLabel={t('ariaLabel')}
+      title={title}
+      ariaLabel={t('ariaLabel', { title })}
       onClose={() => {
         layoutStore.activePanelId = null
         layoutStore.activeSubPanelId = null

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -319,7 +319,7 @@
     }
   },
   "sidePanel": {
-    "ariaLabel": "Seitenleiste",
+    "ariaLabel": "Seitenleiste - {{title}}",
     "backToTools": "Zurück zu den Meeting-Tools",
     "heading": {
       "participants": "Teilnehmende",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -318,7 +318,7 @@
     }
   },
   "sidePanel": {
-    "ariaLabel": "Sidepanel",
+    "ariaLabel": "Sidepanel - {{title}}",
     "backToTools": "Back to meeting tools",
     "heading": {
       "participants": "Participants",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -318,7 +318,7 @@
     }
   },
   "sidePanel": {
-    "ariaLabel": "Panneau latéral",
+    "ariaLabel": "Panneau latéral - {{title}}",
     "backToTools": "Retour aux outils de réunion",
     "heading": {
       "participants": "Participants",

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -318,7 +318,7 @@
     }
   },
   "sidePanel": {
-    "ariaLabel": "Zijbalk",
+    "ariaLabel": "Zijbalk - {{title}}",
     "backToTools": "Terug naar vergadertools",
     "heading": {
       "participants": "Deelnemers",


### PR DESCRIPTION
The aria-label only announced the presence of a sidepanel without including its title.

Append the sidepanel title to improve accessibility and context for screen readers.

Closes #1176.
