### PR TITLE
🧱(helm) include app labels and cron job name in cron jobs

### DIFF
--- a/src/helm/meet/Chart.yaml
+++ b/src/helm/meet/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 type: application
 name: meet
-version: 0.0.24
+version: 0.0.25

--- a/src/helm/meet/templates/backend_cronjob_list.yaml
+++ b/src/helm/meet/templates/backend_cronjob_list.yaml
@@ -23,6 +23,9 @@ items:
           template:
             metadata:
               name: {{ $fullName }}-{{ .name }}
+              labels:
+                cronjob-name: {{ .name }}
+                {{- include "meet.common.labels" (list $ $component) | nindent 16 }}
             spec:
               {{- if $.Values.image.credentials }}
               imagePullSecrets:


### PR DESCRIPTION
Jobs created from cron jobs were lacking some labels that ease with targetting them notably as part of network policies.
