### PR TITLE
🩹(frontend) rename Nginx config to override default configuration

### DIFF
--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -79,7 +79,7 @@ COPY --from=addons-builder \
     /home/addons/outlook/dist \
     /usr/share/nginx/html/addons/outlook
 
-COPY ./docker/dinum-frontend/nginx/dinum.conf /etc/nginx/conf.d
+COPY ./docker/dinum-frontend/nginx/default.conf /etc/nginx/conf.d
 COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]

--- a/docker/dinum-frontend/nginx/default.conf
+++ b/docker/dinum-frontend/nginx/default.conf
@@ -5,8 +5,6 @@ server {
 
   root /usr/share/nginx/html;
 
-  include /etc/nginx/extra/*.conf;
-
   location = /.well-known/windows-app-web-link {
       default_type application/json;
       alias /usr/share/nginx/html/.well-known/windows-app-web-link;
@@ -33,6 +31,7 @@ server {
 
   location ~ ^/addons/outlook(/.*)?$ {
       alias /usr/share/nginx/html/addons/outlook$1;
+      error_page 404 =200 /index.html;
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       add_header Pragma "no-cache" always;
       add_header Expires 0 always;
@@ -53,7 +52,6 @@ server {
 
       sub_filter 'NONCE_PLACEHOLDER' $nonce;
       sub_filter_once off;
-      sub_filter_types text/html;
   }
 
   # Serve static files with caching


### PR DESCRIPTION
Rename the configuration file to `default.conf` so it replaces the default config bundled in the Nginx image.

Handles properly 404 path.