### PR TITLE
♿️(frontend) set explicit document title on recording download page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🥅(backend) refine Twirp error handling for participant operations
 - ✨(summary) allow more file extensions #1265
 - ♿️(frontend) refocus reactions toolbar with ctrl+shift+e is activated #1262
+- ♿️(frontend) set an explicit document title on recording download page #1261
 
 ### Fixed
 

--- a/src/frontend/src/features/recording/routes/RecordingDownload.tsx
+++ b/src/frontend/src/features/recording/routes/RecordingDownload.tsx
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query'
 import { Center, VStack } from '@/styled-system/jsx'
 import { css } from '@/styled-system/css'
 import { useTranslation } from 'react-i18next'
+import { useTitle } from 'hoofd'
+import { useMemo } from 'react'
 import { mediaUrl } from '@/api/mediaUrl'
 import { UserAware, useUser } from '@/features/auth'
 import { Screen } from '@/layout/Screen'
@@ -13,6 +15,8 @@ import { LoadingScreen } from '@/components/LoadingScreen'
 import { fetchRecording } from '../api/fetchRecording'
 import { RecordingStatus } from '@/features/recording'
 import { useConfig } from '@/api/useConfig'
+
+const APP_TITLE = import.meta.env.VITE_APP_TITLE ?? ''
 
 const BetaBadge = () => (
   <span
@@ -48,6 +52,21 @@ export const RecordingDownload = () => {
     retry: false,
     enabled: !!recordingId,
   })
+
+  const isSaved =
+    data?.status === RecordingStatus.Saved ||
+    data?.status === RecordingStatus.NotificationSucceed ||
+    data?.status === RecordingStatus.FailedToStop
+
+  const pageTitle = useMemo(() => {
+    if (isError) return `${APP_TITLE} - ${t('error.title')}`
+    if (data && !isSaved) return `${APP_TITLE} - ${t('unsaved.title')}`
+    if (data?.is_expired) return `${APP_TITLE} - ${t('expired.title')}`
+    if (data && isSaved) return `${APP_TITLE} - ${t('success.title')}`
+    return APP_TITLE
+  }, [isError, data, isSaved, t])
+
+  useTitle(pageTitle)
 
   if (isLoggedIn === undefined || isAuthLoading) {
     return <LoadingScreen />


### PR DESCRIPTION
## Purpose

The browser tab showed only the generic app title (e.g. “LaSuite Meet” / “Visio”) on the recording download page, so users could not quickly tell which tab or context they were in.

<img width="1302" height="569" alt="Capture d&#39;écran 2026-04-10 095829" src="https://github.com/user-attachments/assets/3d31ecae-9dd6-4ad8-999f-a2fb2d02e064" />

## Proposal

- [x] Explicit tab title when the recording is ready (`success.title`)
- [x] Title aligned with the “not ready” state (`unsaved.title`) when the recording status is not saved / not downloadable ye