### PR TITLE
🐛(frontend) prefill prejoin name from the user profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
 
 - ✨(summary) generalized stt api call #1420
 
+### Fixed
+
+- 🐛(frontend) prefill prejoin name from the user profile #1435
+
 ## [1.21.0] - 2026-06-15
 
 ### Added

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -33,6 +33,7 @@ import { ApiLobbyStatus, type ApiRequestEntry } from '../api/requestEntry'
 import { Spinner } from '@/primitives/Spinner'
 import { ApiAccessLevel } from '../api/ApiRoom'
 import { useLoginHint } from '@/hooks/useLoginHint'
+import { useUser } from '@/features/auth/api/useUser'
 import { openPermissionsDialog } from '@/stores/permissions'
 import { useResolveInitiallyDefaultDeviceId } from '../livekit/hooks/useResolveInitiallyDefaultDeviceId'
 import { isSafari } from '@/utils/livekit'
@@ -137,6 +138,21 @@ export const Join = ({
       username,
     }
   }
+
+  // Prefill the prejoin name from the authenticated user's profile when they
+  // haven't chosen one yet, so logged-in users aren't asked to type their own
+  // name on every join/refresh. Seed once so it never fights a manual edit, and
+  // write it to the store (not just the field) so the room/lobby requests use
+  // it too. The query may resolve after this screen mounts, hence the effect.
+  const { user, isLoggedIn } = useUser()
+  const hasSeededUsername = useRef(false)
+  useEffect(() => {
+    if (hasSeededUsername.current) return
+    if (isLoggedIn && !username && user?.full_name) {
+      hasSeededUsername.current = true
+      saveUsername(user.full_name)
+    }
+  }, [isLoggedIn, username, user?.full_name])
 
   const tracks = usePreviewTracks(
     {
@@ -453,7 +469,7 @@ export const Join = ({
                 onChange={saveUsername}
                 label={t('usernameLabel')}
                 id="input-name"
-                defaultValue={username}
+                value={username}
                 validate={(value) => !value && t('errors.usernameEmpty')}
                 wrapperProps={{
                   noMargin: true,


### PR DESCRIPTION
## Purpose

On the prejoin screen, the display-name field is sourced **only** from `userChoicesStore` (persisted to `localStorage` via LiveKit's `loadUserChoices`). Nothing seeds it from the authenticated user's profile, so a logged-in user who hasn't manually typed a name is shown an **empty, required** field and asked to enter their name on **every join / refresh** — even though the backend already knows them and `useUser()` (`/users/me` → `full_name`) exposes the name client-side.

Reported by a self-hosting deployment using OIDC (Authentik): users authenticate, `meet_user.full_name` is populated, yet the prejoin still demands a name on each refresh.

## Changes

In `src/features/rooms/components/Join.tsx`:

- Seed `username` from `user.full_name` when the user **is logged in** and **hasn't set one yet**, via `saveUsername(...)`. Writing it to the store (not just the field) means the room/lobby requests (`fetchRoom`, `useLobby`) and LiveKit connect use it too.
- Seed **once** (guarded by a ref) so it never fights a manual edit or a deliberate clear.
- Done in an effect because `useUser()` can resolve **after** the prejoin mounts (e.g. a cold load straight to a room URL).
- Switch the name `Field` from `defaultValue` to a controlled `value={username}` so a profile that resolves after mount is actually reflected (a `defaultValue` only applies on first mount).

**Guests are unaffected** — `isLoggedIn` is false, so nothing is seeded and the field behaves exactly as before.

## Checks

- `npm run lint` (eslint, `--max-warnings 0`) ✅
- `panda codegen && tsc -b` (typecheck) ✅
- Changelog entry added under `[Unreleased] / Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)