### PR TITLE
♿️(summary) improve accessibility of transcription download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - 💄(spinner) enforce spinner height #1183
 - 💄(custom-background) add upload indicator with preview #1183
 - ♿️(backend) improve logo accessibility in recording email notification #1092
+- ♿️(summary) improve accessibility of transcription download link #1187
 
 ### Fixed
 

--- a/src/summary/summary/core/locales/de.py
+++ b/src/summary/summary/core/locales/de.py
@@ -23,8 +23,7 @@ Einige Punkte, die wir Ihnen empfehlen zu überprüfen:
 
 """,
     download_header_template=(
-        "\n*Laden Sie Ihre Aufnahme herunter, "
-        "indem Sie [diesem Link folgen]({download_link})*\n"
+        "\n*[Laden Sie hier Ihre Aufnahme herunter (externer Link)]({download_link})*\n"
     ),
     hallucination_replacement_text="[Text konnte nicht transkribiert werden]",
     document_default_title="Transkription",

--- a/src/summary/summary/core/locales/en.py
+++ b/src/summary/summary/core/locales/en.py
@@ -23,7 +23,7 @@ A few things we recommend you check:
 
 """,
     download_header_template=(
-        "\n*Download your recording by [following this link]({download_link})*\n"
+        "\n*[Download your recording (external link)]({download_link})*\n"
     ),
     hallucination_replacement_text="[Unable to transcribe text]",
     document_default_title="Transcription",

--- a/src/summary/summary/core/locales/fr.py
+++ b/src/summary/summary/core/locales/fr.py
@@ -23,7 +23,7 @@ Quelques points que nous vous conseillons de vérifier :
 
 """,
     download_header_template=(
-        "\n*Télécharger votre enregistrement en [suivant ce lien]({download_link})*\n"
+        "\n*[Télécharger votre enregistrement (lien externe)]({download_link})*\n"
     ),
     hallucination_replacement_text="[Texte impossible à transcrire]",
     document_default_title="Transcription",

--- a/src/summary/summary/core/locales/nl.py
+++ b/src/summary/summary/core/locales/nl.py
@@ -23,7 +23,7 @@ Een paar punten die wij u aanraden te controleren:
 
 """,
     download_header_template=(
-        "\n*Download uw opname door [deze link te volgen]({download_link})*\n"
+        "\n*[Download hier je opname (externe link)]({download_link})*\n"
     ),
     hallucination_replacement_text="[Tekst kon niet worden getranscribeerd]",
     document_default_title="Transcriptie",


### PR DESCRIPTION
Update the link label to use explicit text "Download your recording" instead of generic "following this link."

This ensures blind users understand the purpose of the link and the behavior of opening a new window.

It closes #1086 