### PR TITLE
🐛(summary) support webm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ✨(backend) add metadata collection of VAD, connection and chat events
 
+### Fixed
+
+- 🐛(summary) support webm #1290
+
 ## [1.14.0] - 2026-04-16
 
 ### Added

--- a/src/summary/pyproject.toml
+++ b/src/summary/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "celery==5.6.2",
     "redis==5.2.1",
     "minio==7.2.20",
-    "mutagen==1.47.0",
     "openai==2.28.0",
     "posthog==7.9.12",
     "requests==2.33.0",

--- a/src/summary/summary/core/file_service.py
+++ b/src/summary/summary/core/file_service.py
@@ -1,6 +1,7 @@
 """File service to encapsulate files' manipulations."""
 
 import io
+import json
 import logging
 import os
 import subprocess
@@ -10,7 +11,6 @@ from datetime import timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
-import mutagen
 import requests
 from minio import Minio
 from minio.error import MinioException, S3Error
@@ -155,8 +155,24 @@ class FileService:
 
     def _validate_duration(self, local_path: Path) -> float:
         """Validate audio file duration against configured maximum."""
-        file_metadata = mutagen.File(local_path).info
-        duration = file_metadata.length
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-show_format",
+                local_path,
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        data = json.loads(result.stdout)
+        duration = float(data["format"]["duration"])
 
         logger.info(
             "Recording file duration: %.2f seconds",


### PR DESCRIPTION
Mutagen lib doesn't support webm files.
Since we have ffmpeg installed I just switch to
using ffprobe for a broader support.