### PR TITLE
🐛(backend) Fix info panel crash for unregistered rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Fixed
 
 - 🩹(backend) identify externally provisioned users to PostHog
+- 🐛(backend) fix info panel crash for unregistered rooms
 
 ## [1.23.0] - 2026-07-08
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -92,6 +92,7 @@ from core.services.subtitle import SubtitleException, SubtitleService
 from core.tasks.file import process_file_deletion
 
 from ..authentication.livekit import LiveKitTokenAuthentication
+from ..models import RoomAccessLevel
 from . import permissions, serializers, throttling
 from .feature_flag import FeatureFlag
 
@@ -267,6 +268,9 @@ class RoomViewSet(
             username = request.query_params.get("username", None)
             data = {
                 "id": None,
+                "slug": slug,
+                "is_administrable": False,
+                "access_level": RoomAccessLevel.PUBLIC,
                 "livekit": {
                     "url": settings.LIVEKIT_CONFIGURATION["url"],
                     "room": slug,

--- a/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
+++ b/src/backend/core/tests/rooms/test_api_rooms_retrieve.py
@@ -130,6 +130,9 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed(mock_token):
     assert response.status_code == 200
     assert response.json() == {
         "id": None,
+        "slug": "unregistered-room",
+        "access_level": "public",
+        "is_administrable": False,
         "livekit": {
             "url": "test_url_value",
             "room": "unregistered-room",
@@ -162,6 +165,9 @@ def test_api_rooms_retrieve_anonymous_unregistered_allowed_not_normalized(mock_t
     assert response.status_code == 200
     assert response.json() == {
         "id": None,
+        "slug": "reunion",
+        "access_level": "public",
+        "is_administrable": False,
         "livekit": {
             "url": "test_url_value",
             "room": "reunion",

--- a/src/frontend/src/features/rooms/api/ApiRoom.ts
+++ b/src/frontend/src/features/rooms/api/ApiRoom.ts
@@ -22,7 +22,7 @@ export type ApiRoom = {
   id: string
   name: string
   slug: string
-  pin_code: string
+  pin_code?: string
   is_administrable: boolean
   access_level: ApiAccessLevel
   livekit?: ApiLiveKit


### PR DESCRIPTION
The info panel was crashing when opening a room that was not registered in the database (with ALLOW_UNREGISTERED_ROOMS=true), because the API response did not include the room slug.

Instead of adding frontend fallbacks, update the unregistered-room response to include the slug, keeping the API contract consistent with registered rooms.

Note: this still relies on the unregistered-room response staying aligned with the registered-room schema. Any future divergence between the two responses could introduce similar issues. A refactoring on the backend side is needed.

It closes #1441.
