### PR TITLE
refactor: unify TrackSource usage to livekit-client Track.Source (closes #1282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ✨(backend) add metadata collection of VAD, connection and chat events
 
+### Changed
+
+- ♻️(frontend) unify TrackSource usage to livekit-client Track.Source #1282
+
 ## [1.14.0] - 2026-04-16
 
 ### Added

--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/AudioDevicesControl.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/AudioDevicesControl.tsx
@@ -13,7 +13,7 @@ import * as React from 'react'
 import { SelectDevice } from './SelectDevice'
 import { SettingsButton } from './SettingsButton'
 import { SettingsDialogExtendedKey } from '@/features/settings/type'
-import { TrackSource } from '@livekit/protocol'
+
 import Source = Track.Source
 import { isSafari } from '@/utils/livekit'
 
@@ -53,7 +53,7 @@ export const AudioDevicesControl = ({
   const cannotUseDevice = useCannotUseDevice(kind)
   const selectLabel = t(`settings.${SettingsDialogExtendedKey.AUDIO}`)
 
-  const canPublishTrack = useCanPublishTrack(TrackSource.MICROPHONE)
+  const canPublishTrack = useCanPublishTrack(Track.Source.Microphone)
 
   return (
     <div

--- a/src/frontend/src/features/rooms/livekit/components/controls/Device/VideoDeviceControl.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Device/VideoDeviceControl.tsx
@@ -16,7 +16,6 @@ import * as React from 'react'
 import { SelectDevice } from './SelectDevice'
 import { SettingsButton } from './SettingsButton'
 import { SettingsDialogExtendedKey } from '@/features/settings/type'
-import { TrackSource } from '@livekit/protocol'
 
 const EffectsButton = ({ onPress }: { onPress: () => void }) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'selectDevice' })
@@ -97,7 +96,7 @@ export const VideoDeviceControl = ({
   }
 
   const selectLabel = t(`settings.${SettingsDialogExtendedKey.VIDEO}`)
-  const canPublishTrack = useCanPublishTrack(TrackSource.CAMERA)
+  const canPublishTrack = useCanPublishTrack(Track.Source.Camera)
 
   return (
     <div

--- a/src/frontend/src/features/rooms/livekit/components/controls/ScreenShareToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ScreenShareToggle.tsx
@@ -6,7 +6,7 @@ import { Track } from 'livekit-client'
 import React from 'react'
 import { type ButtonRecipeProps } from '@/primitives/buttonRecipe'
 import { ToggleButtonProps } from '@/primitives/ToggleButton'
-import { TrackSource } from '@livekit/protocol'
+
 import { useCanPublishTrack } from '@/features/rooms/livekit/hooks/useCanPublishTrack'
 
 type Props = Omit<
@@ -31,7 +31,7 @@ export const ScreenShareToggle = ({
   const tooltipLabel = enabled ? 'stop' : 'start'
   const Icon = enabled ? RiCloseFill : RiArrowUpLine
 
-  const canShareScreen = useCanPublishTrack(TrackSource.SCREEN_SHARE)
+  const canShareScreen = useCanPublishTrack(Track.Source.ScreenShare)
 
   // fixme - remove ToggleButton custom styles when we design a proper icon
   return (

--- a/src/frontend/src/features/rooms/livekit/components/effects/Effects.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/effects/Effects.tsx
@@ -1,15 +1,14 @@
 import { useLocalParticipant } from '@livekit/components-react'
-import { LocalVideoTrack } from 'livekit-client'
+import { LocalVideoTrack, Track } from 'livekit-client'
 import { css } from '@/styled-system/css'
 import { EffectsConfiguration } from './EffectsConfiguration'
 import { useCanPublishTrack } from '@/features/rooms/livekit/hooks/useCanPublishTrack'
-import { TrackSource } from '@livekit/protocol'
 
 export const Effects = () => {
   const { cameraTrack } = useLocalParticipant()
   const localCameraTrack = cameraTrack?.track as LocalVideoTrack
 
-  const canPublishCamera = useCanPublishTrack(TrackSource.CAMERA)
+  const canPublishCamera = useCanPublishTrack(Track.Source.Camera)
 
   return (
     <div

--- a/src/frontend/src/features/rooms/livekit/hooks/useCanPublishTrack.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useCanPublishTrack.ts
@@ -1,17 +1,32 @@
 import { TrackSource } from '@livekit/protocol'
+import { Track } from 'livekit-client'
 import {
   useLocalParticipant,
   useParticipantPermissions,
 } from '@livekit/components-react'
 
-export function useCanPublishTrack(trackSource: TrackSource): boolean {
+/**
+ * Maps livekit-client Track.Source (string enum) to
+ * @livekit/protocol TrackSource (numeric enum) used by permissions.
+ */
+const trackSourceToProtocol: Record<string, TrackSource> = {
+  [Track.Source.Camera]: TrackSource.CAMERA,
+  [Track.Source.Microphone]: TrackSource.MICROPHONE,
+  [Track.Source.ScreenShare]: TrackSource.SCREEN_SHARE,
+  [Track.Source.ScreenShareAudio]: TrackSource.SCREEN_SHARE_AUDIO,
+}
+
+export function useCanPublishTrack(source: Track.Source): boolean {
   const { localParticipant } = useLocalParticipant()
   const permissions = useParticipantPermissions({
     participant: localParticipant,
   })
 
+  const protocolSource = trackSourceToProtocol[source]
+
   return Boolean(
     permissions?.canPublish &&
-    permissions?.canPublishSources?.includes(trackSource)
+    protocolSource !== undefined &&
+    permissions?.canPublishSources?.includes(protocolSource)
   )
 }


### PR DESCRIPTION
## Purpose

Refactors the codebase to consistently use `Track.Source` from `livekit-client` instead of mixing it with `TrackSource` from `@livekit/protocol`. Closes #1282.

The frontend used two different enums for the same concept:
- `TrackSource` from `@livekit/protocol` (protobuf, numeric values)
- `Track.Source` from `livekit-client` (string enum)

This created unnecessary coupling to the protocol layer in component files.

## Proposal

- [x] Refactor `useCanPublishTrack` hook to accept `Track.Source` (livekit-client) as its public API
- [x] Add internal mapping from `Track.Source` to `TrackSource` (protocol) for the permissions check
- [x] Update all 4 caller components to use `Track.Source` and remove their `@livekit/protocol` imports
- [x] Isolate the protocol dependency to the single hook
