### PR TITLE
🩹(frontend) fix access control for screen recording feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - 🐛(summary) support webm #1290
 - ⬆️(backend) bump django-lasuite to v0.0.26
 - 🩹(frontend) use a more standard (quality) rating scale
+- 🩹(frontend) fix access control for screen recording feature flag
 
 ## [1.14.0] - 2026-04-16
 

--- a/src/frontend/src/features/recording/components/NoAccessView.tsx
+++ b/src/frontend/src/features/recording/components/NoAccessView.tsx
@@ -21,6 +21,7 @@ interface NoAccessViewProps {
   imagePath: string
   handleRequest: () => Promise<void>
   isActive: boolean
+  isAdminOrOwner?: boolean
 }
 
 export const NoAccessView = ({
@@ -30,6 +31,7 @@ export const NoAccessView = ({
   imagePath,
   handleRequest,
   isActive,
+  isAdminOrOwner = false,
 }: NoAccessViewProps) => {
   const { isLoggedIn } = useUser()
   const { t } = useTranslation('rooms', { keyPrefix: i18nKeyPrefix })
@@ -105,7 +107,7 @@ export const NoAccessView = ({
       {!isLoggedIn && !isActive && (
         <Divider label={t(`${i18nKey}.dividerLabel`)} />
       )}
-      {!isActive && (
+      {!isActive && !isAdminOrOwner && (
         <RequestRecording
           heading={t(`${i18nKey}.request.heading`)}
           body={t(`${i18nKey}.request.body`)}

--- a/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/ScreenRecordingSidePanel.tsx
@@ -5,6 +5,7 @@ import { useRoomId } from '@/features/rooms/livekit/hooks/useRoomId'
 import { useRoomContext } from '@livekit/components-react'
 import {
   RecordingMode,
+  useHasRecordingAccess,
   useHumanizeRecordingMaxDuration,
   useRecordingStatuses,
 } from '@/features/recording'
@@ -26,7 +27,8 @@ import { Checkbox } from '@/primitives/Checkbox'
 import { useTranscriptionLanguage } from '@/features/settings'
 import { useMutateRecording } from '../hooks/useMutateRecording'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
-import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner.ts'
+import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { FeatureFlags } from '@/features/analytics/enums'
 
 export const ScreenRecordingSidePanel = () => {
   const { data } = useConfig()
@@ -38,6 +40,11 @@ export const ScreenRecordingSidePanel = () => {
   const [includeTranscript, setIncludeTranscript] = useState(false)
 
   const isAdminOrOwner = useIsAdminOrOwner()
+
+  const hasScreenRecordingAccess = useHasRecordingAccess(
+    RecordingMode.ScreenRecording,
+    FeatureFlags.ScreenRecording
+  )
 
   const { notifyParticipants } = useNotifyParticipants()
   const { selectedLanguageKey, isLanguageSetToAuto } =
@@ -113,6 +120,19 @@ export const ScreenRecordingSidePanel = () => {
         imagePath="/assets/intro-slider/4.png"
         handleRequest={handleRequestScreenRecording}
         isActive={statuses.isActive}
+      />
+    )
+  }
+
+  if (!hasScreenRecordingAccess) {
+    return (
+      <NoAccessView
+        i18nKeyPrefix={keyPrefix}
+        i18nKey="premium"
+        imagePath="/assets/intro-slider/3.png"
+        isActive={statuses.isActive}
+        handleRequest={handleRequestScreenRecording}
+        isAdminOrOwner={isAdminOrOwner}
       />
     )
   }

--- a/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
+++ b/src/frontend/src/features/recording/components/TranscriptSidePanel.tsx
@@ -34,6 +34,7 @@ import { RowWrapper } from './RowWrapper'
 import { useMutateRecording } from '../hooks/useMutateRecording'
 import { useIsMetadataCollectorEnabled } from '../hooks/useMetadataCollectorEnabled'
 import { useSidePanel } from '@/features/rooms/livekit/hooks/useSidePanel'
+import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
 
 export const TranscriptSidePanel = () => {
   const { data } = useConfig()
@@ -59,6 +60,8 @@ export const TranscriptSidePanel = () => {
     RecordingMode.Transcript,
     FeatureFlags.Transcript
   )
+
+  const isAdminOrOwner = useIsAdminOrOwner()
 
   const isMetadataCollectorEnabled = useIsMetadataCollectorEnabled()
 
@@ -153,6 +156,7 @@ export const TranscriptSidePanel = () => {
         imagePath="/assets/intro-slider/3.png"
         handleRequest={handleRequestTranscription}
         isActive={statuses.isActive}
+        isAdminOrOwner={isAdminOrOwner}
       />
     )
   }

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -416,7 +416,7 @@
     },
     "premium": {
       "heading": "Premium-Funktion",
-      "body": "Diese Funktion ist öffentlichen Bediensteten vorbehalten. Wenn deine E-Mail-Adresse nicht autorisiert ist, kontaktiere bitte den Support, um Zugriff zu erhalten.",
+      "body": "Diese Funktion ist für Sie nicht verfügbar. Bitte wenden Sie sich an den Support, um weitere Informationen zu erhalten.",
       "linkMore": "Dokumentation öffnen",
       "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
@@ -456,6 +456,22 @@
       "body": "Aus Sicherheitsgründen kann nur die*der Ersteller:in bzw. Admin des Meetings eine Videoaufnahme (Beta) starten.",
       "linkMore": "Dokumentation öffnen",
       "linkAriaLabel": "Dokumentation zum Aufzeichnungszugang öffnen – öffnet in neuem Tab",
+      "dividerLabel": "ODER",
+      "login": {
+        "heading": "Anmeldung erforderlich",
+        "body": "Nur die*der Ersteller:in bzw. Admin kann die Aufzeichnung starten. Melde dich an, um deine Berechtigungen zu überprüfen."
+      },
+      "request": {
+        "heading": "Aufnahme anfragen",
+        "body": "Die Moderation wird benachrichtigt und kann die Aufnahme starten.",
+        "buttonLabel": "Anfrage senden"
+      }
+    },
+    "premium": {
+      "heading": "Premium-Funktion",
+      "body": "Diese Funktion ist für Sie nicht verfügbar. Bitte wenden Sie sich an den Support, um weitere Informationen zu erhalten.",
+      "linkMore": "Dokumentation öffnen",
+      "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -415,7 +415,7 @@
     },
     "premium": {
       "heading": "Premium feature",
-      "body": "This feature is reserved for public agents. If your email address is not authorized, please contact support to get access.",
+      "body": "This feature is not available to you. Please contact support for more information.",
       "linkMore": "Open documentation",
       "linkAriaLabel": "Open documentation about premium access - opens in new window",
       "dividerLabel": "OR",
@@ -459,6 +459,22 @@
       "login": {
         "heading": "Login Required",
         "body": "Only the meeting creator or an admin can start screen recording. Log in to verify your permissions."
+      },
+      "request": {
+        "heading": "Request Recording",
+        "body": "The host will be notified and can enable recording for you.",
+        "buttonLabel": "Request"
+      }
+    },
+    "premium": {
+      "heading": "Premium feature",
+      "body": "This feature is not available to you. Please contact support for more information.",
+      "linkMore": "Open documentation",
+      "linkAriaLabel": "Open documentation about premium access - opens in new window",
+      "dividerLabel": "OR",
+      "login": {
+        "heading": "You are not logged in!",
+        "body": "You must be logged in to use this feature. Please log in, then try again."
       },
       "request": {
         "heading": "Request Recording",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -415,7 +415,7 @@
     },
     "premium": {
       "heading": "Fonctionnalité premium",
-      "body": "Cette fonctionnalité est réservée aux agents publics. Si votre adresse email n’est pas autorisée, contactez le support pour obtenir l'accès.",
+      "body": "Cette fonctionnalité ne vous est pas ouverte. Contactez le support pour obtenir plus d'informations.",
       "linkMore": "Ouvrir la documentation",
       "dividerLabel": "OU",
       "login": {
@@ -465,6 +465,22 @@
         "body": "L'hôte recevra une notification et pourra démarrer l'enregistrement pour vous.",
         "buttonLabel": "Demander"
       }
+    },
+    "premium": {
+      "heading": "Fonctionnalité premium",
+      "body": "Cette fonctionnalité ne vous est pas ouverte. Contactez le support pour obtenir plus d'informations.",
+      "linkMore": "Ouvrir la documentation",
+      "dividerLabel": "OU",
+      "login": {
+        "heading": "Vous n'êtes pas connecté !",
+        "body": "Vous devez être connecté pour utiliser cette fonctionnalité. Connectez-vous, puis réessayez."
+      },
+      "request": {
+        "heading": "Demander à l'organisateur",
+        "body": "L'hôte recevra une notification et pourra démarrer l'enregistrement pour vous.",
+        "buttonLabel": "Demander"
+      },
+      "linkAriaLabel": "Ouvrir la documentation sur l'accès premium - ouvre dans une nouvelle fenêtre"
     },
     "durationMessage": "(limité à {{max_duration}}) "
   },

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -415,7 +415,7 @@
     },
     "premium": {
       "heading": "Premiumfunctie",
-      "body": "Deze functie is voorbehouden aan openbare medewerkers. Als uw e-mailadres niet is toegestaan, neem dan contact op met de support om toegang te krijgen.",
+      "body": "Deze functie is niet voor u beschikbaar. Neem contact op met de ondersteuning voor meer informatie.",
       "linkMore": "Documentatie openen",
       "linkAriaLabel": "Documentatie over premiumtoegang openen - opent in nieuw venster",
       "dividerLabel": "OF",
@@ -455,6 +455,22 @@
       "body": "Om veiligheidsredenen kan alleen de maker of een beheerder van de vergadering een opname starten (beta).",
       "linkMore": "Documentatie openen",
       "linkAriaLabel": "Documentatie over opnametoegang openen - opent in nieuw venster",
+      "dividerLabel": "OF",
+      "login": {
+        "heading": "Inloggen vereist",
+        "body": "Alleen de maker van de vergadering of een beheerder kan de opname starten. Log in om uw machtigingen te controleren."
+      },
+      "request": {
+        "heading": "Opname aanvragen",
+        "body": "De host wordt op de hoogte gebracht en kan de opname voor u inschakelen.",
+        "buttonLabel": "Aanvragen"
+      }
+    },
+    "premium": {
+      "heading": "Premiumfunctie",
+      "body": "Deze functie is niet voor u beschikbaar. Neem contact op met de ondersteuning voor meer informatie.",
+      "linkMore": "Documentatie openen",
+      "linkAriaLabel": "Documentatie over premiumtoegang openen - opent in nieuw venster",
       "dividerLabel": "OF",
       "login": {
         "heading": "Inloggen vereist",


### PR DESCRIPTION
Ensure screen recording is properly disabled when the feature flag is set to false.

Previously, no feature flag was enforced, allowing unintended access.

Also update the blocked-access message to be more generic and not specific to public sector users.
