### PR TITLE
🔧(agents) replace deprecated room options API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - 🐛(agents) fix bug when closing metadata-collector
 - ⬆️(dependencies) update python dependencies
 - ⬆️(frontend) update js dependencies
+- ♻️(agents) replace deprecated room options API
 
 ### Fixed
 

--- a/src/agents/metadata_collector.py
+++ b/src/agents/metadata_collector.py
@@ -19,12 +19,13 @@ from livekit.agents import (
     JobContext,
     JobProcess,
     JobRequest,
-    RoomInputOptions,
     RoomIO,
-    RoomOutputOptions,
     WorkerPermissions,
     cli,
     utils,
+)
+from livekit.agents import (
+    room_io as lk_room_io,
 )
 from livekit.plugins import silero
 from minio import Minio
@@ -302,13 +303,11 @@ class MetadataCollector:
             agent_session=session,
             room=self.ctx.room,
             participant=participant,
-            input_options=RoomInputOptions(
-                audio_enabled=True,
-                text_enabled=False,
-            ),
-            output_options=RoomOutputOptions(
-                audio_enabled=False,
-                transcription_enabled=False,
+            options=lk_room_io.RoomOptions(
+                audio_input=lk_room_io.AudioInputOptions(),
+                text_input=False,
+                audio_output=False,
+                text_output=False,
             ),
         )
 


### PR DESCRIPTION
https://github.com/orgs/suitenumerique/projects/11?pane=issue&itemId=177106759

The LiveKit integration was still using RoomInputOptions and RoomOutputOptions, which emit deprecation warnings. Update the implementation to use the unified RoomOptions API.
