### PR TITLE
🛂(backend) reject user access tokens on the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to
 - ♻️(env) refactor env variables handling
 - 🚸(frontend) use "Advanced" instead of "Premium" in the sidepanel
 
+### Fixed
+
+- 🛂(backend) reject user access tokens on the API
+
 ## [1.21.0] - 2026-06-15
 
 ### Added

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from lasuite.oidc_login.backends import (
     OIDCAuthenticationBackend as LaSuiteOIDCAuthenticationBackend,
 )
+from rest_framework.authentication import SessionAuthentication
 
 from core.models import User
 from core.services.marketing import (
@@ -96,3 +97,17 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
                         "Multiple user accounts share a common email."
                     ) from e
         return None
+
+
+class SessionAuthenticationWith401(SessionAuthentication):
+    """
+    Identical to DRF's SessionAuthentication, but returns a WWW-Authenticate
+    header so unauthenticated requests get a 401 instead of a 403.
+
+    The scheme is deliberately NOT 'Basic' — that would trigger the browser's
+    native login popup. 'Session' is ignored by the browser's auth UI but is
+    still truthy, so DRF keeps the status at 401.
+    """
+
+    def authenticate_header(self, request):
+        return "Session"

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -323,8 +323,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
-            "rest_framework.authentication.SessionAuthentication",
+            "core.authentication.backends.SessionAuthenticationWith401",
         ),
         "DEFAULT_PARSER_CLASSES": [
             "rest_framework.parsers.JSONParser",


### PR DESCRIPTION
The original implementation, introduced two years ago, was incorrect and exposed the API to an undesired authentication mode: any user access token obtained for a given user was being accepted as valid credentials on the external API.

Restrict authentication to the intended mode so that user access tokens are no longer accepted on this API.

Thanks @lunika spotting this.

