### PR TITLE
🐛(frontend) proxy /media requests to nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - ♿️(frontend) fix sidepanel accessibility aria-label #1182
 - ♿️(frontend) fix more tools heading hierarchy #1181
 
+### Fixed
+
+- 🐛(frontend) redirect /media requests to nginx #1186
+
 ## [1.11.0] - 2026-03-19
 
 ### Added

--- a/src/frontend/default.conf
+++ b/src/frontend/default.conf
@@ -11,6 +11,16 @@ server {
       add_header Content-Disposition "attachment; filename=windows-app-web-link";
   }
 
+  # Proxy media requests received by the frontend to the nginx server
+   location /media {
+      proxy_pass http://nginx:8083;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+   }
+
   # Serve static files with caching
   location ~* ^/assets/.*\.(css|js|json|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
       expires 30d;


### PR DESCRIPTION
When running the build image with docker compose we need to proxy incoming /media request to nginx so that background images can be properly served.

We didn't have the issue with local dev with vite as vite is configured to do the proxy.
Nor do we have the issue with tilt as medias are served directly.

We need this because if the background image are hosted on another domain, by default (and that's to be fix in LiveKit), request to get the image don't have auth headers so they get rejected.
