### PR TITLE
💚(summary) add ruff ignore on ffprobe run

### DIFF
--- a/src/summary/summary/core/file_service.py
+++ b/src/summary/summary/core/file_service.py
@@ -155,6 +155,7 @@ class FileService:
 
     def _validate_duration(self, local_path: Path) -> float:
         """Validate audio file duration against configured maximum."""
+        # ruff: noqa: S607 Hard to know the ffprobe path, it depends on the deployment
         result = subprocess.run(
             [
                 "ffprobe",


### PR DESCRIPTION
It's hard to know the ffprobe path before hand depending on the environment, so I prefer to ignore the linting error.