### PR TITLE
🐛(backend) handle failed and aborted egress events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) handle failed and aborted egress events
 - 🩹(backend) identify externally provisioned users to PostHog
 - 🐛(backend) fix info panel crash for unregistered rooms
 - ♿️(frontend) focus side panel container on open #1452

--- a/src/backend/core/services/livekit_events.py
+++ b/src/backend/core/services/livekit_events.py
@@ -221,10 +221,10 @@ class LiveKitEventsService:
             api.EgressStatus.EGRESS_FAILED: models.RecordingStatusChoices.FAILED_TO_STOP,
         }
         terminal_status = terminal_status_mapping.get(data.egress_info.status)
-        if (
-            terminal_status is not None
-            and recording.status == models.RecordingStatusChoices.ACTIVE
-        ):
+        if terminal_status is not None and recording.status in {
+            models.RecordingStatusChoices.ACTIVE,
+            models.RecordingStatusChoices.STOPPED,
+        }:
             recording.status = terminal_status
             recording.save()
 

--- a/src/backend/core/services/livekit_events.py
+++ b/src/backend/core/services/livekit_events.py
@@ -216,7 +216,17 @@ class LiveKitEventsService:
                     recording.id,
                 )
 
-        # Silently ignoring EGRESS_ABORTED, EGRESS_FAILED
+        terminal_status_mapping = {
+            api.EgressStatus.EGRESS_ABORTED: models.RecordingStatusChoices.ABORTED,
+            api.EgressStatus.EGRESS_FAILED: models.RecordingStatusChoices.FAILED_TO_STOP,
+        }
+        terminal_status = terminal_status_mapping.get(data.egress_info.status)
+        if (
+            terminal_status is not None
+            and recording.status == models.RecordingStatusChoices.ACTIVE
+        ):
+            recording.status = terminal_status
+            recording.save()
 
     def _handle_room_started(self, data):
         """Handle 'room_started' event."""

--- a/src/backend/core/tests/services/test_livekit_events.py
+++ b/src/backend/core/tests/services/test_livekit_events.py
@@ -415,13 +415,34 @@ def test_handle_egress_ended_does_not_finalize_when_webhooks_enabled(  # noqa: P
 
 
 @pytest.mark.parametrize(
+    ("egress_status", "expected_status"),
+    [
+        (EgressStatus.EGRESS_ABORTED, "aborted"),
+        (EgressStatus.EGRESS_FAILED, "failed_to_stop"),
+    ],
+)
+@mock.patch("core.utils.update_room_metadata")
+def test_handle_egress_ended_records_terminal_error_status(
+    mock_update_room_metadata, egress_status, expected_status, service
+):
+    """Should persist terminal error statuses reported by LiveKit."""
+    recording = RecordingFactory(worker_id="worker-1", status="active")
+    mock_data = mock.MagicMock()
+    mock_data.egress_info.egress_id = recording.worker_id
+    mock_data.egress_info.status = egress_status
+
+    service._handle_egress_ended(mock_data)
+
+    recording.refresh_from_db()
+    assert recording.status == expected_status
+
+
+@pytest.mark.parametrize(
     "egress_status",
     [
         EgressStatus.EGRESS_STARTING,
         EgressStatus.EGRESS_ACTIVE,
         EgressStatus.EGRESS_ENDING,
-        EgressStatus.EGRESS_FAILED,
-        EgressStatus.EGRESS_ABORTED,
     ],
 )
 @mock.patch("core.utils.update_room_metadata")

--- a/src/backend/core/tests/services/test_livekit_events.py
+++ b/src/backend/core/tests/services/test_livekit_events.py
@@ -421,12 +421,17 @@ def test_handle_egress_ended_does_not_finalize_when_webhooks_enabled(  # noqa: P
         (EgressStatus.EGRESS_FAILED, "failed_to_stop"),
     ],
 )
+@pytest.mark.parametrize("initial_status", ["active", "stopped"])
 @mock.patch("core.utils.update_room_metadata")
 def test_handle_egress_ended_records_terminal_error_status(
-    mock_update_room_metadata, egress_status, expected_status, service
+    mock_update_room_metadata,
+    initial_status,
+    egress_status,
+    expected_status,
+    service,
 ):
     """Should persist terminal error statuses reported by LiveKit."""
-    recording = RecordingFactory(worker_id="worker-1", status="active")
+    recording = RecordingFactory(worker_id="worker-1", status=initial_status)
     mock_data = mock.MagicMock()
     mock_data.egress_info.egress_id = recording.worker_id
     mock_data.egress_info.status = egress_status


### PR DESCRIPTION
## Purpose

Handle the terminal LiveKit egress statuses that were previously ignored by `_handle_egress_ended`.

Fixes #1391

## Proposal

- Persist `EGRESS_ABORTED` as the recording's `aborted` status.
- Persist `EGRESS_FAILED` as `failed_to_stop` for an active recording.
- Add regression coverage for both terminal statuses.
- Add the fix to the changelog.

## Validation

- `uv run pytest core/tests/services/test_livekit_events.py -v` — 49 passed.
- `uv run ruff format --check core/services/livekit_events.py core/tests/services/test_livekit_events.py`
- `uv run ruff check core/services/livekit_events.py core/tests/services/test_livekit_events.py`
- `uv run pylint core/services/livekit_events.py core/tests/services/test_livekit_events.py` — 10.00/10.
- `git diff --check`

The containerized full suite could not be reproduced locally because this environment cannot access the Docker socket. A direct full-backend run also requires the repository's Redis, LiveKit, and object-storage services; it was therefore not green in this reduced environment.

AI assistance was used while preparing this change; I reviewed the implementation and validated the focused behavior locally.
