### PR TITLE
🐛(backend) support unencoded S3 notification object keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - 🧱(helm) run clean files command as cronjob
 - ✨(backend) add fallback to save recordings without S3/MinIO webhooks
 - 🩹(frontend) enable screen share button in PiP #1458
+- 🐛(backend) support unencoded S3 notification object keys #1455
 
 ### Changed
 

--- a/src/backend/core/recording/event/parsers.py
+++ b/src/backend/core/recording/event/parsers.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Optional, Protocol
+from urllib.parse import quote_plus
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -164,6 +165,8 @@ class S3Parser(BaseS3Parser):
             if not filepath:
                 raise ParsingEventDataError("Missing object key name")
             filetype, _ = mimetypes.guess_type(filepath)
+            # Preserve already URL-encoded separators while encoding raw S3 object keys.
+            filepath = quote_plus(filepath, safe="%")
             return StorageEvent(
                 filepath=filepath,
                 filetype=filetype,

--- a/src/backend/core/recording/event/parsers.py
+++ b/src/backend/core/recording/event/parsers.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, Dict, Optional, Protocol
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -165,8 +165,9 @@ class S3Parser(BaseS3Parser):
             if not filepath:
                 raise ParsingEventDataError("Missing object key name")
             filetype, _ = mimetypes.guess_type(filepath)
-            # Preserve already URL-encoded separators while encoding raw S3 object keys.
-            filepath = quote_plus(filepath, safe="%")
+            # Normalize raw S3-compatible object keys without re-encoding
+            # already encoded AWS S3 notification keys.
+            filepath = quote(filepath, safe="%+")
             return StorageEvent(
                 filepath=filepath,
                 filetype=filetype,

--- a/src/backend/core/tests/recording/event/test_parsers.py
+++ b/src/backend/core/tests/recording/event/test_parsers.py
@@ -406,6 +406,32 @@ def test_s3_parser_accepts_unencoded_filepath(settings):
     assert parser.get_recording_id(data) == recording_id
 
 
+def test_s3_parser_preserves_plus_signs_in_raw_filepath(settings):
+    """Test S3 parser preserves plus signs while encoding slash separators."""
+    settings.RECORDING_OUTPUT_FOLDER = "recordings"
+
+    recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"
+    parser = S3Parser(bucket_name="recordings-bucket")
+
+    data = {
+        "Records": [
+            {
+                "s3": {
+                    "bucket": {"name": "recordings-bucket"},
+                    "object": {
+                        "key": f"folder+name/recordings/{recording_id}.mp4",
+                    },
+                }
+            }
+        ]
+    }
+
+    event = parser.parse(data)
+
+    assert event.filepath == f"folder+name%2Frecordings%2F{recording_id}.mp4"
+    assert parser.validate(event) == recording_id
+
+
 def test_s3_get_recording_id_success(s3_parser, valid_s3_event):
     """Test successful extraction of recording ID from S3 event."""
     recording_id = s3_parser.get_recording_id(valid_s3_event)

--- a/src/backend/core/tests/recording/event/test_parsers.py
+++ b/src/backend/core/tests/recording/event/test_parsers.py
@@ -361,6 +361,7 @@ def test_s3_parse_unrecognized_extension(s3_parser):
 
 
 def test_s3_parser_keeps_encoded_filepath_compatible(settings):
+    """Test S3 parser keeps already encoded object keys compatible."""
     settings.RECORDING_OUTPUT_FOLDER = "recordings"
 
     recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"
@@ -383,6 +384,7 @@ def test_s3_parser_keeps_encoded_filepath_compatible(settings):
 
 
 def test_s3_parser_accepts_unencoded_filepath(settings):
+    """Test S3 parser accepts raw object keys with slash separators."""
     settings.RECORDING_OUTPUT_FOLDER = "recordings"
 
     recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"

--- a/src/backend/core/tests/recording/event/test_parsers.py
+++ b/src/backend/core/tests/recording/event/test_parsers.py
@@ -406,8 +406,8 @@ def test_s3_parser_accepts_unencoded_filepath(settings):
     assert parser.get_recording_id(data) == recording_id
 
 
-def test_s3_parser_preserves_plus_signs_in_raw_filepath(settings):
-    """Test S3 parser preserves plus signs while encoding slash separators."""
+def test_s3_parser_preserves_plus_signs_in_encoded_filepath(settings):
+    """Test S3 parser preserves plus signs in already encoded object keys."""
     settings.RECORDING_OUTPUT_FOLDER = "recordings"
 
     recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"
@@ -419,17 +419,14 @@ def test_s3_parser_preserves_plus_signs_in_raw_filepath(settings):
                 "s3": {
                     "bucket": {"name": "recordings-bucket"},
                     "object": {
-                        "key": f"folder+name/recordings/{recording_id}.mp4",
+                        "key": f"folder+name%2Frecordings%2F{recording_id}.mp4",
                     },
                 }
             }
         ]
     }
 
-    event = parser.parse(data)
-
-    assert event.filepath == f"folder+name%2Frecordings%2F{recording_id}.mp4"
-    assert parser.validate(event) == recording_id
+    assert parser.get_recording_id(data) == recording_id
 
 
 def test_s3_get_recording_id_success(s3_parser, valid_s3_event):

--- a/src/backend/core/tests/recording/event/test_parsers.py
+++ b/src/backend/core/tests/recording/event/test_parsers.py
@@ -360,6 +360,50 @@ def test_s3_parse_unrecognized_extension(s3_parser):
         s3_parser.parse(event_with_unknown_ext)
 
 
+def test_s3_parser_keeps_encoded_filepath_compatible(settings):
+    settings.RECORDING_OUTPUT_FOLDER = "recordings"
+
+    recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"
+    parser = S3Parser(bucket_name="recordings-bucket")
+
+    data = {
+        "Records": [
+            {
+                "s3": {
+                    "bucket": {"name": "recordings-bucket"},
+                    "object": {
+                        "key": f"recordings%2F{recording_id}.mp4",
+                    },
+                }
+            }
+        ]
+    }
+
+    assert parser.get_recording_id(data) == recording_id
+
+
+def test_s3_parser_accepts_unencoded_filepath(settings):
+    settings.RECORDING_OUTPUT_FOLDER = "recordings"
+
+    recording_id = "80ae9fe5-639a-438b-b86e-9e3dd2d55f4d"
+    parser = S3Parser(bucket_name="recordings-bucket")
+
+    data = {
+        "Records": [
+            {
+                "s3": {
+                    "bucket": {"name": "recordings-bucket"},
+                    "object": {
+                        "key": f"recordings/{recording_id}.mp4",
+                    },
+                }
+            }
+        ]
+    }
+
+    assert parser.get_recording_id(data) == recording_id
+
+
 def test_s3_get_recording_id_success(s3_parser, valid_s3_event):
     """Test successful extraction of recording ID from S3 event."""
     recording_id = s3_parser.get_recording_id(valid_s3_event)


### PR DESCRIPTION
## Purpose

Fixes #1454.

Some S3-compatible storage providers, such as Ceph RGW, send notification object keys with raw path separators:

```text
recordings/<recording-id>.mp4
```

However, the recording event parser currently expects URL-encoded separators:

```text
recordings%2F<recording-id>.mp4
```

As a result, valid storage notifications are ignored, recordings remain in the `stopped` state, and notification emails are not sent.

This pull request normalizes S3 notification object keys before filepath validation while preserving already encoded separators.

## Changes

* URL-encode raw S3 notification object keys before filepath validation.
* Preserve existing percent-encoded sequences to avoid converting `%2F` into `%252F`.
* Add tests for both raw and already encoded object keys.

## Testing

Verified that the parser accepts both:

```text
recordings/<recording-id>.mp4
recordings%2F<recording-id>.mp4
```

Before this change, the first representation raised `InvalidFilepathError`.
