### PR TITLE
(paas) remove buildpack requirements.txt to use the new uv.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - ♻️(fullstack) simplify source serialization
 - ✨(backend) expose room configuration to all API consumers
 - 🩹(frontend) improve reaction toolbar centering with dynamic positioning
+- 🚀 (paas) remove buildpack requirements.txt to use the new uv.lock #1349
 
 ## [1.16.0] - 2026-05-13
 

--- a/bin/buildpack_postfrontend.sh
+++ b/bin/buildpack_postfrontend.sh
@@ -47,4 +47,3 @@ mv src/backend/* ./
 mv deploy/paas/* ./
 
 echo "3.13" > .python-version
-echo "." > requirements.txt


### PR DESCRIPTION
Current version depended on poetry which wasn't handled by buildpack. Now it throws an error:
```
 !     Error: Multiple Python package manager files were found.
 !
 !     Exactly one package manager file should be present in your app's
 !     source code, however, several were found:
 !
 !     requirements.txt (pip)
 !     uv.lock (uv)
```

This fixes it.

Tested successfully on scalingo