### PR TITLE
🐛(agents) fix shutdown exception in metadata extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+
+### Changed
+
+- 🐛(agents) fix bug when closing metadata-collector
+
 ## [1.18.0] - 2026-06-03
 
 ### Added

--- a/src/agents/metadata_collector.py
+++ b/src/agents/metadata_collector.py
@@ -324,7 +324,6 @@ class MetadataCollector:
     async def _close_session(self, session: AgentSession) -> None:
         """Close and cleanup VAD monitoring session."""
         try:
-            await session.drain()
             await session.aclose()
         except Exception:
             logger.exception("Error closing session")


### PR DESCRIPTION
Remove a redundant drain operation causing an exception during the metadata extractor shutdown.

https://github.com/orgs/suitenumerique/projects/11/views/1?pane=issue&itemId=176847725