### PR TITLE
⬆️(frontend) upgrade frontend image to Alpine 3.23 to address CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to
 - 🐛(summary) fix failure webhook notification #1233
 - 🐛(summary) relax whisperX payload format #1233
 - ⬆️(backend) upgrade dependencies to fix Pillow CVE-2026-40192
+- ⬆️(frontend) upgrade frontend image to Alpine 3.23 to address CVEs
 
 ## [1.13.0] - 2026-03-31
 

--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -39,15 +39,16 @@ COPY ./docker/dinum-frontend/fonts/ \
     ./dist/assets/fonts/
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:alpine3.21 AS frontend-production
+FROM nginxinc/nginx-unprivileged:alpine3.23 AS frontend-production
 
 USER root
-RUN apk update && apk upgrade libssl3 \
-    libcrypto3 \
-    libxml2>=2.12.7-r2 \
-    libxslt>=1.1.39-r2 \
-    libexpat>=2.7.2-r0 \
-    libpng>=1.6.53-r0
+
+# Security patches for known CVEs
+RUN apk update && apk upgrade  \
+    musl \
+    musl-utils \
+    zlib>=1.3.2-r0 \
+    && apk del curl
 
 USER nginx
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -39,15 +39,15 @@ ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 RUN npm run build
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:alpine3.21 AS frontend-production
+FROM nginxinc/nginx-unprivileged:alpine3.23 AS frontend-production
 
 USER root
-RUN apk update && apk upgrade libssl3 \
-    libcrypto3 \
-    libxml2>=2.12.7-r2 \
-    libxslt>=1.1.39-r2 \
-    libexpat>=2.7.2-r0 \
-    libpng>=1.6.53-r0 \
+
+# Security patches for known CVEs
+RUN apk update && apk upgrade  \
+    musl \
+    musl-utils \
+    zlib>=1.3.2-r0 \
     && apk del curl
 
 USER nginx


### PR DESCRIPTION
Bump the base image to Alpine 3.23 to resolve most vulnerabilities reported by Cyberwatch and Trivy.

Remaining issues require manual updates:
- musl / musl-utils: upgrade to 1.2.5-r11 (CVE-2026-40200)
- zlib: upgrade to 1.3.2-r0 (CVE-2026-22184)