### PR TITLE
✨(all) support a dedicated domain for the PostHog feature flag API

### DIFF
--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -9,6 +9,7 @@ export interface ApiConfig {
   analytics?: {
     id: string
     host: string
+    flags_api_host?: string
   }
   support?: {
     id: string

--- a/src/frontend/src/features/analytics/hooks/useAnalytics.ts
+++ b/src/frontend/src/features/analytics/hooks/useAnalytics.ts
@@ -28,10 +28,16 @@ export const terminateAnalyticsSession = async () => {
 export type useAnalyticsProps = {
   id?: string
   host?: string
+  flags_api_host?: string
   isDisabled?: boolean
 }
 
-export const useAnalytics = ({ id, host, isDisabled }: useAnalyticsProps) => {
+export const useAnalytics = ({
+  id,
+  host,
+  flags_api_host,
+  isDisabled,
+}: useAnalyticsProps) => {
   const [location] = useLocation()
   const { user } = useUser()
 
@@ -39,9 +45,13 @@ export const useAnalytics = ({ id, host, isDisabled }: useAnalyticsProps) => {
     if (!id || !host || isDisabled) return
     getPosthog().then((ph) => {
       if (ph.__loaded) return
-      ph.init(id, { api_host: host, person_profiles: 'always' })
+      ph.init(id, {
+        api_host: host,
+        flags_api_host: flags_api_host,
+        person_profiles: 'always',
+      })
     })
-  }, [id, host, isDisabled])
+  }, [id, host, flags_api_host, isDisabled])
 
   useEffect(() => {
     if (!user) return


### PR DESCRIPTION
Ad blockers recently started blocking requests to our PostHog feature flag API, leading to undesired behavior in the app.

Following PostHog's documentation, allow configuring a dedicated domain for feature flags, isolated from the main PostHog domain.
