### PR TITLE
🐛(transcription) fix silent fail of speaker assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+## Fixed
+
+- 🐛(transcription) fix silent bug in speaker assignment
+
 ## [1.24.0] - 2026-07-21
 
 ### Added

--- a/src/summary/summary/core/user_assign.py
+++ b/src/summary/summary/core/user_assign.py
@@ -275,7 +275,7 @@ def _build_participant_timelines(
 def _build_speaker_timelines(transcription: Any) -> dict[str, list[Interval]]:
     """Build interval timelines from WhisperX transcription segments."""
     intervals: dict[str, list[Interval]] = {}
-    segments = transcription.segments if hasattr(transcription, "segments") else []
+    segments = transcription.get("segments") or []
     max_word_duration = settings.resolve_speaker_identities_max_word_duration
 
     for segment in segments:


### PR DESCRIPTION
Fix bug introduced by #1362  which caused speaker assignment to silently fail. Bug was due to change in input variable type.

NB: Manual testing shows working speaker assignement