### PR TITLE
Fix misc issue with the tilt stack.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,10 +373,6 @@ build-k8s-cluster: ## build the kubernetes cluster using kind
 	./bin/start-kind.sh
 .PHONY: build-k8s-cluster
 
-install-external-secrets: ## install the kubernetes secrets from Vaultwarden
-	./bin/install-external-secrets.sh
-.PHONY: build-k8s-cluster
-
 start-tilt-keycloak: ## start the kubernetes cluster using kind, without Pro Connect for authentication, use keycloak
 	DEV_ENV=dev-keycloak tilt up --namespace=meet -f ./bin/Tiltfile
 .PHONY: build-k8s-cluster

--- a/Makefile
+++ b/Makefile
@@ -369,7 +369,8 @@ frontend-i18n-generate: \
 .PHONY: frontend-i18n-generate
 
 # -- K8S
-build-k8s-cluster: ## build the kubernetes cluster using kind
+build-k8s-cluster: \ ## build the kubernetes cluster using kind
+    env.d/development/kube-secret
 	./bin/start-kind.sh
 .PHONY: build-k8s-cluster
 


### PR DESCRIPTION
Automatically copy required Kubernetes secrets when using the
Tilt development stack, as `make bootstrap` is not documented
as a prerequisite.

feedback from @arnaud-robin 