### PR TITLE
♿️(fronted) improve button descriptions for Transcribe and Record actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ♿️(frontend) fix sidepanel accessibility aria-label #1182
 - ♿️(frontend) fix more tools heading hierarchy #1181
+- ♿️(fronted) improve button descriptions for More tools actions #1184
 
 ## [1.11.0] - 2026-03-19
 

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -354,11 +354,11 @@
     "tools": {
       "transcript": {
         "title": "Transkribieren",
-        "body": "Das Gespräch aufzeichnen."
+        "body": "Wandelt Meetings in Text um."
       },
       "screenRecording": {
-        "title": "Aufzeichnen",
-        "body": "Das Meeting aufzeichnen."
+        "title": "Aufnehmen",
+        "body": "Speichert Meetings als Video."
       }
     }
   },

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -353,11 +353,11 @@
     "tools": {
       "transcript": {
         "title": "Transcribe",
-        "body": "Record the conversation."
+        "body": "Turn meetings into text."
       },
       "screenRecording": {
         "title": "Record",
-        "body": "Record the meeting."
+        "body": "Save meetings as video."
       }
     }
   },

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -353,11 +353,11 @@
     "tools": {
       "transcript": {
         "title": "Transcrire",
-        "body": "Enregistrer la conversation."
+        "body": "Transcrire la réunion."
       },
       "screenRecording": {
         "title": "Enregistrer",
-        "body": "Enregistrer la réunion."
+        "body": "Enregistrer la réunion en vidéo."
       }
     }
   },

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -353,11 +353,11 @@
     "tools": {
       "transcript": {
         "title": "Transcriberen",
-        "body": "Het gesprek opnemen."
+        "body": "Zet vergaderingen om in tekst."
       },
       "screenRecording": {
         "title": "Opnemen",
-        "body": "De vergadering opnemen."
+        "body": "Sla vergaderingen op als video."
       }
     }
   },


### PR DESCRIPTION
The "Transcribe" and "Record" buttons had unclear and misleading descriptions, both using the verb "record," which caused confusion, especially for screen reader users.

Update descriptions to clearly reflect each action:
- Transcribe: generate a written transcript of the conversation
- Record: save the meeting as a video

This improves accessibility (RGAA 11.9) and reduces the risk of users triggering the wrong action.

Closes #1173