### PR TITLE
✨(all) allow forcing SSO display name for authenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨(backend) allow searching the recording admin table by owner email
 - ✨(frontend) add participant color gradient when camera is off #1490
+- ✨(all) allow forcing SSO display name for authenticated users
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 - 🗑️(settings) deprecate SUMMARY_SERVICE_VERSION=1
 - ⬆️(mail) update mjml to v5 and @html-to/text-cli
+- 🚸(frontend) initialize the join input name with the persisted full name
 
 ### Fixed
 

--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -68,6 +68,9 @@ def get_frontend_configuration(request):
             "enable_firefox_proxy_workaround": settings.LIVEKIT_ENABLE_FIREFOX_PROXY_WORKAROUND,
             "default_sources": settings.LIVEKIT_DEFAULT_SOURCES,
         },
+        "authenticated_users_can_edit_display_name": (
+            settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME
+        ),
     }
     frontend_configuration.update(settings.FRONTEND_CONFIGURATION)
     return Response(frontend_configuration)

--- a/src/backend/core/tests/test_utils.py
+++ b/src/backend/core/tests/test_utils.py
@@ -7,6 +7,7 @@ import json
 from unittest import mock
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 
 import jwt
 import pytest
@@ -64,6 +65,46 @@ def test_generate_token_explicit_username_overrides_default():
 
     claims = decode_token(token)
     assert claims["name"] == "Custom Name"
+
+
+def test_authenticated_username_ignored_when_editing_disabled(settings):
+    """With editing disabled, an authenticated user's username is ignored."""
+    settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
+    user = UserFactory(full_name="Jane Doe")
+    token = generate_token(room="my-room", user=user, username="Custom Name")
+    claims = decode_token(token)
+    assert claims["name"] == "Jane Doe"
+
+
+def test_authenticated_default_name_unaffected_when_editing_disabled(settings):
+    """Disabling editing doesn't disturb the default full-name path."""
+    settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
+    user = UserFactory(full_name="Jane Doe")
+    token = generate_token(room="my-room", user=user)
+    claims = decode_token(token)
+    assert claims["name"] == "Jane Doe"
+
+
+def test_anonymous_uses_username_when_provided():
+    """An anonymous user's provided username is used as the display name."""
+    token = generate_token(room="my-room", user=AnonymousUser(), username="Guest42")
+    claims = decode_token(token)
+    assert claims["name"] == "Guest42"
+
+
+def test_anonymous_username_used_even_when_editing_disabled(settings):
+    """The setting governs authenticated users only; anonymous can still set a name."""
+    settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = False
+    token = generate_token(room="my-room", user=AnonymousUser(), username="Guest42")
+    claims = decode_token(token)
+    assert claims["name"] == "Guest42"
+
+
+def test_anonymous_falls_back_to_anonymous_label():
+    """With no username, an anonymous user is labelled 'Anonymous'."""
+    token = generate_token(room="my-room", user=AnonymousUser())
+    claims = decode_token(token)
+    assert claims["name"] == "Anonymous"
 
 
 @mock.patch("asyncio.get_running_loop")

--- a/src/backend/core/tests/test_utils.py
+++ b/src/backend/core/tests/test_utils.py
@@ -2,13 +2,68 @@
 Test utils functions
 """
 
+# pylint: disable=W0621
 import json
 from unittest import mock
 
+from django.conf import settings
+
+import jwt
 import pytest
 from livekit.api import TwirpError
 
-from core.utils import NotificationError, create_livekit_client, notify_participants
+from core.factories import UserFactory
+from core.utils import (
+    NotificationError,
+    create_livekit_client,
+    generate_token,
+    notify_participants,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def decode_token(token: str) -> dict:
+    """Decode a LiveKit JWT access token for inspection."""
+    return jwt.decode(
+        token,
+        settings.LIVEKIT_CONFIGURATION["api_secret"],
+        algorithms=["HS256"],
+    )
+
+
+def test_generate_token_authenticated_uses_full_name():
+    """The token's display name should default to the user's full name."""
+    user = UserFactory(full_name="Jane Doe")
+
+    token = generate_token(room="my-room", user=user)
+
+    claims = decode_token(token)
+    assert claims["name"] == "Jane Doe"
+    assert claims["sub"] == str(user.sub)
+
+
+def test_generate_token_authenticated_fallback_user_representation():
+    """
+    When the user has no full name, the token's display name should fall back
+    to the user's string representation.
+    """
+    user = UserFactory(full_name=None)
+
+    token = generate_token(room="my-room", user=user)
+
+    claims = decode_token(token)
+    assert claims["name"] == str(user)
+
+
+def test_generate_token_explicit_username_overrides_default():
+    """An explicitly provided username should take precedence over the full name."""
+    user = UserFactory(full_name="Jane Doe")
+
+    token = generate_token(room="my-room", user=user, username="Custom Name")
+
+    claims = decode_token(token)
+    assert claims["name"] == "Custom Name"
 
 
 @mock.patch("asyncio.get_running_loop")

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -109,7 +109,7 @@ def generate_token(
         default_username = "Anonymous"
     else:
         identity = str(user.sub)
-        default_username = str(user)
+        default_username = user.full_name or str(user)
 
     if color is None:
         color = generate_color(identity)

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -114,6 +114,11 @@ def generate_token(
     if color is None:
         color = generate_color(identity)
 
+    can_edit = (
+        settings.AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME or user.is_anonymous
+    )
+    display_name = (username or default_username) if can_edit else default_username
+
     token = (
         AccessToken(
             api_key=settings.LIVEKIT_CONFIGURATION["api_key"],
@@ -121,7 +126,7 @@ def generate_token(
         )
         .with_grants(video_grants)
         .with_identity(identity)
-        .with_name(username or default_username)
+        .with_name(display_name)
         .with_attributes(
             {"color": color, "room_admin": "true" if is_admin_or_owner else "false"}
         )

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -671,6 +671,11 @@ class Base(Configuration):
         environ_name="PARTICIPANT_FORBIDDEN_PERMISSION_FIELDS",
         environ_prefix=None,
     )
+    AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME = values.BooleanValue(
+        True,
+        environ_name="AUTHENTICATED_PARTICIPANTS_CAN_EDIT_DISPLAY_NAME",
+        environ_prefix=None,
+    )
 
     # Recording settings
     RECORDING_ENABLE = values.BooleanValue(

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -58,6 +58,7 @@ export interface ApiConfig {
   transcription_destination?: string
   max_participants_for_sound: number
   auto_mute_on_join_threshold: number
+  authenticated_users_can_edit_display_name: boolean
 }
 
 const fetchConfig = (): Promise<ApiConfig> => {

--- a/src/frontend/src/features/home/components/CreateMeetingMenu.tsx
+++ b/src/frontend/src/features/home/components/CreateMeetingMenu.tsx
@@ -9,10 +9,11 @@ import { useState } from 'react'
 
 import { menuRecipe } from '@/primitives/menuRecipe'
 import { ApiRoom } from '@/features/rooms/api/ApiRoom'
-import { loadUserChoices } from '@livekit/components-core'
+import { useSnapshot } from 'valtio'
+import { userStore } from '@/stores/user'
 
 export const CreateMeetingMenu = () => {
-  const { username } = loadUserChoices()
+  const { username } = useSnapshot(userStore)
 
   const { t } = useTranslation('home')
   const { mutateAsync: createRoom } = useCreateRoom()

--- a/src/frontend/src/features/rooms/components/Conference.tsx
+++ b/src/frontend/src/features/rooms/components/Conference.tsx
@@ -36,6 +36,7 @@ import { PictureInPictureConference } from '@/features/pip/components/PictureInP
 import { notifyAutoMutedOnJoin } from '@/features/notifications/utils'
 import { useSnapshot } from 'valtio'
 import { userPreferencesStore } from '@/stores/userPreferences'
+import { userStore } from '@/stores/user'
 
 export const Conference = ({
   roomId,
@@ -52,6 +53,8 @@ export const Conference = ({
   const { userChoices: userConfig } = usePersistentUserChoices() as {
     userChoices: LocalUserChoices
   }
+
+  const { username } = useSnapshot(userStore)
 
   useEffect(() => {
     posthog.capture('visit-room', { slug: roomId })
@@ -83,10 +86,10 @@ export const Conference = ({
     queryFn: () =>
       fetchRoom({
         roomId: roomId as string,
-        username: userConfig.username,
+        username: username,
       }).catch((error) => {
         if (error.statusCode == '404') {
-          createRoom({ slug: roomId, username: userConfig.username })
+          createRoom({ slug: roomId, username })
         }
       }),
     retry: false,

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -42,11 +42,12 @@ import {
   saveAudioInputDeviceId,
   saveAudioInputEnabled,
   saveAudioOutputDeviceId,
-  saveUsername,
   saveVideoInputDeviceId,
   saveVideoInputEnabled,
   userChoicesStore,
 } from '@/stores/userChoices'
+
+import { saveUsername, userStore } from '@/stores/user'
 
 import { useCannotUseDevice } from '../livekit/hooks/useCannotUseDevice'
 import { useSnapshot } from 'valtio'
@@ -121,8 +122,9 @@ export const Join = ({
     audioOutputDeviceId,
     videoDeviceId,
     processorConfig,
-    username,
   } = useSnapshot(userChoicesStore)
+
+  const { username } = useSnapshot(userStore)
 
   const initialUserChoices = useRef<LocalUserChoices | null>(null)
 
@@ -134,7 +136,6 @@ export const Join = ({
       audioOutputDeviceId,
       videoDeviceId,
       processorConfig,
-      username,
     }
   }
 

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -118,7 +118,7 @@ export const Join = ({
   const { t } = useTranslation('rooms', { keyPrefix: 'join' })
 
   const { data: configData } = useConfig()
-  const { isLoggedIn } = useUser()
+  const { isLoggedIn, user } = useUser()
 
   const {
     audioEnabled,
@@ -461,7 +461,7 @@ export const Join = ({
                   onChange={saveUsername}
                   label={t('usernameLabel')}
                   id="input-name"
-                  defaultValue={username}
+                  defaultValue={username || user?.full_name}
                   validate={(value) => !value && t('errors.usernameEmpty')}
                   wrapperProps={{
                     noMargin: true,

--- a/src/frontend/src/features/rooms/components/Join.tsx
+++ b/src/frontend/src/features/rooms/components/Join.tsx
@@ -51,6 +51,8 @@ import { saveUsername, userStore } from '@/stores/user'
 
 import { useCannotUseDevice } from '../livekit/hooks/useCannotUseDevice'
 import { useSnapshot } from 'valtio'
+import { useUser } from '@/features/auth/api/useUser'
+import { useConfig } from '@/api/useConfig'
 
 const onError = (e: Error) => console.error('ERROR', e)
 
@@ -114,6 +116,9 @@ export const Join = ({
   roomId: string
 }) => {
   const { t } = useTranslation('rooms', { keyPrefix: 'join' })
+
+  const { data: configData } = useConfig()
+  const { isLoggedIn } = useUser()
 
   const {
     audioEnabled,
@@ -449,20 +454,23 @@ export const Join = ({
               <H lvl={1} margin="sm" centered>
                 {t('heading')}
               </H>
-              <Field
-                type="text"
-                onChange={saveUsername}
-                label={t('usernameLabel')}
-                id="input-name"
-                defaultValue={username}
-                validate={(value) => !value && t('errors.usernameEmpty')}
-                wrapperProps={{
-                  noMargin: true,
-                  fullWidth: true,
-                }}
-                autoComplete="name"
-                maxLength={50}
-              />
+              {(!isLoggedIn ||
+                configData?.authenticated_users_can_edit_display_name) && (
+                <Field
+                  type="text"
+                  onChange={saveUsername}
+                  label={t('usernameLabel')}
+                  id="input-name"
+                  defaultValue={username}
+                  validate={(value) => !value && t('errors.usernameEmpty')}
+                  wrapperProps={{
+                    noMargin: true,
+                    fullWidth: true,
+                  }}
+                  autoComplete="name"
+                  maxLength={50}
+                />
+              )}
             </VStack>
           </Form>
         )

--- a/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
@@ -8,7 +8,7 @@ import { HStack } from '@/styled-system/jsx'
 import { useState } from 'react'
 import { LoginButton } from '@/components/LoginButton'
 import { useRenameParticipant } from '@/features/rooms/api/renameParticipant'
-import { saveUsername } from '@/stores/userChoices'
+import { saveUsername } from '@/stores/user'
 import { logout } from '@/features/auth/utils/logout'
 
 export type AccountTabProps = Pick<DialogProps, 'onOpenChange'> &

--- a/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
@@ -10,6 +10,7 @@ import { LoginButton } from '@/components/LoginButton'
 import { useRenameParticipant } from '@/features/rooms/api/renameParticipant'
 import { saveUsername } from '@/stores/user'
 import { logout } from '@/features/auth/utils/logout'
+import { useConfig } from '@/api/useConfig'
 
 export type AccountTabProps = Pick<DialogProps, 'onOpenChange'> &
   Pick<TabPanelProps, 'id'>
@@ -17,6 +18,7 @@ export type AccountTabProps = Pick<DialogProps, 'onOpenChange'> &
 export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
   const { t } = useTranslation('settings')
   const room = useRoomContext()
+  const { data } = useConfig()
   const { user, isLoggedIn } = useUser()
 
   const { renameParticipant } = useRenameParticipant()
@@ -45,15 +47,17 @@ export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
   return (
     <TabPanel padding={'md'} flex id={id}>
       <H lvl={2}>{t('account.heading')}</H>
-      <Field
-        type="text"
-        label={t('account.nameLabel')}
-        value={name}
-        onChange={setName}
-        validate={(value) => {
-          return !value ? <p>{t('account.nameError')}</p> : null
-        }}
-      />
+      {(!isLoggedIn || data?.authenticated_users_can_edit_display_name) && (
+        <Field
+          type="text"
+          label={t('account.nameLabel')}
+          value={name}
+          onChange={setName}
+          validate={(value) => {
+            return !value ? <p>{t('account.nameError')}</p> : null
+          }}
+        />
+      )}
       <H lvl={2}>{t('account.authentication')}</H>
       {isLoggedIn ? (
         <>

--- a/src/frontend/src/stores/user.ts
+++ b/src/frontend/src/stores/user.ts
@@ -1,0 +1,37 @@
+import { proxy, subscribe } from 'valtio'
+import { STORAGE_KEYS } from '@/utils/storageKeys'
+
+type State = {
+  username: string
+}
+
+const DEFAULT_STATE = {
+  username: '',
+}
+
+function getUserState(): State {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.USER)
+    if (!stored) return DEFAULT_STATE
+    const parsed = JSON.parse(stored)
+    return {
+      ...parsed,
+    }
+  } catch (error: unknown) {
+    console.error(
+      '[UserPreferencesStore] Failed to parse stored settings:',
+      error
+    )
+    return DEFAULT_STATE
+  }
+}
+
+export const userStore = proxy<State>(getUserState())
+
+subscribe(userStore, () => {
+  localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(userStore))
+})
+
+export const saveUsername = (username: string) => {
+  userStore.username = username
+}

--- a/src/frontend/src/stores/userChoices.ts
+++ b/src/frontend/src/stores/userChoices.ts
@@ -12,7 +12,7 @@ import { VideoQuality } from 'livekit-client'
 
 export type VideoResolution = 'h720' | 'h360' | 'h180'
 
-export type LocalUserChoices = LocalUserChoicesLK & {
+export type LocalUserChoices = Omit<LocalUserChoicesLK, 'username'> & {
   processorConfig?: ProcessorConfig
   noiseReductionEnabled?: boolean
   audioOutputDeviceId?: string
@@ -32,7 +32,13 @@ function getUserChoicesState(): LocalUserChoices {
 
 export const userChoicesStore = proxy<LocalUserChoices>(getUserChoicesState())
 subscribe(userChoicesStore, () => {
-  saveUserChoices(userChoicesStore, false)
+  // TEMPORARY: cast needed because our store omits `username`, which we no
+  // longer persis in this store, while LiveKit's `saveUserChoices` still expects the full
+  // `LocalUserChoices` shape. `username` ends up `undefined` in the saved
+  // object, which `saveUserChoices` tolerates at runtime.
+  // We are migrating away from LiveKit's persistence logic to our own store
+  // handling for more control — this cast can be removed once that lands.
+  saveUserChoices(userChoicesStore as LocalUserChoicesLK, false)
 })
 
 // we run some logic on store loading to check if the processor config is still valid
@@ -88,10 +94,6 @@ export const saveVideoPublishResolution = (resolution: VideoResolution) => {
 
 export const saveVideoSubscribeQuality = (quality: VideoQuality) => {
   userChoicesStore.videoSubscribeQuality = quality
-}
-
-export const saveUsername = (username: string) => {
-  userChoicesStore.username = username
 }
 
 export const saveNoiseReductionEnabled = (enabled: boolean) => {

--- a/src/frontend/src/utils/storageKeys.tsx
+++ b/src/frontend/src/utils/storageKeys.tsx
@@ -4,5 +4,6 @@
 export const STORAGE_KEYS = {
   NOTIFICATIONS: 'app_notification_settings',
   USER_PREFERENCES: 'app_user_preferences',
+  USER: 'app_user',
   ACCESSIBILITY: 'app_accessibility_settings',
 } as const

--- a/src/helm/env.d/common.yaml.gotmpl
+++ b/src/helm/env.d/common.yaml.gotmpl
@@ -191,6 +191,8 @@ backend:
     SUMMARY_SERVICE_API_TOKEN: password
     SUMMARY_SERVICE_WEBHOOK_API_TOKEN: webhook-password
     RECORDING_DOWNLOAD_BASE_URL: https://meet.127.0.0.1.nip.io/recording
+    OIDC_USERINFO_FULLNAME_FIELDS: first_name, last_name
+    OIDC_USERINFO_SHORTNAME_FIELD: first_name
 
   migrate:
     command:


### PR DESCRIPTION
Add a new setting that controls whether an authenticated user can
rename or modify their display name, or if they must use the one
returned by the SSO.

When the setting is disabled, only anonymous users can set a display
name freely; authenticated users always use their SSO display name.

Requested by many self-hosters.