### PR TITLE
🩹(frontend) fix spacing regression in mobile control bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to
 - ⬆️(mail) fix dependencies not having resolved or integrity field #1321
 - 🐛(summary) complete webm support #1328
 - 🐛(backend) add link to "Open" text in recording email
+- 🩹(frontend) fix spacing regression in mobile control bar
 
 ## [1.15.0] - 2026-04-30
 

--- a/src/frontend/src/features/layout/components/ControlBarRegion.tsx
+++ b/src/frontend/src/features/layout/components/ControlBarRegion.tsx
@@ -12,7 +12,7 @@ const controlBarRegion = cva({
   variants: {
     mobile: {
       true: {
-        justifyContent: 'space-between',
+        justifyContent: 'center',
         width: '330px',
       },
     },


### PR DESCRIPTION
Correct excessive spacing between action buttons in the mobile control bar introduced by a recent layout change.