### PR TITLE
🔊(summary) Improve logging of speaker assign

### DIFF
--- a/src/summary/summary/core/user_assign.py
+++ b/src/summary/summary/core/user_assign.py
@@ -8,9 +8,10 @@ Multiple speakers can map to the same participant (e.g. two people sharing
 one microphone). A participant with no matching speaker gets no assignment.
 """
 
+import json
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime
 from typing import Any
 
@@ -318,6 +319,24 @@ def _build_speaker_timelines(transcription: Any) -> dict[str, list[Interval]]:
     return intervals
 
 
+def _json_default(obj: Any) -> Any:
+    """Encode datetimes, dataclasses, and pydantic models for `json.dumps`.
+
+    Intended to be used for logging of `resolve_speaker_identities` (input
+    and computed variables)
+    """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return asdict(obj)
+    if hasattr(obj, "segments") and hasattr(obj, "word_segments"):
+        return {"segments": obj.segments, "word_segments": obj.word_segments}
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
 def resolve_speaker_identities(
     metadata: dict[str, Any],
     transcription: Any,
@@ -343,17 +362,6 @@ def resolve_speaker_identities(
         metadata, recording_start_datetime, recording_end_datetime
     )
     speaker_timelines = _build_speaker_timelines(transcription)
-
-    logger.debug(
-        "Assignment inputs: %d participants, %d speakers\n%s\n%s\n%s",
-        len(participant_timelines),
-        len(speaker_timelines),
-        participant_timelines,
-        speaker_timelines,
-        _format_timelines_debug(
-            participant_timelines, participant_names, speaker_timelines
-        ),
-    )
 
     result = AssignmentResult()
 
@@ -396,5 +404,31 @@ def resolve_speaker_identities(
                 best_score,
                 overlap_threshold,
             )
+
+    logger.debug(
+        json.dumps(
+            {
+                "input": {
+                    "recording_start_datetime": recording_start_datetime.isoformat(),
+                    "recording_end_datetime": recording_end_datetime.isoformat(),
+                    "metadata": metadata,
+                    "transcription": transcription,
+                },
+                "computed": {
+                    "speaker_timelines": speaker_timelines,
+                    "participant_timelines": participant_timelines,
+                    "result": result,
+                },
+            },
+            default=_json_default,
+            indent=2,
+            ensure_ascii=False,
+        ),
+    )
+    logger.debug(
+        _format_timelines_debug(
+            participant_timelines, participant_names, speaker_timelines
+        ),
+    )
 
     return result


### PR DESCRIPTION
## Purpose

Improve logging output and opportunistic fix of bug when developing using docker.

# Proposal:



```
            {
                "input": {
                    "recording_start_datetime": recording_start_datetime.isoformat(),
                    "recording_end_datetime": recording_end_datetime.isoformat(),
                    "metadata": metadata,
                    "transcription": transcription,
                },
                "computed": {
                    "speaker_timelines": speaker_timelines,
                    "participant_timelines": participant_timelines,
                    "result": result,
                },
            },
```



```
[2026-05-13 10:10:33,206: DEBUG/MainProcess] {
  "input": {
    "recording_start_datetime": "2026-05-13T10:10:24.095621+00:00",
    "recording_end_datetime": "2026-05-13T10:10:32.096611+00:00",
    "metadata": {
      "events": [
        {
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "type": "participant_connected",
          "timestamp": "2026-05-13T10:10:23.179064+00:00",
          "data": null
        },
        {
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "type": "speech_start",
          "timestamp": "2026-05-13T10:10:25.611214+00:00",
          "data": null
        },
        {
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "type": "speech_end",
          "timestamp": "2026-05-13T10:10:27.560992+00:00",
          "data": null
        },
        {
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "type": "speech_start",
          "timestamp": "2026-05-13T10:10:28.113836+00:00",
          "data": null
        },
        {
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "type": "speech_end",
          "timestamp": "2026-05-13T10:10:31.864194+00:00",
          "data": null
        }
      ],
      "participants": [
        {
          "participantId": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "name": "CaMeLeDeV"
        }
      ]
    },
    "transcription": {
      "segments": [
        {
          "start": 1.415,
          "end": 6.835,
          "text": " Petite démonstration pour montrer l'output du logging.",
          "words": [
            {
              "word": "Petite",
              "start": 1.415,
              "end": 2.037,
              "score": 0.726,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "démonstration",
              "start": 2.077,
              "end": 3.984,
              "score": 0.89,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "pour",
              "start": 4.025,
              "end": 4.265,
              "score": 0.862,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "montrer",
              "start": 4.285,
              "end": 4.888,
              "score": 0.876,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "l'output",
              "start": 4.928,
              "end": 5.751,
              "score": 0.649,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "du",
              "start": 5.791,
              "end": 6.373,
              "score": 0.958,
              "speaker": "SPEAKER_00"
            },
            {
              "word": "logging.",
              "start": 6.413,
              "end": 6.835,
              "score": 0.715,
              "speaker": "SPEAKER_00"
            }
          ],
          "speaker": "SPEAKER_00"
        }
      ],
      "word_segments": [
        {
          "word": "Petite",
          "start": 1.415,
          "end": 2.037,
          "score": 0.726,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "démonstration",
          "start": 2.077,
          "end": 3.984,
          "score": 0.89,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "pour",
          "start": 4.025,
          "end": 4.265,
          "score": 0.862,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "montrer",
          "start": 4.285,
          "end": 4.888,
          "score": 0.876,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "l'output",
          "start": 4.928,
          "end": 5.751,
          "score": 0.649,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "du",
          "start": 5.791,
          "end": 6.373,
          "score": 0.958,
          "speaker": "SPEAKER_00"
        },
        {
          "word": "logging.",
          "start": 6.413,
          "end": 6.835,
          "score": 0.715,
          "speaker": "SPEAKER_00"
        }
      ]
    }
  },
  "computed": {
    "speaker_timelines": {
      "SPEAKER_00": [
        {
          "start": 1.415,
          "end": 3.077
        },
        {
          "start": 4.025,
          "end": 6.835
        }
      ]
    },
    "participant_timelines": {
      "042bdc02-9a87-436b-a3a3-9960c43ac473": [
        {
          "start": 1.5155928134918213,
          "end": 3.4653708934783936
        },
        {
          "start": 4.01821494102478,
          "end": 7.768572807312012
        }
      ]
    },
    "result": {
      "assignments": [
        {
          "speaker_label": "SPEAKER_00",
          "participant_id": "042bdc02-9a87-436b-a3a3-9960c43ac473",
          "participant_name": "CaMeLeDeV",
          "score": 0.9775060792728486
        }
      ],
      "unassigned_speakers": []
    }
  }
}
```