### PR TITLE
📝(docs) document rebranding the favicon via a volume mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- 📝(docs) document rebranding the favicon via a volume mount #1443
 - ✨(backend) add command to clean pending and deleted files
 - 🧱(helm) run clean files command as cronjob
 

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -244,6 +244,69 @@ meet-admin               <none>   meet.127.0.0.1.nip.io       localhost   80, 44
 
 You can use LaSuite Meet on https://meet.127.0.0.1.nip.io from the local device. The provisioning user in keycloak is meet/meet.
 
+## Rebranding the favicon
+
+The favicon is bundled into the frontend image and served as a set of static
+files from `/usr/share/nginx/html` (`favicon.ico`, `favicon-16x16.png`,
+`favicon-32x32.png`, `apple-touch-icon.png`, `android-chrome-192x192.png`,
+`android-chrome-512x512.png`, `icon.png`). To rebrand without forking and
+rebuilding the image, overlay your own icons onto those paths with a volume —
+this serves the right icon from the first byte (no rebuild, no flash) and
+covers every variant, including the iOS home-screen and Android/PWA icons.
+
+Put your icons in a `ConfigMap` (`binaryData` keeps the PNGs intact)…
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: meet-favicon
+binaryData:
+  # base64 of each replacement icon
+  favicon.ico: <base64…>
+  favicon-16x16.png: <base64…>
+  favicon-32x32.png: <base64…>
+  apple-touch-icon.png: <base64…>
+  android-chrome-192x192.png: <base64…>
+  android-chrome-512x512.png: <base64…>
+```
+
+```bash
+# e.g. build the ConfigMap straight from a directory of icons
+$ kubectl create configmap meet-favicon --from-file=./my-icons/
+```
+
+…then mount each file over the bundled one via the chart's
+`frontend.extraVolumes` / `frontend.extraVolumeMounts` (the `subPath` mounts
+the single file without hiding the rest of `html/`):
+
+```yaml
+frontend:
+  extraVolumes:
+    - name: favicon
+      configMap:
+        name: meet-favicon
+  extraVolumeMounts:
+    - name: favicon
+      mountPath: /usr/share/nginx/html/favicon.ico
+      subPath: favicon.ico
+    - name: favicon
+      mountPath: /usr/share/nginx/html/favicon-16x16.png
+      subPath: favicon-16x16.png
+    - name: favicon
+      mountPath: /usr/share/nginx/html/favicon-32x32.png
+      subPath: favicon-32x32.png
+    - name: favicon
+      mountPath: /usr/share/nginx/html/apple-touch-icon.png
+      subPath: apple-touch-icon.png
+    - name: favicon
+      mountPath: /usr/share/nginx/html/android-chrome-192x192.png
+      subPath: android-chrome-192x192.png
+    - name: favicon
+      mountPath: /usr/share/nginx/html/android-chrome-512x512.png
+      subPath: android-chrome-512x512.png
+```
+
 ## All options
 
 These are the environmental options available on meet backend.


### PR DESCRIPTION
## Purpose

The favicon is baked into the frontend image, so rebranding Meet (logo, name, theme) appears to require forking and rebuilding the frontend just to change the tab icon.

Originally this PR added a runtime `FRONTEND_FAVICON_URL` config knob (mirroring `custom_css_url`). Per review feedback from @lebaudantoine, that approach is the wrong fit for favicons: the bundled `<link rel="icon">` lives in the static `index.html`, so the browser fetches it during HTML parse — before the JS swap can run — giving a visible favicon flash on every load, and the swap only covered the `rel~="icon"` PNGs (not `apple-touch-icon`, the `android-chrome`/PWA icons, `favicon.ico`, or the manifest).

## Changes

Reworked to **docs-only**. Since the icons are served from stable, unhashed paths under `/usr/share/nginx/html`, they can simply be overlaid with a volume — no code, no rebuild, no flash, and every variant is covered.

`docs/installation/kubernetes.md` now has a **"Rebranding the favicon"** section showing the recipe: a `ConfigMap` (`binaryData`) of replacement icons mounted over the bundled ones via the chart's `frontend.extraVolumes` / `frontend.extraVolumeMounts` (per-file `subPath`).

No code changes; backwards-compatible; no i18n impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)