### PR TITLE
♿️(frontend) make fullscreen share warning keyboard accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - ✨(summary) generalized stt api call #1420
 - ♻️(env) refactor env variables handling
 - 🚸(frontend) use "Advanced" instead of "Premium" in the sidepanel
+- ♿️(frontend) make fullscreen share warning keyboard accessible #1459
 
 ### Fixed
 

--- a/src/frontend/src/features/pip/components/layout/StageFrame.tsx
+++ b/src/frontend/src/features/pip/components/layout/StageFrame.tsx
@@ -1,12 +1,19 @@
 import { useTranslation } from 'react-i18next'
 import { styled } from '@/styled-system/jsx'
+import { useLocalParticipant } from '@livekit/components-react'
 
 export const StageFrame = ({ children }: { children: React.ReactNode }) => {
   const { t } = useTranslation('rooms', {
     keyPrefix: 'pictureInPicture',
   })
+  const { localParticipant } = useLocalParticipant()
+
   return (
-    <Container role="region" aria-label={t('stage')} {...{ inert: '' }}>
+    <Container
+      role="region"
+      aria-label={t('stage')}
+      {...(!localParticipant.isScreenShareEnabled ? { inert: '' } : {})}
+    >
       {children}
     </Container>
   )

--- a/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/FullScreenShareWarning.tsx
@@ -1,6 +1,6 @@
 import { css } from '@/styled-system/css'
 import { Button, Text } from '@/primitives'
-import { useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { screenSharePreferenceStore } from '@/stores/screenSharePreferences'
 import { useSnapshot } from 'valtio'
 import { useLocalParticipant } from '@livekit/components-react'
@@ -61,9 +61,19 @@ export const FullScreenShareWarning = ({
     await localParticipant.setScreenShareEnabled(false, {}, {})
   }
 
-  const handleDismissWarning = () => {
+  const handleDismissWarning = useCallback(() => {
     screenSharePreferenceStore.enabled = false
-  }
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        handleDismissWarning()
+      }
+    },
+    [handleDismissWarning]
+  )
 
   if (!shouldShowWarning) return null
 
@@ -98,6 +108,7 @@ export const FullScreenShareWarning = ({
             })}
           >
             <Text
+              role="alert"
               style={{
                 color: 'white',
                 flexBasis: '55%',
@@ -117,11 +128,14 @@ export const FullScreenShareWarning = ({
               })}
             >
               <Button
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
                 variant="tertiary"
                 size="sm"
                 style={{
                   height: 'fit-content',
                 }}
+                onKeyDown={handleKeyDown}
                 onPress={async () => {
                   await handleStopScreenShare()
                 }}
@@ -134,6 +148,7 @@ export const FullScreenShareWarning = ({
                 style={{
                   height: 'fit-content',
                 }}
+                onKeyDown={handleKeyDown}
                 onPress={() => handleDismissWarning()}
               >
                 {t('ignore')}


### PR DESCRIPTION
## Purpose

The fullscreen screen share warning was not accessible: keyboard users could not reach its actions and screen readers were not notified when it appeared.

## Proposal

- [x] Improve `FullScreenShareWarning` with `role="alert"`, autoFocus on "Stop presenting", and `Escape` to dismiss.
