### PR TITLE
✨(frontend) allow disabling silent login via a URL parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(frontend) allow disabling silent login via a URL parameter
+
 ### Changed
 
 - ✨(frontend) enhance noise reduction with BBBA audio processing pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(frontend) allow disabling silent login via a URL parameter
+- ✨(frontend) allow hiding the login button via a URL parameter
 
 ### Changed
 

--- a/src/frontend/src/features/auth/api/useUser.tsx
+++ b/src/frontend/src/features/auth/api/useUser.tsx
@@ -5,6 +5,16 @@ import { type ApiUser } from './ApiUser'
 import { useMemo } from 'react'
 import { useConfig } from '@/api/useConfig'
 
+const SILENT_LOGIN_PARAM = 'silentLogin'
+
+const isSilentLoginDisabledByUrl = () => {
+  if (typeof window === 'undefined') return false
+  const value = new URLSearchParams(window.location.search).get(
+    SILENT_LOGIN_PARAM
+  )
+  return value === 'false'
+}
+
 /**
  * returns info about currently logged-in user
  *
@@ -17,16 +27,22 @@ export const useUser = (
 ) => {
   const { data, isLoading: isConfigLoading } = useConfig()
 
+  const disabledByUrl = useMemo(() => isSilentLoginDisabledByUrl(), [])
+
   const options = useMemo(() => {
     if (isConfigLoading) return
-    if (data?.is_silent_login_enabled !== true) {
+
+    const silentDisabled =
+      data?.is_silent_login_enabled !== true || disabledByUrl
+
+    if (silentDisabled) {
       return {
         ...opts,
         attemptSilent: false,
       }
     }
     return opts.fetchUserOptions
-  }, [data, opts, isConfigLoading])
+  }, [data, opts, isConfigLoading, disabledByUrl])
 
   const query = useQuery({
     queryKey: [keys.user],

--- a/src/frontend/src/features/auth/api/useUser.tsx
+++ b/src/frontend/src/features/auth/api/useUser.tsx
@@ -37,7 +37,7 @@ export const useUser = (
 
     if (silentDisabled) {
       return {
-        ...opts,
+        ...opts.fetchUserOptions,
         attemptSilent: false,
       }
     }

--- a/src/frontend/src/layout/Header.tsx
+++ b/src/frontend/src/layout/Header.tsx
@@ -14,6 +14,7 @@ import { VisualOnlyTooltip } from '@/primitives/VisualOnlyTooltip'
 
 import { useLoginHint } from '@/hooks/useLoginHint'
 import { logout } from '@/features/auth/utils/logout'
+import { useMemo } from 'react'
 
 const Logo = () => (
   <img
@@ -84,6 +85,16 @@ const LoginHint = () => {
   )
 }
 
+const HIDE_LOGIN_PARAM = 'hideLogin'
+
+const isLoginButtonHidden = () => {
+  if (typeof window === 'undefined') return false
+  const value = new URLSearchParams(window.location.search).get(
+    HIDE_LOGIN_PARAM
+  )
+  return value === 'true'
+}
+
 export const Header = () => {
   const { t } = useTranslation()
   const isHome = useMatchesRoute('home')
@@ -92,6 +103,9 @@ export const Header = () => {
   const isTermsOfService = useMatchesRoute('termsOfService')
   const isRoom = useMatchesRoute('room')
   const { user, isLoggedIn } = useUser()
+
+  const loginButtonDisabledByUrl = useMemo(() => isLoginButtonHidden(), [])
+
   const userLabel = user?.full_name || user?.email
   const loggedInTooltip = t('loggedInUserTooltip')
   const loggedInAriaLabel = userLabel
@@ -152,7 +166,8 @@ export const Header = () => {
                 !isHome &&
                 !isLegalTerms &&
                 !isAccessibility &&
-                !isTermsOfService && (
+                !isTermsOfService &&
+                !loginButtonDisabledByUrl && (
                   <>
                     <LoginButton proConnectHint={false} />
                     <LoginHint />


### PR DESCRIPTION
Several clients ran into issues with the silent login, leading to redirections that were not appropriate for their use case.

Offer a URL parameter to control this behavior and disable silent login when needed.