### PR TITLE
🩹(frontend) use a more standard (quality) rating scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 - 🐛(summary) support webm #1290
 - ⬆️(backend) bump django-lasuite to v0.0.26
+- 🩹(frontend) use a more standard (quality) rating scale
 
 ## [1.14.0] - 2026-04-16
 

--- a/src/frontend/src/features/rooms/components/Rating.tsx
+++ b/src/frontend/src/features/rooms/components/Rating.tsx
@@ -144,7 +144,7 @@ const RateQuality = ({
   posthog,
   onNext,
   metadata,
-  maxRating = 7,
+  maxRating = 5,
 }: {
   posthog: PostHog
   onNext: () => void


### PR DESCRIPTION
A 1–7 scale is not commonly used in software products. Feedback from both users and the support team suggests reducing the number of options to simplify usage and analysis.

Adopting a 1–5 scale improves usability and makes responses easier to interpret and process.

The scale has to be odd.
