### PR TITLE
Security: Room IDs are generated with non-cryptographic randomness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 - ♻(frontend) standardize role terminology across localizations
 - 🐛(backend) make start-recording atomic and fault-tolerant
+- 🔒️(frontend) room ids are generated with non-cryptographic rand
 
 ## [1.15.0] - 2026-04-30
 

--- a/src/frontend/src/features/rooms/utils/generateRoomId.ts
+++ b/src/frontend/src/features/rooms/utils/generateRoomId.ts
@@ -1,10 +1,20 @@
 // Google Meet uses only letters in a room identifier
 const ROOM_ID_ALLOWED_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz'
 
-const getRandomChar = () =>
-  ROOM_ID_ALLOWED_CHARACTERS[
-    Math.floor(Math.random() * ROOM_ID_ALLOWED_CHARACTERS.length)
+const getRandomChar = () => {
+  const maxValue =
+    Math.floor(0x100000000 / ROOM_ID_ALLOWED_CHARACTERS.length) *
+    ROOM_ID_ALLOWED_CHARACTERS.length
+  const randomValue = new Uint32Array(1)
+
+  do {
+    crypto.getRandomValues(randomValue)
+  } while (randomValue[0] >= maxValue)
+
+  return ROOM_ID_ALLOWED_CHARACTERS[
+    randomValue[0] % ROOM_ID_ALLOWED_CHARACTERS.length
   ]
+}
 
 const generateSegment = (length: number): string =>
   Array.from(Array(length), getRandomChar).join('')


### PR DESCRIPTION
## Problem

Room identifiers are created with `Math.random()`, which is predictable and not suitable for security-sensitive identifiers. Predictable room IDs increase the risk of room enumeration and unauthorized access attempts, especially when IDs are part of join URLs.

**Severity**: `medium`
**File**: `src/frontend/src/features/rooms/utils/generateRoomId.ts`

## Solution

Use a cryptographically secure generator (`crypto.getRandomValues` / `crypto.randomUUID`) and increase effective entropy of room identifiers. Also enforce server-side authorization regardless of ID secrecy.

## Changes

- `src/frontend/src/features/rooms/utils/generateRoomId.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
