### PR TITLE
fix: configure Keycloak PostgreSQL connection

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -212,8 +212,7 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_DB: postgres
-      KC_DB_URL_HOST: kc_postgresql
-      KC_DB_URL_DATABASE: keycloak
+      KC_DB_URL: jdbc:postgresql://kc_postgresql:5432/keycloak
       KC_DB_PASSWORD: pass
       KC_DB_USERNAME: meet
       KC_DB_SCHEMA: public


### PR DESCRIPTION
# Summary

Fix Keycloak PostgreSQL connection configuration used during local bootstrap.

# Problem

Running the bootstrap command failed:

```bash
make bootstrap FLUSH_ARGS='--no-input'
```

Keycloak was unable to start because it could not obtain a JDBC connection to PostgreSQL.

# Root Cause

The Keycloak database configuration used separate host and database variables:

```yaml
KC_DB_URL_HOST: kc_postgresql
KC_DB_URL_DATABASE: keycloak
```

This configuration was causing Keycloak to fail when establishing a connection to the PostgreSQL service.

# Changes

Replaced the separate Keycloak database configuration:

```yaml
KC_DB_URL_HOST: kc_postgresql
KC_DB_URL_DATABASE: keycloak
```

with a complete JDBC connection URL:

```yaml
KC_DB_URL: jdbc:postgresql://kc_postgresql:5432/keycloak
```

Additional details:

* Uses the Docker Compose service hostname (`kc_postgresql`)
* Uses the internal PostgreSQL container port (`5432`)
* Simplifies the database connection configuration
* Ensures Keycloak can connect to PostgreSQL during bootstrap

# Testing

Tested locally using:

```bash
make bootstrap FLUSH_ARGS='--no-input'
```

Verified that:

* PostgreSQL starts successfully
* Keycloak starts successfully
* JDBC connection errors are resolved
* Bootstrap completes successfully

# Impact

This change fixes local development bootstrap failures caused by PostgreSQL connection issues and improves the reliability of the Keycloak startup process.


<img width="799" height="789" alt="Screenshot from 2026-06-13 00-13-59" src="https://github.com/user-attachments/assets/c91496b4-853b-45b4-83f8-8c6162981a52" />
<img width="1920" height="371" alt="Screenshot from 2026-06-13 00-17-16" src="https://github.com/user-attachments/assets/58a0b279-193f-4fad-80cb-2a3d7f2c4613" />
<img width="1920" height="371" alt="Screenshot from 2026-06-13 00-18-03" src="https://github.com/user-attachments/assets/170bd460-bb04-43b0-a2cc-6c75b7d01731" />
