### PR TITLE
🩹(frontend) fix CSP regression breaking inline styles and ProConnect image

### DIFF
--- a/docker/dinum-frontend/nginx/default.conf
+++ b/docker/dinum-frontend/nginx/default.conf
@@ -51,6 +51,9 @@ server {
       set $csp "default-src 'self'; upgrade-insecure-requests; ";
       set $csp "${csp}frame-ancestors ${ms_domains}; ";
       set $csp "${csp}script-src 'nonce-${nonce}' 'strict-dynamic'; ";
+      set $csp "${csp}style-src 'self' 'unsafe-inline'; ";
+      set $csp "${csp}img-src 'self' data:; ";
+      set $csp "${csp}font-src 'self' data:; ";
       set $csp "${csp}connect-src 'self' ${ms_domains}; ";
       set $csp "${csp}frame-src 'none'; ";
       set $csp "${csp}object-src 'none'; ";

--- a/src/helm/extra/templates/frontend_nginx_cm.yaml
+++ b/src/helm/extra/templates/frontend_nginx_cm.yaml
@@ -59,6 +59,9 @@ data:
             set $csp "default-src 'self'; upgrade-insecure-requests; ";
             set $csp "${csp}frame-ancestors ${ms_domains}; ";
             set $csp "${csp}script-src 'nonce-${nonce}' 'strict-dynamic'; ";
+            set $csp "${csp}style-src 'self' 'unsafe-inline'; ";
+            set $csp "${csp}img-src 'self' data:; ";
+            set $csp "${csp}font-src 'self' data:; ";
             set $csp "${csp}connect-src 'self' ${ms_domains}; ";
             set $csp "${csp}frame-src 'none'; ";
             set $csp "${csp}object-src 'none'; ";


### PR DESCRIPTION
A previous CSP change suggested by CodeRabbit was not properly tested and broke inline styling as well as the loading of the ProConnect image.

Adjust the CSP directives to allow these resources again.
