### PR TITLE
🩹(frontend) avoid waiting room requests without room id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - ⬆️(dependencies) update vite to v7.3.2 [SECURITY]
 - ⬆️(dependencies) update django to v5.2.13 [SECURITY]
 - 🔒(backend) rely on backend to allow participant update their metadata
+- 🩹(backend) fix swagger and redoc documentation URLs
 
 ## [1.13.0] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to
 - ⬆️(dependencies) update django to v5.2.13 [SECURITY]
 - 🔒(backend) rely on backend to allow participant update their metadata
 - 🩹(backend) fix swagger and redoc documentation URLs
+- 🩹(frontend) avoid waiting room requests without room id
 
 ## [1.13.0] - 2026-03-31
 

--- a/src/backend/core/tests/swagger/test_openapi_schema.py
+++ b/src/backend/core/tests/swagger/test_openapi_schema.py
@@ -40,3 +40,14 @@ def test_openapi_client_schema():
         "core/tests/swagger/swagger.json", "r", encoding="utf-8"
     ) as expected_schema:
         assert response.json() == json.load(expected_schema)
+
+
+def test_openapi_documentation_routes():
+    """Swagger and ReDoc documentation should be served on canonical URLs."""
+    client = Client()
+
+    swagger_response = client.get("/v1.0/swagger/")
+    redoc_response = client.get("/v1.0/redoc/")
+
+    assert swagger_response.status_code == 200
+    assert redoc_response.status_code == 200

--- a/src/backend/meet/urls.py
+++ b/src/backend/meet/urls.py
@@ -37,12 +37,12 @@ if settings.USE_SWAGGER or settings.DEBUG:
             name="client-api-schema",
         ),
         path(
-            f"{settings.API_VERSION}//swagger/",
+            f"{settings.API_VERSION}/swagger/",
             SpectacularSwaggerView.as_view(url_name="client-api-schema"),
             name="swagger-ui-schema",
         ),
         re_path(
-            f"{settings.API_VERSION}//redoc/",
+            f"{settings.API_VERSION}/redoc/",
             SpectacularRedocView.as_view(url_name="client-api-schema"),
             name="redoc-schema",
         ),

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -92,6 +92,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1457,6 +1458,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4519,6 +4521,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4626,8 +4629,7 @@
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
       "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
@@ -4643,8 +4645,7 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.15.tgz",
       "integrity": "sha512-omOlCPvTWyPm4ZE5bZUhlSvnHM2ZWM2U+1cPiYFL/e8aV5O9MouELp+L4dMKNTON0nTeHqEg+KWDfFQMY5Wkaw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4687,6 +4688,7 @@
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4760,6 +4762,7 @@
       "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -5065,6 +5068,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5590,6 +5594,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6565,6 +6570,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6936,6 +6942,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7637,6 +7644,7 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7737,6 +7745,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -8700,6 +8709,7 @@
       "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.17.1.tgz",
       "integrity": "sha512-pbJOSRVzZOoe9fL3RWjVxrYjsPo9npIVKGSl2Jhm1x4GxC6uubPWktWPxNLOnrshgxwAKrs2VeLY7LxBOtU1NQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@livekit/mutex": "1.1.1",
         "@livekit/protocol": "1.44.0",
@@ -9451,6 +9461,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9570,6 +9581,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9824,6 +9836,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9931,6 +9944,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10818,6 +10832,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10948,7 +10963,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -11075,6 +11091,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11229,6 +11246,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.3.0.tgz",
       "integrity": "sha512-1MfKNcmOIdBSatiJsYgw420n6jnD+jeoI0V+RkOQbCB0ElLh6GKUfPr0hc9uq/KBGeghivDEarRsKFFdSQQnKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -11339,6 +11357,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11914,6 +11933,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12121,6 +12141,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/src/features/rooms/api/enterRoom.ts
+++ b/src/frontend/src/features/rooms/api/enterRoom.ts
@@ -17,6 +17,10 @@ export const enterRoom = async ({
   allowEntry,
   participantId,
 }: EnterRoomParams): Promise<EnterRoomResponse> => {
+  if (!roomId) {
+    throw new Error('Room id is not available')
+  }
+
   return await fetchApi<EnterRoomResponse>(`/rooms/${roomId}/enter/`, {
     method: 'POST',
     body: JSON.stringify({

--- a/src/frontend/src/features/rooms/api/listWaitingParticipants.ts
+++ b/src/frontend/src/features/rooms/api/listWaitingParticipants.ts
@@ -21,6 +21,10 @@ export type WaitingParticipantsParams = {
 export const listWaitingParticipants = async ({
   roomId,
 }: WaitingParticipantsParams): Promise<WaitingParticipantsResponse> => {
+  if (!roomId) {
+    throw new Error('Room id is not available')
+  }
+
   return fetchApi<WaitingParticipantsResponse>(
     `/rooms/${roomId}/waiting-participants/`,
     {
@@ -30,7 +34,7 @@ export const listWaitingParticipants = async ({
 }
 
 export const useListWaitingParticipants = (
-  roomId: string,
+  roomId: string | undefined,
   queryOptions?: Omit<
     UseQueryOptions<
       WaitingParticipantsResponse,
@@ -46,7 +50,7 @@ export const useListWaitingParticipants = (
     WaitingParticipantsResponse
   >({
     queryKey: [keys.waitingParticipants, roomId],
-    queryFn: () => listWaitingParticipants({ roomId }),
+    queryFn: () => listWaitingParticipants({ roomId: roomId ?? '' }),
     ...queryOptions,
   })
 }

--- a/src/frontend/src/features/rooms/hooks/useWaitingParticipants.ts
+++ b/src/frontend/src/features/rooms/hooks/useWaitingParticipants.ts
@@ -17,7 +17,7 @@ export const useWaitingParticipants = () => {
   const [listEnabled, setListEnabled] = useState(true)
 
   const roomData = useRoomData()
-  const roomId = roomData?.id || '' // FIXME - bad practice
+  const roomId = roomData?.id
 
   const room = useRoomContext()
   const isAdminOrOwner = useIsAdminOrOwner()
@@ -41,7 +41,7 @@ export const useWaitingParticipants = () => {
   const { data: waitingData, refetch: refetchWaiting } =
     useListWaitingParticipants(roomId, {
       retry: false,
-      enabled: listEnabled && isAdminOrOwner,
+      enabled: Boolean(roomId) && listEnabled && isAdminOrOwner,
       refetchInterval: POLL_INTERVAL_MS,
       refetchIntervalInBackground: true,
     })
@@ -61,8 +61,12 @@ export const useWaitingParticipants = () => {
     participant: WaitingParticipant,
     allowEntry: boolean
   ) => {
+    if (!roomId) {
+      throw new Error('Room id is not available')
+    }
+
     await enterRoom({
-      roomId: roomId,
+      roomId,
       allowEntry,
       participantId: participant.id,
     })
@@ -72,13 +76,17 @@ export const useWaitingParticipants = () => {
   const handleParticipantsEntry = async (
     allowEntry: boolean
   ): Promise<void> => {
+    if (!roomId) {
+      throw new Error('Room id is not available')
+    }
+
     try {
       setListEnabled(false)
 
       await Promise.all(
         waitingParticipants.map((participant) =>
           enterRoom({
-            roomId: roomId,
+            roomId,
             allowEntry,
             participantId: participant.id,
           })


### PR DESCRIPTION
Guard waiting room API calls until room data is available.

## Purpose

The waiting room flow could build API requests before the room data was loaded by falling back to an empty string for `roomId`. This could lead to malformed requests such as `/rooms//waiting-participants/` or `/rooms//enter/`, and made the loading state harder to reason about.

## Proposal

Stop using an empty string fallback for the room id, only enable the waiting room query when a real room id is available, and fail fast in waiting room API helpers when the room id is missing.

- [x] remove the empty string fallback from the waiting room hook
- [x] only enable waiting room polling when `roomId` is available
- [x] guard waiting room API helpers against missing `roomId`
- [x] add a changelog entry for the fix
