### PR TITLE
🔒️(backend) cap and throttle room invitation endpoint to prevent abuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - ♻(frontend) standardize role terminology across localizations
 - 🐛(backend) make start-recording atomic and fault-tolerant
 - 🔒️(frontend) room ids are generated with non-cryptographic rand
+- 🔒️(backend) cap and throttle room invitation endpoint to prevent abuse
 
 ## [1.15.0] - 2026-04-30
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -300,6 +300,15 @@ class RoomInviteSerializer(serializers.Serializer):
 
     emails = serializers.ListField(child=serializers.EmailField(), allow_empty=False)
 
+    def validate_emails(self, value):
+        """Cap the number of recipients per request."""
+        max_emails = settings.ROOM_INVITE_MAX_EMAILS
+        if len(value) > max_emails:
+            raise serializers.ValidationError(
+                f"Cannot invite more than {max_emails} recipients in a single request."
+            )
+        return value
+
 
 class BaseParticipantsManagementSerializer(BaseValidationOnlySerializer):
     """Base serializer for participant management operations."""

--- a/src/backend/core/api/throttling.py
+++ b/src/backend/core/api/throttling.py
@@ -73,3 +73,23 @@ class CreationCallbackAnonRateThrottle(MonitoredAnonRateThrottle):
     """Throttle Anonymous user requesting room generation callback"""
 
     scope = "creation_callback"
+
+
+class InviteBurstUserRateThrottle(MonitoredUserRateThrottle):
+    """Burst throttle for the room invitation endpoint.
+
+    Caps the request rate to a near-human cadence to deter scripted loops
+    from a single authenticated account.
+    """
+
+    scope = "invite_burst"
+
+
+class InviteSustainedUserRateThrottle(MonitoredUserRateThrottle):
+    """Sustained throttle for the room invitation endpoint.
+
+    Catches slower but persistent abuse that would slip past the burst
+    throttle by pacing requests just under one per second.
+    """
+
+    scope = "invite_sustained"

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -552,6 +552,10 @@ class RoomViewSet(
         permission_classes=[
             permissions.HasPrivilegesOnRoom,
         ],
+        throttle_classes=[
+            throttling.InviteBurstUserRateThrottle,
+            throttling.InviteSustainedUserRateThrottle,
+        ],
     )
     def invite(self, request, pk=None):  # pylint: disable=unused-argument
         """Send email invitations to join a room.

--- a/src/backend/core/tests/rooms/test_api_rooms_invite.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_invite.py
@@ -187,6 +187,53 @@ def test_api_rooms_invite_partially_invalid_emails():
 
 
 @mock.patch.object(InvitationService, "invite_to_room")
+def test_api_rooms_invite_too_many_emails(mock_invite_to_room, settings):
+    """Should reject payloads exceeding ROOM_INVITE_MAX_EMAILS without sending."""
+    settings.ROOM_INVITE_MAX_EMAILS = 5
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+    client.force_login(user)
+
+    emails = [f"user{i}@yopmail.com" for i in range(6)]
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps({"emails": emails}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert "emails" in response.json()
+    mock_invite_to_room.assert_not_called()
+
+
+@mock.patch.object(InvitationService, "invite_to_room")
+def test_api_rooms_invite_at_cap_accepted(mock_invite_to_room, settings):
+    """Should accept payloads of exactly ROOM_INVITE_MAX_EMAILS recipients."""
+    settings.ROOM_INVITE_MAX_EMAILS = 5
+
+    client = APIClient()
+    room = RoomFactory()
+    user = UserFactory()
+    room.accesses.create(user=user, role=random.choice(["administrator", "owner"]))
+    client.force_login(user)
+
+    emails = [f"user{i}@yopmail.com" for i in range(5)]
+
+    response = client.post(
+        f"/api/v1.0/rooms/{room.id}/invite/",
+        json.dumps({"emails": emails}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    mock_invite_to_room.assert_called_once()
+
+
+@mock.patch.object(InvitationService, "invite_to_room")
 def test_api_rooms_invite_duplicates(mock_invite_to_room):
     """Test duplicate emails should be deduplicated before processing."""
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -344,6 +344,16 @@ class Base(Configuration):
                 environ_name="CREATION_CALLBACK_THROTTLE_RATES",
                 environ_prefix=None,
             ),
+            "invite_burst": values.Value(
+                default="1/second",
+                environ_name="INVITE_BURST_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
+            "invite_sustained": values.Value(
+                default="10/minute",
+                environ_name="INVITE_SUSTAINED_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
         },
     }
     MONITORED_THROTTLE_FAILURE_CALLBACK = (
@@ -806,6 +816,13 @@ class Base(Configuration):
     ROOM_CREATION_CALLBACK_CACHE_TIMEOUT = values.PositiveIntegerValue(
         600,  # 10 minutes
         environ_name="ROOM_CREATION_CALLBACK_CACHE_TIMEOUT",
+        environ_prefix=None,
+    )
+
+    # Maximum recipients accepted by the room invitation endpoint per request.
+    ROOM_INVITE_MAX_EMAILS = values.PositiveIntegerValue(
+        50,
+        environ_name="ROOM_INVITE_MAX_EMAILS",
         environ_prefix=None,
     )
 


### PR DESCRIPTION
The invite endpoint accepted unbounded email lists and had no rate limit, letting any room owner trigger arbitrary volumes of outgoing mail. This adds a per-request cap (ROOM_INVITE_MAX_EMAILS, default 50) enforced by the serializer, plus stacked burst (1/second) and sustained (10/minute) per-user throttles in the spirit of the existing request_entry throttles.
