### PR TITLE
Security: Untrusted stylesheet URL is injected into document head

### DIFF
--- a/src/frontend/src/components/AppInitialization.tsx
+++ b/src/frontend/src/components/AppInitialization.tsx
@@ -21,11 +21,22 @@ export const AppInitialization = () => {
 
   useEffect(() => {
     if (custom_css_url) {
-      const link = document.createElement('link')
-      link.href = custom_css_url
-      link.id = 'meet-custom-css'
-      link.rel = 'stylesheet'
-      document.head.appendChild(link)
+      try {
+        const customCssUrl = new URL(custom_css_url, window.location.origin)
+        const trustedOrigins = [window.location.origin]
+
+        if (
+          customCssUrl.protocol === 'https:' &&
+          trustedOrigins.includes(customCssUrl.origin)
+        ) {
+          const link = document.createElement('link')
+          link.href = customCssUrl.toString()
+          link.id = 'meet-custom-css'
+          link.rel = 'stylesheet'
+          document.head.appendChild(link)
+        }
+      } catch {
+      }
     }
   }, [custom_css_url])
 


### PR DESCRIPTION
## Problem

The frontend loads `custom_css_url` from runtime config and directly appends it as a `<link rel="stylesheet">` without origin allowlisting or scheme validation. If an attacker can influence this config, they can inject hostile CSS to perform UI redressing, data exfiltration via CSS side channels, or phishing overlays.

**Severity**: `high`
**File**: `src/frontend/src/components/AppInitialization.tsx`

## Solution

Validate `custom_css_url` against a strict allowlist of trusted origins and `https:` scheme before injecting. Reject or ignore untrusted URLs, and consider serving tenant customization styles from trusted backend storage instead of arbitrary external URLs.

## Changes

- `src/frontend/src/components/AppInitialization.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
