### PR TITLE
♻️(frontend) wrap MuteEveryoneButton with AdminOrOwnerOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - ✨(meet) use compatible with summary v2 #1362
 - ♻️(backend) refactor analytics backend from Protocol to abstract class
 - 🔥(summary) remove call to summary enabled feature flag
+- ♻️(frontend) wrap MuteEveryoneButton with AdminOrOwnerOnly
 
 ### Fixed
 

--- a/src/frontend/src/features/rooms/livekit/components/controls/Participants/MuteEveryoneButton.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/Participants/MuteEveryoneButton.tsx
@@ -1,23 +1,20 @@
 import { Button } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import type { Participant } from 'livekit-client'
-import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
 import { useMuteParticipants } from '@/features/rooms/api/muteParticipants'
 import { RiMicOffLine } from '@remixicon/react'
 import { css } from '@/styled-system/css'
+import { AdminOrOwnerOnly } from '@/features/rooms/components/AdminOrOwnerOnly'
 
 type MuteEveryoneButtonProps = {
   participants: Array<Participant>
 }
 
-export const MuteEveryoneButton = ({
-  participants,
-}: MuteEveryoneButtonProps) => {
+const MuteEveryoneButtonInner = ({ participants }: MuteEveryoneButtonProps) => {
   const { muteParticipants } = useMuteParticipants()
   const { t } = useTranslation('rooms')
 
-  const isAdminOrOwner = useIsAdminOrOwner()
-  if (!isAdminOrOwner || !participants.length) return null
+  if (!participants.length) return null
 
   return (
     <Button
@@ -34,5 +31,15 @@ export const MuteEveryoneButton = ({
       <RiMicOffLine size={16} />
       {t('participants.muteParticipants')}
     </Button>
+  )
+}
+
+export const MuteEveryoneButton = ({
+  participants,
+}: MuteEveryoneButtonProps) => {
+  return (
+    <AdminOrOwnerOnly>
+      <MuteEveryoneButtonInner participants={participants} />
+    </AdminOrOwnerOnly>
   )
 }


### PR DESCRIPTION
Avoids mounting the button's hooks and rendering its logic for users who are not admin or owner, which previously happened on every re-render of the parent.

