### PR TITLE
🐛(frontend) announce keyboard shortcut hint to screen readers

### DIFF
--- a/src/frontend/src/features/rooms/livekit/components/KeyboardShortcutHint.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/KeyboardShortcutHint.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 import { styled } from '@/styled-system/jsx'
+import { srOnly } from '@/styles/a11y'
 
 const Hint = styled('div', {
   base: {
@@ -26,6 +27,7 @@ const Hint = styled('div', {
 
 export interface KeyboardShortcutHintProps {
   children: ReactNode
+  announce?: boolean
 }
 
 /**
@@ -34,6 +36,21 @@ export interface KeyboardShortcutHintProps {
  */
 export const KeyboardShortcutHint: React.FC<KeyboardShortcutHintProps> = ({
   children,
+  announce = false,
 }) => {
-  return <Hint>{children}</Hint>
+  return (
+    <>
+      <Hint aria-hidden="true">{children}</Hint>
+      {announce ? (
+        <span
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className={srOnly}
+        >
+          {children}
+        </span>
+      ) : null}
+    </>
+  )
 }

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantTile.tsx
@@ -239,7 +239,7 @@ export const ParticipantTile: (
           )}
         </ParticipantContextIfNeeded>
       </TrackRefContextIfNeeded>
-      <KeyboardShortcutHint>
+      <KeyboardShortcutHint announce={hasKeyboardFocus}>
         {t('toolbarHint', {
           shortcut: formatShortcutLabel(
             getShortcutDescriptorById('open-shortcuts')?.shortcut


### PR DESCRIPTION
## Summary

Fixes #1175 by making the keyboard shortcut hint available to screen readers when a participant tile receives keyboard focus.

## Changes

- keep the existing visual shortcut hint for keyboard users
- hide the visual-only hint from assistive technologies to avoid duplicate output
- add a polite live-region announcement for the shortcut help message
- trigger the announcement only while the participant tile has keyboard focus

## Testing

- `npm run lint`
- `npm run check`

## Notes

This keeps the current visual behavior unchanged while exposing the same shortcut guidance to screen-reader users.
