### PR TITLE
📌(agents) pin Docker image to a specific tag for reproducible builds

### DIFF
--- a/src/agents/Dockerfile
+++ b/src/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS base
+FROM python:3.13.13-slim AS base
 
 # Install system dependencies required by LiveKit
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Avoid using floating tags and pin the image to an explicit version to ensure consistent and reproducible agent builds.
