### PR TITLE
🧑‍💻(bin) update release tooling to support uv-based deps management

### DIFF
--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -101,6 +101,12 @@ update_npm_version "mail"
 # Update backend pyproject.toml
 update_python_version "backend"
 
+# Run uv lock in backend
+print_info "Running uv lock in backend..."
+cd "src/backend"
+uv lock
+cd -
+
 # Update summary pyproject.toml
 update_python_version "summary"
 
@@ -149,6 +155,7 @@ echo "      - src/frontend/package.json"
 echo "      - src/sdk/package.json"
 echo "      - src/mail/package.json"
 echo "      - src/backend/pyproject.toml"
+echo "      - src/backend/uv.lock"
 echo "      - src/summary/pyproject.toml"
 echo "      - src/agents/pyproject.toml"
 echo "      - CHANGELOG.md"


### PR DESCRIPTION
Following the switch from pip to uv, prepare the release workflow to automatically run `uv lock` on backend and
keep dependencies up to date.
