### PR TITLE
(front) fix frontend build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- 🚀 (front) fix frontend build failure
+
 ## [1.22.0] - 2026-07-03
 
 ### Added

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "@tanstack/eslint-plugin-query": "5.100.14",
         "@tanstack/react-query-devtools": "5.100.14",
         "@types/humanize-duration": "3.27.4",
+        "@types/node": "24.12.4",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "6.0.2",
@@ -4014,8 +4015,6 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -12501,9 +12500,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -52,6 +52,7 @@
     "@tanstack/eslint-plugin-query": "5.100.14",
     "@tanstack/react-query-devtools": "5.100.14",
     "@types/humanize-duration": "3.27.4",
+    "@types/node": "24.12.4",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "6.0.2",


### PR DESCRIPTION
## Purpose

 The Scalingo frontend build (defined in src/frontend/package.json) started failing with:

```
 error TS2688: Cannot find type definition file for 'node'.
 The file is in the program because:
 Entry point of type library 'node' specified in compilerOptions
```

An LLM found out the commit 27ebc2f2 (2026-06-04, "replace NodeJS.Timeout with ReturnType<typeof setTimeout>") removed `@types/node` from `src/frontend/package.json` devDependencies, however `src/frontend/tsconfig.node.json` still declares  `"types": ["node"]`. Therefore `@types/node` remained in package-lock only as vite's optional peer dependency, and `npm ci` actually installing an optional-only peer dependency turns out to depend on the npm version:

  - npm 10.8.2 (bundled with `node:20-alpine`, used by `docker/dinum-frontend/Dockerfile`) still installs it
  - npm 11.16.0 (bundled with the latest Node 24.x, used by the scalingo-26 stack) does **not** install it → `node_modules/@types/node` is missing, and `tsc -b` fails.

## Proposal

Re-add `@types/node` as an explicit devDependency.

Tested and working on Scalingo, package-lock was generated with `node:20-alpine` that the Dockerfile uses.