### PR TITLE
🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- 🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1
+
+
 ## [1.23.0] - 2026-07-08
 
 ### Added

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 # pylint: disable=too-many-lines
 
 import json
+import warnings
 from os import path
 from socket import gethostbyname, gethostname
 
@@ -1126,6 +1127,20 @@ class Base(Configuration):
         if cls.FILE_UPLOAD_TMP_PATH == cls.FILE_UPLOAD_PATH:
             raise ValueError(
                 "FILE_UPLOAD_TMP_PATH cannot be the same as FILE_UPLOAD_PATH"
+            )
+
+        if (
+            cls.SUMMARY_SERVICE_VERSION == 1
+            and cls.SUMMARY_SERVICE_ENDPOINT is not None
+        ):
+            warnings.warn(
+                "SUMMARY_SERVICE_VERSION=1 is deprecated. "
+                "The legacy v1 API has been removed from the experimental "
+                "Summary service. Please update your Summary service deployment to "
+                "the v2 API and set SUMMARY_SERVICE_VERSION=2.",
+                # We use UserWarning to make sure it shows up in production deployment
+                UserWarning,
+                stacklevel=2,
             )
 
         # The SENTRY_DSN setting should be available to activate sentry for an environment


### PR DESCRIPTION
Add a deprecation warning when SUMMARY_SERVICE_VERSION=1 and an endpoint is configured meaning summary service is in use.