### PR TITLE
🩹(frontend) fix reconnect loop caused by connectionObserverStore updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - ⬆️(backend) bump django-lasuite to v0.0.26
 - 🩹(frontend) use a more standard (quality) rating scale
 - 🩹(frontend) fix access control for screen recording feature flag
+- 🩹(frontend) fix reconnect loop caused by connectionObserverStore updates
 
 ## [1.14.0] - 2026-04-16
 

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -31,7 +31,6 @@ import { useConfig } from '@/api/useConfig'
 import { isFireFox } from '@/utils/livekit'
 import { useIsMobile } from '@/utils/useIsMobile'
 import { navigateTo } from '@/navigation/navigateTo'
-import { useSnapshot } from 'valtio'
 import { connectionObserverStore } from '@/stores/connectionObserver'
 
 export const Conference = ({
@@ -45,8 +44,6 @@ export const Conference = ({
 }) => {
   const posthog = usePostHog()
   const { data: apiConfig } = useConfig()
-
-  const connectionObserverSnap = useSnapshot(connectionObserverStore)
 
   const { userChoices: userConfig } = usePersistentUserChoices() as {
     userChoices: LocalUserChoices
@@ -234,16 +231,16 @@ export const Conference = ({
           onDisconnected={(e) => {
             const metadata = {
               room_id: roomId,
-              pc_publisher: connectionObserverSnap.publisher && {
-                ...connectionObserverSnap.publisher,
+              pc_publisher: connectionObserverStore.publisher && {
+                ...connectionObserverStore.publisher,
               },
-              pc_subscriber: connectionObserverSnap.subscriber && {
-                ...connectionObserverSnap.subscriber,
+              pc_subscriber: connectionObserverStore.subscriber && {
+                ...connectionObserverStore.subscriber,
               },
               pc_publisher_changes_count:
-                connectionObserverSnap.publisherChangesCount,
+                connectionObserverStore.publisherChangesCount,
               pc_subscriber_changes_count:
-                connectionObserverSnap.subscriberChangesCount,
+                connectionObserverStore.subscriberChangesCount,
             }
 
             connectionObserverStore.publisher = null


### PR DESCRIPTION
Updating connectionObserverSnapshot triggered page re-renders, causing participants to reconnect due to a race condition.

Read directly from the underlying store instead of using the snapshot to avoid unnecessary re-renders.
