### PR TITLE
fix: standardize role terminology across localizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 🔒️(backend) add validation of Room.configuration
 
+### Fixed
+
+- ♻(frontend) standardize role terminology across localizations
+
 ## [1.15.0] - 2026-04-30
 
 ### Added

--- a/src/frontend/src/locales/de/recording.json
+++ b/src/frontend/src/locales/de/recording.json
@@ -1,7 +1,7 @@
 {
   "error": {
     "title": "Aufzeichnung nicht verfügbar",
-    "body": "Die Aufzeichnung ist nicht verfügbar oder wurde möglicherweise gelöscht. Nur die*der Organisator:in der Besprechung hat Zugriff darauf. Wende dich bei Bedarf gerne an die Person."
+    "body": "Die Aufzeichnung ist nicht verfügbar oder wurde möglicherweise gelöscht. Nur der Host der Besprechung hat Zugriff darauf. Wende dich bei Bedarf gerne an die Person."
   },
   "expired": {
     "title": "Aufzeichnung abgelaufen",
@@ -22,7 +22,7 @@
     "button": "Herunterladen",
     "warning": {
       "title": "Linkfreigabe deaktiviert",
-      "body": "Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur Organisator:innen können sie herunterladen."
+      "body": "Die Freigabe der Aufzeichnung per Link ist noch nicht verfügbar. Nur Hosts können sie herunterladen."
     }
   }
 }

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -3,7 +3,7 @@
     "heading": {
       "normal": "Du hast das Meeting verlassen",
       "duplicateIdentity": "Du bist dem Meeting von einem anderen Gerät aus beigetreten",
-      "participantRemoved": "Du wurdest von der*dem Organisator:in aus dem Meeting entfernt"
+      "participantRemoved": "Du wurdest vom Host aus dem Meeting entfernt"
     },
     "home": "Zur Startseite zurückkehren",
     "back": "Dem Meeting erneut beitreten"
@@ -383,7 +383,7 @@
     "body": "Transkribiere bis zu {{max_duration}} Meetingdauer.",
     "bodyWithoutMaxDuration": "Transkribieren dein Meeting ohne Zeitbegrenzung.",
     "details": {
-      "receiver": "Das Transkript wird an die*den Organisator:in und die Mitorganisierenden gesendet.",
+      "receiver": "Das Transkript wird an den Host und die Co-Hosts gesendet.",
       "destination": "Ein neues Dokument wird erstellt auf",
       "destinationUnknown": "Ein neues Dokument wird erstellt",
       "language": "Meeting-Sprache:",
@@ -438,7 +438,7 @@
     "linkMore": "Dokumentation öffnen",
     "linkAriaLabel": "Dokumentation zur Aufzeichnung öffnen – öffnet in neuem Tab",
     "details": {
-      "receiver": "Die Aufzeichnung wird an die*den Organisator:in und die Mitorganisierenden gesendet.",
+      "receiver": "Die Aufzeichnung wird an den Host und die Co-Hosts gesendet.",
       "destination": "Diese Aufzeichnung wird vorübergehend auf unseren Servern gespeichert",
       "loading": "Aufzeichnung wird gestartet",
       "linkMore": "Mehr erfahren",
@@ -494,7 +494,7 @@
     "button": "OK"
   },
   "admin": {
-    "description": "Diese Einstellungen für Organisierende ermöglichen dir die Kontrolle über dein Meeting. Nur Organisierende haben Zugriff auf diese Optionen.",
+    "description": "Diese Host-Einstellungen ermöglichen dir die Kontrolle über dein Meeting. Nur Hosts haben Zugriff auf diese Optionen.",
     "access": {
       "title": "Raumzugang",
       "description": "Diese Einstellungen gelten auch für zukünftige Meetings in diesem Raum.",

--- a/src/frontend/src/locales/en/recording.json
+++ b/src/frontend/src/locales/en/recording.json
@@ -1,7 +1,7 @@
 {
   "error": {
     "title": "Recording unavailable",
-    "body": "The recording is unavailable or may have been deleted. Only the meeting organizer can access it. Feel free to contact them if needed."
+    "body": "The recording is unavailable or may have been deleted. Only the meeting host can access it. Feel free to contact them if needed."
   },
   "expired": {
     "title": "Recording expired",
@@ -22,7 +22,7 @@
     "button": "Download",
     "warning": {
       "title": "Link sharing disabled",
-      "body": "Sharing the recording via link is not yet available. Only organizers can download it."
+      "body": "Sharing the recording via link is not yet available. Only hosts can download it."
     }
   }
 }

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -3,7 +3,7 @@
     "heading": {
       "normal": "You have left the meeting",
       "duplicateIdentity": "You have joined the meeting from another device",
-      "participantRemoved": "You have been removed from the meeting by an administrator"
+      "participantRemoved": "You have been removed from the meeting by a host"
     },
     "home": "Return to home",
     "back": "Rejoin the meeting"
@@ -328,7 +328,7 @@
       "chat": "Messages in the chat",
       "transcript": "Transcribe",
       "screenRecording": "Record",
-      "admin": "Admin settings",
+      "admin": "Host settings",
       "tools": "More tools",
       "info": "Meeting information"
     },
@@ -338,7 +338,7 @@
       "chat": "messages",
       "transcript": "transcribe",
       "screenRecording": "record",
-      "admin": "admin settings",
+      "admin": "host settings",
       "tools": "more tools",
       "info": "meeting information"
     },
@@ -493,7 +493,7 @@
     "button": "OK"
   },
   "admin": {
-    "description": "These organizer settings allow you to maintain control of your meeting. Only organizers can access these controls.",
+    "description": "These host settings allow you to maintain control of your meeting. Only hosts can access these controls.",
     "access": {
       "title": "Room access",
       "description": "These settings will also apply to future occurrences of this meeting.",

--- a/src/frontend/src/locales/nl/recording.json
+++ b/src/frontend/src/locales/nl/recording.json
@@ -1,7 +1,7 @@
 {
   "error": {
     "title": "Opname niet beschikbaar",
-    "body": "De opname is niet beschikbaar of is mogelijk verwijderd. Alleen de organisator van de vergadering heeft toegang. Neem gerust contact met hem of haar op als dat nodig is."
+    "body": "De opname is niet beschikbaar of is mogelijk verwijderd. Alleen de host van de vergadering heeft toegang. Neem gerust contact met hem of haar op als dat nodig is."
   },
   "expired": {
     "title": "Opname verlopen",
@@ -22,7 +22,7 @@
     "button": "Downloaden",
     "warning": {
       "title": "Delen via link uitgeschakeld",
-      "body": "Het delen van de opname via een link is nog niet beschikbaar. Alleen organisatoren kunnen deze downloaden."
+      "body": "Het delen van de opname via een link is nog niet beschikbaar. Alleen hosts kunnen deze downloaden."
     }
   }
 }

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -437,7 +437,7 @@
     "linkMore": "Documentatie openen",
     "linkAriaLabel": "Documentatie over opname openen - opent in nieuw venster",
     "details": {
-      "receiver": "De opname wordt verzonden naar de organisator en co-organisatoren.",
+      "receiver": "De opname wordt verzonden naar de host en co-hosts.",
       "destination": "Deze opname wordt tijdelijk op onze servers bewaard",
       "loading": "Opname wordt gestart",
       "linkMore": "Meer informatie",
@@ -493,7 +493,7 @@
     "button": "Opnieuw proberen"
   },
   "admin": {
-    "description": "Deze organisatorinstellingen geven u controle over uw vergadering. Alleen organisatoren hebben toegang tot deze bedieningselementen.",
+    "description": "Deze hostinstellingen geven u controle over uw vergadering. Alleen hosts hebben toegang tot deze bedieningselementen.",
     "access": {
       "title": "Toegang tot vergadering",
       "description": "Deze instellingen zijn ook van toepassing op toekomstige sessies van deze vergadering.",


### PR DESCRIPTION
## Purpose

Fixes #1126 — inconsistent role terminology in localization files.

The localization files mixed several terms for the same host role:
- **en**: `administrator`, `organizer`, `organizers`, `Admin settings`
- **de**: `Organisator:in`, `Organisierende`, `Mitorganisierenden`
- **nl**: `organisator`, `organisatoren`, `co-organisatoren`

This PR standardizes all three locales on **host** / **co-host** across `rooms.json` and `recording.json`.

## Proposal

- [x] **English (en)**
  - `rooms.json`: `by an administrator` → `by a host`
  - `rooms.json`: `Admin settings` → `Host settings` (heading + content)
  - `rooms.json`: `organizer settings` → `host settings`, `organizers` → `hosts`
  - `recording.json`: `meeting organizer` → `meeting host`
  - `recording.json`: `Only organizers` → `Only hosts`
- [x] **German (de)**
  - `rooms.json`: `Organisator:in` → `Host` (participantRemoved, transcript/recording receiver)
  - `rooms.json`: `Organisierende` / `Mitorganisierenden` → `Hosts` / `Co-Hosts`
  - `rooms.json`: admin description standardized to `Host-Einstellungen` / `Hosts`
  - `recording.json`: `Organisator:in` → `Host`, `Organisator:innen` → `Hosts`
- [x] **Dutch (nl)**
  - `rooms.json`: `organisatorinstellingen` / `organisatoren` → `hostinstellingen` / `hosts`
  - `rooms.json`: `organisator en co-organisatoren` → `host en co-hosts`
  - `recording.json`: `organisator` → `host`, `organisatoren` → `hosts`

### Not changed

- `termsOfService.json` — legal document, left as-is.
- `fr` locale — already consistent with `organisateur`.
