### PR TITLE
🩹(backend) identify externally provisioned users to PostHog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - 🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1
 - ⬆️(mail) update mjml to v5 and @html-to/text-cli
 
+### Fixed
+
+- 🩹(backend) identify externally provisioned users to PostHog
+
 ## [1.23.0] - 2026-07-08
 
 ### Added

--- a/src/backend/core/external_api/viewsets.py
+++ b/src/backend/core/external_api/viewsets.py
@@ -215,5 +215,6 @@ class RoomViewSet(
                 "client_id": client_id,
                 "external_api": True,
                 "auth_method": auth_method,
+                "$set": {"email": self.request.user.email},
             },
         )


### PR DESCRIPTION
In the external API, applications authenticate with a client_id/secret and can provision users with only an email. In that flow, users are not identified to PostHog, so the user DB id alone is not enough to identify them in analytics afterwards.

The issue does not exist in the public API, where users are authenticated and therefore already identified.

Inspired by @flochehab's approach in summary.