### PR TITLE
✨(frontend) add participant color gradient when camera is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(backend) allow searching the recording admin table by owner email
+- ✨(frontend) add participant color gradient when camera is off #1490
 
 ### Changed
 

--- a/src/frontend/src/features/rooms/livekit/components/ParticipantPlaceholder.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/ParticipantPlaceholder.tsx
@@ -2,6 +2,7 @@ import type { Participant } from 'livekit-client'
 import { styled } from '@/styled-system/jsx'
 import { Avatar } from '@/components/Avatar'
 import { useIsSpeaking } from '@livekit/components-react'
+import { getParticipantBackgroundGradient } from '@/features/rooms/utils/getParticipantBackgroundGradient'
 import { getParticipantColor } from '@/features/rooms/utils/getParticipantColor'
 import { useSize } from '@/features/rooms/livekit/hooks/useResizeObserver'
 import { useMemo, useRef } from 'react'
@@ -10,7 +11,6 @@ const StyledParticipantPlaceHolder = styled('div', {
   base: {
     width: '100%',
     height: '100%',
-    backgroundColor: 'primaryDark.100',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
@@ -26,6 +26,10 @@ export const ParticipantPlaceholder = ({
 }: ParticipantPlaceholderProps) => {
   const isSpeaking = useIsSpeaking(participant)
   const participantColor = getParticipantColor(participant)
+  const backgroundGradient = useMemo(
+    () => getParticipantBackgroundGradient(participantColor),
+    [participantColor]
+  )
 
   const placeholderEl = useRef<HTMLDivElement>(null)
   const { width, height } = useSize(placeholderEl)
@@ -39,7 +43,13 @@ export const ParticipantPlaceholder = ({
   const initialSize = useMemo(() => Math.round(avatarSize * 0.3), [avatarSize])
 
   return (
-    <StyledParticipantPlaceHolder ref={placeholderEl}>
+    <StyledParticipantPlaceHolder
+      ref={placeholderEl}
+      style={{
+        backgroundColor: participantColor,
+        backgroundImage: backgroundGradient,
+      }}
+    >
       <div
         style={{
           borderRadius: '50%',

--- a/src/frontend/src/features/rooms/utils/getParticipantBackgroundGradient.ts
+++ b/src/frontend/src/features/rooms/utils/getParticipantBackgroundGradient.ts
@@ -1,0 +1,12 @@
+/**
+ * Builds a radial gradient from the participant's avatar color:
+ * brighter in the center (where the avatar sits), darker at the edges.
+ * Mixed in oklch so the color stays vivid as it darkens instead of greying out.
+ */
+export const getParticipantBackgroundGradient = (color: string): string =>
+  `radial-gradient(circle at 50% 45%,
+    color-mix(in oklch, ${color} 82%, white) 0%,
+    color-mix(in oklch, ${color} 90%, white) 8%,
+    ${color} 35%,
+    color-mix(in oklch, ${color} 85%, black) 65%,
+    color-mix(in oklch, ${color} 65%, black) 100%)`


### PR DESCRIPTION
## Purpose

When the camera is off, participant tiles use a fixed dark background instead of the participant color.

## Proposal

Use a radial gradient derived from the existing participant color attribute.

**BEFORE**
<img width="1855" height="778" alt="Capture d&#39;écran 2026-07-09 110420" src="https://github.com/user-attachments/assets/9e4ea175-cdcd-4544-9cfb-bcf50bd2ba55" />

--------------------------------------------
**AFTER**
<img width="1881" height="817" alt="Capture d&#39;écran 2026-07-09 111055" src="https://github.com/user-attachments/assets/bdcfea78-cbcb-4d58-a49a-8a57d0315971" />
<img width="1865" height="793" alt="Capture d&#39;écran 2026-07-09 110351" src="https://github.com/user-attachments/assets/bf8ed594-5b83-4374-b0dc-4dcdb352eef1" />
<img width="481" height="510" alt="Capture d&#39;écran 2026-07-09 111109" src="https://github.com/user-attachments/assets/06d0f51b-25f5-427e-ac35-a5d0ac432a0a" />

- [x] Add `getParticipantBackgroundGradient` utility
- [x] Apply gradient in `ParticipantPlaceholder`
- [x] Verify rendering with multiple participants and layouts