### PR TITLE
🐛(frontend) fix metadata agent collector enabled check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to
 - 🚸(frontend) mute join notification sound in larger rooms
 - 🚸(frontend) mute participants by default when joining a large meeting
 
+### Fixed
+
+- 🐛(frontend) fix metadata agent collector enabled check
+
 ## [1.20.0] - 2026-06-12
 
 ### Changed

--- a/src/frontend/src/features/recording/hooks/useMetadataCollectorEnabled.ts
+++ b/src/frontend/src/features/recording/hooks/useMetadataCollectorEnabled.ts
@@ -6,5 +6,5 @@ export const useIsMetadataCollectorEnabled = () => {
   const featureEnabled = useFeatureFlagEnabled(FeatureFlags.metadataCollector)
   const isAnalyticsEnabled = useIsAnalyticsEnabled()
 
-  return (featureEnabled && isAnalyticsEnabled) || true
+  return !isAnalyticsEnabled || Boolean(featureEnabled)
 }


### PR DESCRIPTION
Fix an incorrect check that caused issues in production when determining whether the metadata agent collector is enabled.