### PR TITLE
🐛(frontend) fix noise reduction left-channel-only audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - ♻️(addon) improve Outlook add-on: i18n support, feedback link, smarter link
 
+### Fixed
+
+- 🐛(frontend) fix noise reduction left-channel-only audio
+
 ## [1.19.0] - 2026-06-04
 
 ### Added

--- a/docker/dinum-frontend/Dockerfile
+++ b/docker/dinum-frontend/Dockerfile
@@ -60,6 +60,8 @@ USER root
 
 # Security patches for known CVEs
 RUN apk update && apk upgrade  \
+    libcrypto3>=3.5.7-r0 \
+    libssl3>=3.5.7-r0 \
     musl \
     musl-utils \
     zlib>=1.3.2-r0 \

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -45,6 +45,8 @@ USER root
 
 # Security patches for known CVEs
 RUN apk update && apk upgrade  \
+    libcrypto3>=3.5.7-r0 \
+    libssl3>=3.5.7-r0 \
     musl \
     musl-utils \
     zlib>=1.3.2-r0 \

--- a/src/frontend/src/features/rooms/livekit/processors/RnnNoiseProcessor.ts
+++ b/src/frontend/src/features/rooms/livekit/processors/RnnNoiseProcessor.ts
@@ -43,7 +43,16 @@ export class RnnNoiseProcessor implements AudioProcessorInterface {
 
     this.noiseSuppressionNode = new AudioWorkletNode(
       audioContext,
-      NoiseSuppressorWorklet_Name
+      NoiseSuppressorWorklet_Name,
+      {
+        // RNNoise is a mono algorithm. Its worklet only denoises and writes
+        // channel 0. Force any (possibly stereo) input to down-mix to a single
+        // channel and emit a single channel, so we don't produce a stereo frame
+        // whose right channel is left silent.
+        channelCount: 1,
+        channelCountMode: 'explicit',
+        outputChannelCount: [1],
+      }
     )
 
     this.destinationNode = audioContext.createMediaStreamDestination()


### PR DESCRIPTION
Fix bug with RNNoise noise reduction which interprets mono input as left channel with some browsers.

https://github.com/suitenumerique/meet/issues/764

Thanks to @chrnin for the insight.