### PR TITLE
🚸(frontend) use "Advanced" instead of "Premium" in the recording sidepanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 - ✨(summary) generalized stt api call #1420
 - ♻️(env) refactor env variables handling
+- 🚸(frontend) use "Advanced" instead of "Premium" in the sidepanel
 
 ## [1.21.0] - 2026-06-15
 

--- a/src/frontend/src/locales/de/rooms.json
+++ b/src/frontend/src/locales/de/rooms.json
@@ -432,10 +432,10 @@
       }
     },
     "premium": {
-      "heading": "Premium-Funktion",
+      "heading": "Advanced-Funktion",
       "body": "Diese Funktion ist für Sie nicht verfügbar. Bitte wenden Sie sich an den Support, um weitere Informationen zu erhalten.",
       "linkMore": "Dokumentation öffnen",
-      "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen – öffnet in neuem Tab",
+      "linkAriaLabel": "Dokumentation zum Advanced-Zugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",
@@ -485,10 +485,10 @@
       }
     },
     "premium": {
-      "heading": "Premium-Funktion",
+      "heading": "Advanced-Funktion",
       "body": "Diese Funktion ist für Sie nicht verfügbar. Bitte wenden Sie sich an den Support, um weitere Informationen zu erhalten.",
       "linkMore": "Dokumentation öffnen",
-      "linkAriaLabel": "Dokumentation zum Premium-Zugang öffnen – öffnet in neuem Tab",
+      "linkAriaLabel": "Dokumentation zum Advanced-Zugang öffnen – öffnet in neuem Tab",
       "dividerLabel": "ODER",
       "login": {
         "heading": "Anmeldung erforderlich",

--- a/src/frontend/src/locales/en/rooms.json
+++ b/src/frontend/src/locales/en/rooms.json
@@ -431,10 +431,10 @@
       }
     },
     "premium": {
-      "heading": "Premium feature",
+      "heading": "Advanced feature",
       "body": "This feature is not available to you. Please contact support for more information.",
       "linkMore": "Open documentation",
-      "linkAriaLabel": "Open documentation about premium access - opens in new window",
+      "linkAriaLabel": "Open documentation about advanced access - opens in new window",
       "dividerLabel": "OR",
       "login": {
         "heading": "You are not logged in!",
@@ -484,10 +484,10 @@
       }
     },
     "premium": {
-      "heading": "Premium feature",
+      "heading": "Advanced feature",
       "body": "This feature is not available to you. Please contact support for more information.",
       "linkMore": "Open documentation",
-      "linkAriaLabel": "Open documentation about premium access - opens in new window",
+      "linkAriaLabel": "Open documentation about advanced access - opens in new window",
       "dividerLabel": "OR",
       "login": {
         "heading": "You are not logged in!",

--- a/src/frontend/src/locales/fr/rooms.json
+++ b/src/frontend/src/locales/fr/rooms.json
@@ -431,7 +431,7 @@
       }
     },
     "premium": {
-      "heading": "Fonctionnalité premium",
+      "heading": "Fonctionnalité avancée",
       "body": "Cette fonctionnalité ne vous est pas ouverte. Contactez le support pour obtenir plus d'informations.",
       "linkMore": "Ouvrir la documentation",
       "dividerLabel": "OU",
@@ -444,7 +444,7 @@
         "body": "L'hôte recevra une notification et pourra démarrer la transcription pour vous.",
         "buttonLabel": "Demander"
       },
-      "linkAriaLabel": "Ouvrir la documentation sur l'accès premium - ouvre dans une nouvelle fenêtre"
+      "linkAriaLabel": "Ouvrir la documentation sur la fonctionnalité avancée - ouvre dans une nouvelle fenêtre"
     }
   },
   "screenRecording": {
@@ -484,7 +484,7 @@
       }
     },
     "premium": {
-      "heading": "Fonctionnalité premium",
+      "heading": "Fonctionnalité avancée",
       "body": "Cette fonctionnalité ne vous est pas ouverte. Contactez le support pour obtenir plus d'informations.",
       "linkMore": "Ouvrir la documentation",
       "dividerLabel": "OU",
@@ -497,7 +497,7 @@
         "body": "L'hôte recevra une notification et pourra démarrer l'enregistrement pour vous.",
         "buttonLabel": "Demander"
       },
-      "linkAriaLabel": "Ouvrir la documentation sur l'accès premium - ouvre dans une nouvelle fenêtre"
+      "linkAriaLabel": "Ouvrir la documentation sur la fonctionnalité avancée - ouvre dans une nouvelle fenêtre"
     },
     "durationMessage": "(limité à {{max_duration}}) "
   },

--- a/src/frontend/src/locales/nl/rooms.json
+++ b/src/frontend/src/locales/nl/rooms.json
@@ -431,10 +431,10 @@
       }
     },
     "premium": {
-      "heading": "Premiumfunctie",
+      "heading": "Geavanceerde functie",
       "body": "Deze functie is niet voor u beschikbaar. Neem contact op met de ondersteuning voor meer informatie.",
       "linkMore": "Documentatie openen",
-      "linkAriaLabel": "Documentatie over premiumtoegang openen - opent in nieuw venster",
+      "linkAriaLabel": "Documentatie over Geavanceerde functie openen - opent in nieuw venster",
       "dividerLabel": "OF",
       "login": {
         "heading": "Inloggen vereist",
@@ -484,10 +484,10 @@
       }
     },
     "premium": {
-      "heading": "Premiumfunctie",
+      "heading": "Geavanceerde functie",
       "body": "Deze functie is niet voor u beschikbaar. Neem contact op met de ondersteuning voor meer informatie.",
       "linkMore": "Documentatie openen",
-      "linkAriaLabel": "Documentatie over premiumtoegang openen - opent in nieuw venster",
+      "linkAriaLabel": "Documentatie over Geavanceerde functie openen - opent in nieuw venster",
       "dividerLabel": "OF",
       "login": {
         "heading": "Inloggen vereist",


### PR DESCRIPTION
Following internal feedback, rename the "Premium" wording to "Advanced" across the transcription and recording sidepanels, so the label no longer implies a paid tier.
