### PR TITLE
✨(frontend) add connection test page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 - ✨(backend) add roomkit viewset to start a room without WebRTC join
 - ✨(frontend) let users set default configuration for generated links
 - ✨(frontend) expose media state to external gateways
+- ✨(frontend) add connection test feature
 
 ### Changed
 

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -104,3 +104,6 @@ APPLICATION_JWT_AUDIENCE=http://localhost:8071/external-api/v1.0/
 APPLICATION_JWT_SECRET_KEY=devKey
 APPLICATION_BASE_URL=http://localhost:3000
 
+# Diagnostics
+CONNECTION_TEST_ENABLED = True
+

--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -65,6 +65,7 @@ def get_frontend_configuration(request):
             "default_access_level": settings.RESOURCE_DEFAULT_ACCESS_LEVEL,
         },
         "subtitle": {"enabled": settings.ROOM_SUBTITLE_ENABLED},
+        "diagnostics": {"connection_test_enabled": settings.CONNECTION_TEST_ENABLED},
         "livekit": {
             "url": settings.LIVEKIT_CONFIGURATION["url"],
             "force_wss_protocol": settings.LIVEKIT_FORCE_WSS_PROTOCOL,

--- a/src/backend/core/api/feature_flag.py
+++ b/src/backend/core/api/feature_flag.py
@@ -17,6 +17,7 @@ class FeatureFlag:
         "addons": "ADDONS_ENABLED",
         "application": "APPLICATION_ENABLED",
         "roomkit": "ROOMKIT_ENABLED",
+        "connection_test": "CONNECTION_TEST_ENABLED",
     }
 
     @classmethod

--- a/src/backend/core/api/throttling.py
+++ b/src/backend/core/api/throttling.py
@@ -85,3 +85,15 @@ class RoomKitJoinRateThrottle(MonitoredUserRateThrottle):
     """
 
     scope = "roomkit_join"
+
+
+class ConnectionTestUserRateThrottle(MonitoredUserRateThrottle):
+    """Throttle authenticated users requesting connection test tokens."""
+
+    scope = "connection_test"
+
+
+class ConnectionTestAnonRateThrottle(MonitoredAnonRateThrottle):
+    """Throttle anonymous users requesting connection test tokens."""
+
+    scope = "connection_test"

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2,8 +2,10 @@
 # pylint: disable=too-many-lines
 
 import uuid
+from datetime import timedelta
 from logging import getLogger
 from urllib.parse import unquote, urlparse
+from uuid import uuid4
 
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -28,6 +30,9 @@ from rest_framework import (
     exceptions as drf_exceptions,
 )
 from rest_framework import (
+    permissions as drf_permissions,
+)
+from rest_framework import (
     response as drf_response,
 )
 from rest_framework import (
@@ -36,6 +41,7 @@ from rest_framework import (
 from rest_framework.settings import api_settings
 
 from core import analytics, enums, models, utils
+from core.api import throttling
 from core.api.filters import ListFileFilter
 from core.enums import MEDIA_STORAGE_URL_PATTERN
 from core.recording.enums import FileExtension
@@ -93,7 +99,9 @@ from core.services.room_roles import (
     RoomRoleService,
 )
 from core.services.subtitle import SubtitleException, SubtitleService
+from core.tasks.connection_test import delete_connection_test_room
 from core.tasks.file import process_file_deletion
+from core.utils import generate_token
 
 from ..authentication.livekit import LiveKitTokenAuthentication
 from ..models import RoomAccessLevel
@@ -1563,3 +1571,64 @@ class FileViewSet(
         request = utils.generate_s3_authorization_headers(f"{url_params.get('key'):s}")
 
         return drf_response.Response("authorized", headers=request.headers, status=200)
+
+
+class DiagnosticsViewSet(viewsets.ViewSet):
+    """Endpoints helping users and support diagnose connectivity issues.
+
+    Diagnostics are grouped behind a single prefix so upcoming checks
+    (rtcstats collection, ICE candidate reports, etc.) can be added as new
+    actions rather than new top-level routes.
+
+    They are open to anonymous users: someone who cannot join a room is
+    exactly who needs to run a test, and they may well not be logged in.
+    Each action therefore carries its own throttle scope.
+    """
+
+    permission_classes = [drf_permissions.AllowAny]
+
+    @decorators.action(
+        detail=False,
+        methods=["POST"],
+        url_path="connection",
+        url_name="connection",
+        throttle_classes=[
+            throttling.ConnectionTestUserRateThrottle,
+            throttling.ConnectionTestAnonRateThrottle,
+        ],
+    )
+    @FeatureFlag.require("connection_test")
+    def connection(self, request):
+        """Return a short-lived LiveKit token for an ephemeral test room.
+
+        Going through the room API is not an option here: it is tied to
+        registered meetings, lobby rules and longer-lived tokens. Each call
+        gets its own room so two people testing at the same time never meet.
+        """
+        room = f"{settings.CONNECTION_TEST_ROOM_PREFIX}-{uuid4()}"
+        expires_in = settings.CONNECTION_TEST_TOKEN_TTL_SECONDS
+
+        # LiveKit refreshes tokens for connected clients, so JWT TTL alone does not
+        # eject someone who stays connected. Schedule a hard DeleteRoom when Celery
+        # is available.
+        if settings.CELERY_ENABLED:
+            delete_connection_test_room.apply_async(
+                args=[room],
+                countdown=settings.CONNECTION_TEST_ROOM_MAX_AGE_SECONDS,
+            )
+
+        return drf_response.Response(
+            {
+                "livekit": {
+                    "url": settings.LIVEKIT_CONFIGURATION["url"],
+                    "room": room,
+                    "token": generate_token(
+                        room=room,
+                        user=request.user,
+                        username="Connection Test",
+                        ttl=timedelta(seconds=expires_in),
+                    ),
+                    "expires_in": expires_in,
+                },
+            }
+        )

--- a/src/backend/core/services/livekit_events.py
+++ b/src/backend/core/services/livekit_events.py
@@ -137,6 +137,13 @@ class LiveKitEventsService:
 
         room_name = data.room.name or data.egress_info.room_name
 
+        if self._is_connection_test_room(room_name):
+            logger.info(
+                "Ignoring webhook event for connection test room '%s'.",
+                room_name,
+            )
+            return
+
         if self._filter_regex and not self._filter_regex.search(room_name):
             logger.info("Filtered webhook event for room '%s'", room_name)
             return
@@ -227,6 +234,11 @@ class LiveKitEventsService:
                 )
 
         # Silently ignoring EGRESS_ABORTED, EGRESS_FAILED
+
+    @staticmethod
+    def _is_connection_test_room(room_name: str) -> bool:
+        """Return True for ephemeral rooms created by the connection test endpoint."""
+        return room_name.startswith(settings.CONNECTION_TEST_ROOM_PREFIX)
 
     def _handle_room_started(self, data):
         """Handle 'room_started' event."""

--- a/src/backend/core/services/room_management.py
+++ b/src/backend/core/services/room_management.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 
 from asgiref.sync import async_to_sync
 from livekit.api import (
+    DeleteRoomRequest,
     ListRoomsRequest,
     TwirpError,
     UpdateRoomMetadataRequest,
@@ -86,5 +87,32 @@ class RoomManagement:
             )
             raise RoomManagementException("Could not update room metadata") from e
 
+        finally:
+            await lkapi.aclose()
+
+    @async_to_sync
+    async def delete_room(self, room_name: str):
+        """Delete a LiveKit room and disconnect all participants.
+
+        Raises:
+            RoomNotFoundException: the room does not exist in LiveKit.
+            RoomManagementException: the deletion otherwise fails.
+        """
+
+        lkapi = utils.create_livekit_client()
+
+        try:
+            await lkapi.room.delete_room(DeleteRoomRequest(room=room_name))
+            logger.info("Deleted LiveKit room %s", room_name)
+        except TwirpError as e:
+            if e.code == "not_found":
+                logger.warning(
+                    "Room %s not found in LiveKit, skipping deletion",
+                    room_name,
+                )
+                raise RoomNotFoundException("Room does not exist") from e
+
+            logger.exception("Unexpected error deleting room %s", room_name)
+            raise RoomManagementException("Could not delete room") from e
         finally:
             await lkapi.aclose()

--- a/src/backend/core/tasks/__init__.py
+++ b/src/backend/core/tasks/__init__.py
@@ -1,0 +1,9 @@
+"""Celery tasks for the core app."""
+
+from core.tasks.connection_test import delete_connection_test_room
+from core.tasks.file import process_file_deletion
+
+__all__ = (
+    "delete_connection_test_room",
+    "process_file_deletion",
+)

--- a/src/backend/core/tasks/connection_test.py
+++ b/src/backend/core/tasks/connection_test.py
@@ -1,0 +1,39 @@
+"""Tasks related to connection test rooms."""
+
+import logging
+
+from django.conf import settings
+
+from core.services.room_management import (
+    RoomManagement,
+    RoomManagementException,
+    RoomNotFoundException,
+)
+from core.tasks._task import task
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def delete_connection_test_room(room_name: str):
+    """Force-delete an ephemeral connection-test room.
+
+    Used as a hard cap so a participant cannot keep an auto-refreshed
+    LiveKit session open indefinitely after requesting a test token.
+    """
+    prefix = settings.CONNECTION_TEST_ROOM_PREFIX
+    if not room_name.startswith(prefix):
+        logger.error(
+            "Refusing to delete room '%s': expected prefix '%s'.",
+            room_name,
+            prefix,
+        )
+        return
+
+    try:
+        RoomManagement().delete_room(room_name)
+    except RoomNotFoundException:
+        # Room may already be gone after empty/departure timeout.
+        logger.info("Connection test room '%s' already gone.", room_name)
+    except RoomManagementException:
+        logger.exception("Failed to delete connection test room '%s'.", room_name)

--- a/src/backend/core/tests/services/test_livekit_events.py
+++ b/src/backend/core/tests/services/test_livekit_events.py
@@ -720,6 +720,7 @@ def test_receive_unsupported_event(mock_receive, service):
 
     # Mock returned data with unsupported event type
     mock_data = mock.MagicMock()
+    mock_data.room.name = str(uuid.uuid4())
     mock_data.event = "unsupported_event"
     mock_receive.return_value = mock_data
 
@@ -823,3 +824,33 @@ def test_receive_filter_processes_matching_events(
     service.receive(mock_request)
 
     mock_handle_room_started.assert_called_once()
+
+
+@mock.patch.object(api.WebhookReceiver, "receive")
+@mock.patch.object(LiveKitEventsService, "_handle_room_finished")
+@mock.patch.object(LiveKitEventsService, "_handle_room_started")
+def test_receive_ignores_connection_test_room(
+    mock_handle_room_started,
+    mock_handle_room_finished,
+    mock_receive,
+    mock_livekit_config,
+    settings,
+):
+    """Should ignore all webhook events for connection test rooms in receive()."""
+
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+
+    mock_request = mock.MagicMock()
+    mock_request.headers = {"Authorization": "test_token"}
+    mock_request.body = b"{}"
+
+    mock_data = mock.MagicMock()
+    mock_data.room.name = f"{settings.CONNECTION_TEST_ROOM_PREFIX}-{uuid.uuid4()}"
+    mock_data.event = "room_started"
+    mock_receive.return_value = mock_data
+
+    service = LiveKitEventsService()
+    service.receive(mock_request)
+
+    mock_handle_room_started.assert_not_called()
+    mock_handle_room_finished.assert_not_called()

--- a/src/backend/core/tests/services/test_room_management.py
+++ b/src/backend/core/tests/services/test_room_management.py
@@ -1,0 +1,60 @@
+"""Tests for the RoomManagement service."""
+
+from unittest import mock
+
+import pytest
+from livekit.api import TwirpError
+
+from core.services.room_management import (
+    RoomManagement,
+    RoomManagementException,
+    RoomNotFoundException,
+)
+
+
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_delete_room_calls_livekit(mock_create_livekit_client):
+    """DeleteRoom is forwarded to the LiveKit API."""
+    mock_api = mock.MagicMock()
+    mock_api.room.delete_room = mock.AsyncMock()
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    RoomManagement().delete_room("room-abc")
+
+    mock_api.room.delete_room.assert_awaited_once()
+    request = mock_api.room.delete_room.await_args.args[0]
+    assert request.room == "room-abc"
+    mock_api.aclose.assert_awaited_once()
+
+
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_delete_room_raises_not_found(mock_create_livekit_client):
+    """Missing rooms raise RoomNotFoundException."""
+    mock_api = mock.MagicMock()
+    mock_api.room.delete_room = mock.AsyncMock(
+        side_effect=TwirpError("not_found", "room not found", status=404)
+    )
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    with pytest.raises(RoomNotFoundException):
+        RoomManagement().delete_room("missing-room")
+
+    mock_api.aclose.assert_awaited_once()
+
+
+@mock.patch("core.services.room_management.utils.create_livekit_client")
+def test_delete_room_raises_management_exception(mock_create_livekit_client):
+    """Unexpected Twirp errors raise RoomManagementException."""
+    mock_api = mock.MagicMock()
+    mock_api.room.delete_room = mock.AsyncMock(
+        side_effect=TwirpError("internal", "boom", status=500)
+    )
+    mock_api.aclose = mock.AsyncMock()
+    mock_create_livekit_client.return_value = mock_api
+
+    with pytest.raises(RoomManagementException):
+        RoomManagement().delete_room("room-abc")
+
+    mock_api.aclose.assert_awaited_once()

--- a/src/backend/core/tests/tasks/test_connection_test.py
+++ b/src/backend/core/tests/tasks/test_connection_test.py
@@ -1,0 +1,51 @@
+"""Tests for connection test Celery tasks."""
+
+from unittest import mock
+
+from django.test.utils import override_settings
+
+from core.services.room_management import (
+    RoomManagementException,
+    RoomNotFoundException,
+)
+from core.tasks.connection_test import delete_connection_test_room
+
+
+@mock.patch("core.tasks.connection_test.RoomManagement.delete_room")
+def test_delete_connection_test_room_calls_room_management(mock_delete_room, settings):
+    """RoomManagement.delete_room is called for connection-test rooms."""
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+    delete_connection_test_room("connection-test-abc")
+
+    mock_delete_room.assert_called_once_with("connection-test-abc")
+
+
+@mock.patch("core.tasks.connection_test.RoomManagement.delete_room")
+def test_delete_connection_test_room_refuses_other_rooms(mock_delete_room, settings):
+    """Refuse to delete rooms outside the connection-test namespace."""
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+    delete_connection_test_room("production-room")
+
+    mock_delete_room.assert_not_called()
+
+
+@mock.patch("core.tasks.connection_test.RoomManagement.delete_room")
+def test_delete_connection_test_room_ignores_missing_room(mock_delete_room, settings):
+    """Missing rooms are treated as already cleaned up."""
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+    mock_delete_room.side_effect = RoomNotFoundException("Room does not exist")
+
+    delete_connection_test_room("connection-test-gone")
+
+    mock_delete_room.assert_called_once_with("connection-test-gone")
+
+
+@mock.patch("core.tasks.connection_test.RoomManagement.delete_room")
+def test_delete_connection_test_room_logs_other_failures(mock_delete_room, settings):
+    """Unexpected LiveKit failures are swallowed after logging."""
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+    mock_delete_room.side_effect = RoomManagementException("Could not delete room")
+
+    delete_connection_test_room("connection-test-fail")
+
+    mock_delete_room.assert_called_once_with("connection-test-fail")

--- a/src/backend/core/tests/test_api_diagnostics.py
+++ b/src/backend/core/tests/test_api_diagnostics.py
@@ -1,0 +1,165 @@
+"""Test diagnostics API endpoints."""
+
+import uuid
+from unittest import mock
+
+from django.test.utils import override_settings
+from django.urls import reverse
+
+import jwt
+import pytest
+from rest_framework.test import APIClient
+
+from core.api.throttling import (
+    ConnectionTestAnonRateThrottle,
+    ConnectionTestUserRateThrottle,
+)
+from core.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_api_diagnostics_connection_url():
+    """The connection check is exposed under the diagnostics namespace."""
+    assert reverse("diagnostics-connection") == "/api/v1.0/diagnostics/connection/"
+
+
+def test_api_diagnostics_connection_rejects_get():
+    """Only POST is exposed, the endpoint has no side effect to trigger."""
+    client = APIClient()
+    response = client.get("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 405
+
+
+def test_api_diagnostics_connection_returns_ephemeral_livekit_config(settings, client):
+    """Each request gets a dedicated room and a short-lived token."""
+
+    settings.CONNECTION_TEST_TOKEN_TTL_SECONDS = 600
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+
+    response_a = client.post("/api/v1.0/diagnostics/connection/")
+    response_b = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response_a.status_code == 200
+    assert response_b.status_code == 200
+
+    data_a = response_a.json()
+    data_b = response_b.json()
+
+    room_a = data_a["livekit"]["room"]
+    room_b = data_b["livekit"]["room"]
+
+    assert room_a.startswith("connection-test-")
+    assert room_b.startswith("connection-test-")
+    uuid.UUID(room_a.removeprefix("connection-test-"))
+    uuid.UUID(room_b.removeprefix("connection-test-"))
+    assert room_a != room_b
+    assert data_a["livekit"]["url"]
+    assert data_a["livekit"]["token"]
+    assert data_a["livekit"]["expires_in"] == 600
+    assert data_a["livekit"]["token"] != data_b["livekit"]["token"]
+
+
+def test_api_diagnostics_connection_token_is_short_lived_for_user(settings, client):
+    """Connection test tokens expire quickly for users."""
+
+    settings.CONNECTION_TEST_TOKEN_TTL_SECONDS = 300
+
+    client = APIClient()
+    response = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 200
+
+    config = response.json()["livekit"]
+    payload = jwt.decode(
+        config["token"],
+        settings.LIVEKIT_CONFIGURATION["api_secret"],
+        algorithms=["HS256"],
+        options={"verify_exp": False},
+    )
+
+    assert config["expires_in"] == 300
+    assert payload["video"]["room"] == config["room"]
+    assert payload["name"] == "Connection Test"
+    assert payload["video"]["roomAdmin"] is False
+    assert payload["exp"] - payload["nbf"] == 300
+
+
+@override_settings()
+def test_api_diagnostics_connection_token_for_authenticated_user(settings, client):
+    """Logged-in users get a token bound to their own identity."""
+
+    settings.CONNECTION_TEST_TOKEN_TTL_SECONDS = 300
+
+    user = UserFactory()
+    client.force_login(user)
+
+    response = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 200
+
+    payload = jwt.decode(
+        response.json()["livekit"]["token"],
+        settings.LIVEKIT_CONFIGURATION["api_secret"],
+        algorithms=["HS256"],
+        options={"verify_exp": False},
+    )
+
+    assert payload["sub"] == str(user.sub)
+    assert payload["video"]["roomAdmin"] is False
+    assert payload["exp"] - payload["nbf"] == 300
+
+
+@mock.patch("core.api.viewsets.delete_connection_test_room.apply_async")
+def test_api_diagnostics_connection_schedules_room_deletion(
+    mock_apply_async, settings, client
+):
+    """When Celery is enabled, schedule a hard room delete after max age."""
+
+    settings.CELERY_ENABLED = True
+    settings.CONNECTION_TEST_ROOM_MAX_AGE_SECONDS = 300
+    settings.CONNECTION_TEST_ROOM_PREFIX = "connection-test"
+
+    response = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 200
+    room = response.json()["livekit"]["room"]
+    mock_apply_async.assert_called_once_with(args=[room], countdown=300)
+
+
+@mock.patch("core.api.viewsets.delete_connection_test_room.apply_async")
+def test_api_diagnostics_connection_skips_room_deletion_without_celery(
+    mock_apply_async, settings, client
+):
+    """Without Celery, do not schedule deletion (apply_async would run immediately)."""
+
+    settings.CELERY_ENABLED = False
+    response = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 200
+    mock_apply_async.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "throttle_class",
+    [ConnectionTestAnonRateThrottle, ConnectionTestUserRateThrottle],
+)
+def test_api_diagnostics_connection_is_throttled(throttle_class, client):
+    """Both throttles stay wired to the action once routed through the viewset."""
+    with (
+        mock.patch.object(throttle_class, "allow_request", return_value=False),
+        mock.patch.object(throttle_class, "wait", return_value=42),
+    ):
+        response = client.post("/api/v1.0/diagnostics/connection/")
+
+    assert response.status_code == 429
+
+
+def test_api_diagnostics_connection_feature_flag(client, settings):
+    """Should return a not found error when the connection diagnostics feature is disabled."""
+
+    settings.CONNECTION_TEST_ENABLED = False
+
+    response = client.post("/api/v1.0/diagnostics/connection/")
+    assert response.status_code == 404

--- a/src/backend/core/urls.py
+++ b/src/backend/core/urls.py
@@ -30,6 +30,11 @@ router.register(
     addons_viewsets.SessionViewSet,
     basename="addons_sessions",
 )
+router.register(
+    "diagnostics",
+    viewsets.DiagnosticsViewSet,
+    basename="diagnostics",
+)
 
 # - External API
 external_router = SimpleRouter()

--- a/src/backend/core/utils.py
+++ b/src/backend/core/utils.py
@@ -12,6 +12,7 @@ import mimetypes
 import random
 import secrets
 import string
+from datetime import timedelta
 from functools import lru_cache
 from typing import List, Optional
 from uuid import uuid4
@@ -67,6 +68,7 @@ def generate_token(  # noqa: PLR0917
     sources: Optional[List[str]] = None,
     role: Optional[str] = None,
     participant_id: Optional[str] = None,
+    ttl: Optional[timedelta] = None,
 ) -> str:
     """Generate a LiveKit access token for a user in a specific room.
 
@@ -82,6 +84,7 @@ def generate_token(  # noqa: PLR0917
         role (Optional[str]): Room's access role if any
         participant_id (Optional[str]): Stable identifier for anonymous users;
                          used as identity when user.is_anonymous.
+        ttl (Optional[timedelta]): Token validity duration. Defaults to LiveKit SDK default.
 
     Returns:
         str: The LiveKit JWT access token.
@@ -135,6 +138,8 @@ def generate_token(  # noqa: PLR0917
             }
         )
     )
+    if ttl is not None:
+        token = token.with_ttl(ttl)
 
     return token.to_jwt()
 

--- a/src/backend/meet/settings.py
+++ b/src/backend/meet/settings.py
@@ -354,6 +354,11 @@ class Base(Configuration):
                 environ_name="ROOMKIT_JOIN_THROTTLE_RATES",
                 environ_prefix=None,
             ),
+            "connection_test": values.Value(
+                default="30/minute",
+                environ_name="CONNECTION_TEST_THROTTLE_RATES",
+                environ_prefix=None,
+            ),
         },
     }
     MONITORED_THROTTLE_FAILURE_CALLBACK = (
@@ -659,6 +664,26 @@ class Base(Configuration):
         environ_name="LIVEKIT_ENABLE_FIREFOX_PROXY_WORKAROUND",
         environ_prefix=None,
         default=False,
+    )
+    CONNECTION_TEST_ENABLED = values.BooleanValue(
+        environ_name="CONNECTION_TEST_ENABLED",
+        environ_prefix=None,
+        default=False,
+    )
+    CONNECTION_TEST_TOKEN_TTL_SECONDS = values.PositiveIntegerValue(
+        300,
+        environ_name="CONNECTION_TEST_TOKEN_TTL_SECONDS",
+        environ_prefix=None,
+    )
+    CONNECTION_TEST_ROOM_MAX_AGE_SECONDS = values.PositiveIntegerValue(
+        300,
+        environ_name="CONNECTION_TEST_ROOM_MAX_AGE_SECONDS",
+        environ_prefix=None,
+    )
+    CONNECTION_TEST_ROOM_PREFIX = values.Value(
+        "connection-test",
+        environ_name="CONNECTION_TEST_ROOM_PREFIX",
+        environ_prefix=None,
     )
     LIVEKIT_VERIFY_SSL = values.BooleanValue(
         True, environ_name="LIVEKIT_VERIFY_SSL", environ_prefix=None
@@ -1269,6 +1294,8 @@ class Test(Base):
     ADDONS_ENABLED = True
     ADDONS_CSRF_SECRET = "secret-key-padded-for-minimum-len!-addons"  # noqa:S105
     ADDONS_TOKEN_SECRET_KEY = "secret-key-padded-for-minimum-len!-addons"  # noqa:S105
+
+    CONNECTION_TEST_ENABLED = True
 
     def __init__(self):
         # pylint: disable=invalid-name

--- a/src/frontend/src/api/useConfig.ts
+++ b/src/frontend/src/api/useConfig.ts
@@ -45,6 +45,9 @@ export interface ApiConfig {
   subtitle: {
     enabled: boolean
   }
+  diagnostics: {
+    connection_test_enabled?: boolean
+  }
   telephony: {
     enabled: boolean
     international_phone_number?: string

--- a/src/frontend/src/features/diagnostics/api/fetchConnectionTestDetails.ts
+++ b/src/frontend/src/features/diagnostics/api/fetchConnectionTestDetails.ts
@@ -1,0 +1,17 @@
+import { fetchApi } from '@/api/fetchApi'
+
+export type LiveKitConnectionDetails = {
+  url: string
+  room: string
+  token: string
+  expires_in: number
+}
+
+export type ConnectionTestResponse = {
+  livekit: LiveKitConnectionDetails
+}
+
+export const fetchConnectionTestDetails = () =>
+  fetchApi<ConnectionTestResponse>('/diagnostics/connection/', {
+    method: 'POST',
+  })

--- a/src/frontend/src/features/diagnostics/checks/selectedCandidate.ts
+++ b/src/frontend/src/features/diagnostics/checks/selectedCandidate.ts
@@ -1,0 +1,257 @@
+import { Checker, Track, type CheckInfo } from 'livekit-client'
+
+/**
+ * Addresses are useful to a network administrator (they identify the egress IP
+ * and the SFU endpoint actually reached) but they also land in a downloadable
+ * report. Flip this to false to keep only the candidate types and protocols.
+ */
+const INCLUDE_CANDIDATE_ADDRESSES = true
+
+/** Beyond this, the log becomes noise rather than evidence. */
+const MAX_LOGGED_PAIRS = 8
+
+export type IceCandidateInfo = {
+  /** host, srflx, prflx or relay. */
+  type?: string
+  /** Transport to the first hop: udp or tcp. */
+  protocol?: string
+  /** Transport used by the relay itself (udp, tcp, tls). Local relay only. */
+  relayProtocol?: string
+  /** Chrome reports an mDNS `.local` name here for host candidates. */
+  address?: string
+  port?: number
+  /** Local candidates only, and not reported by every browser. */
+  networkType?: string
+}
+
+export type IceCandidatePair = {
+  /** The pair the browser is actually sending media on. */
+  selected: boolean
+  nominated?: boolean
+  local: IceCandidateInfo
+  remote: IceCandidateInfo
+  /** Round trip time in milliseconds. */
+  rttMs?: number
+  availableOutgoingBitrate?: number
+  bytesSent?: number
+}
+
+export type IceCandidateReport = {
+  selected: IceCandidatePair | null
+  /** Every pair that completed its connectivity checks, selected one first. */
+  working: IceCandidatePair[]
+}
+
+const PROBE_WIDTH = 320
+const PROBE_HEIGHT = 180
+const PROBE_FPS = 15
+const SETTLE_DELAY_MS = 3000
+
+type Stats = Record<string, unknown> & { type?: string }
+
+const readCandidate = (stats?: Stats): IceCandidateInfo => {
+  if (!stats) return {}
+
+  return {
+    type: stats.candidateType as string | undefined,
+    protocol: stats.protocol as string | undefined,
+    relayProtocol: stats.relayProtocol as string | undefined,
+    networkType: stats.networkType as string | undefined,
+    ...(INCLUDE_CANDIDATE_ADDRESSES
+      ? {
+          address: stats.address as string | undefined,
+          port: stats.port as number | undefined,
+        }
+      : {}),
+  }
+}
+
+const describeCandidate = (candidate: IceCandidateInfo) => {
+  const transport = candidate.relayProtocol ?? candidate.protocol ?? 'unknown'
+  const endpoint =
+    candidate.address === undefined
+      ? ''
+      : ` ${candidate.address}:${candidate.port ?? '?'}`
+  return `${candidate.type ?? 'unknown'} ${transport}${endpoint}`
+}
+
+const parseCandidates = (report: RTCStatsReport): IceCandidateReport => {
+  let selectedId: string | undefined
+
+  report.forEach((stats: Stats) => {
+    if (stats.type === 'transport' && stats.selectedCandidatePairId) {
+      selectedId = stats.selectedCandidatePairId as string
+    }
+  })
+
+  const working: IceCandidatePair[] = []
+
+  report.forEach((stats: Stats) => {
+    // `succeeded` means the pair completed its connectivity checks; failed,
+    // waiting and in-progress pairs are not evidence of anything working.
+    if (stats.type !== 'candidate-pair' || stats.state !== 'succeeded') return
+
+    const rtt = stats.currentRoundTripTime as number | undefined
+
+    working.push({
+      selected: selectedId !== undefined && stats.id === selectedId,
+      nominated: stats.nominated as boolean | undefined,
+      local: readCandidate(report.get(stats.localCandidateId as string)),
+      remote: readCandidate(report.get(stats.remoteCandidateId as string)),
+      rttMs: rtt === undefined ? undefined : Math.round(rtt * 1000),
+      availableOutgoingBitrate: stats.availableOutgoingBitrate as
+        | number
+        | undefined,
+      bytesSent: stats.bytesSent as number | undefined,
+    })
+  })
+
+  // Firefox does not report transport.selectedCandidatePairId: fall back to the
+  // nominated pair, then to the one that actually carried bytes.
+  let selected = working.find((pair) => pair.selected) ?? null
+  if (!selected) {
+    selected =
+      working.find((pair) => pair.nominated) ??
+      working
+        .slice()
+        .sort((a, b) => (b.bytesSent ?? 0) - (a.bytesSent ?? 0))[0] ??
+      null
+    if (selected) selected.selected = true
+  }
+
+  working.sort((a, b) => Number(b.selected) - Number(a.selected))
+
+  return { selected, working }
+}
+
+/**
+ * A synthetic track avoids asking for camera or microphone permission: this
+ * check must work for someone who denied both.
+ */
+const createProbeTrack = () => {
+  const canvas = document.createElement('canvas')
+  canvas.width = PROBE_WIDTH
+  canvas.height = PROBE_HEIGHT
+
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('Could not get canvas context')
+
+  let frame = 0
+  let rafId = 0
+  const draw = () => {
+    frame = (frame + 4) % 360
+    context.fillStyle = `hsl(${frame}, 100%, 50%)`
+    context.fillRect(0, 0, canvas.width, canvas.height)
+    rafId = requestAnimationFrame(draw)
+  }
+  draw()
+
+  const track = canvas.captureStream(PROBE_FPS).getVideoTracks()[0]
+
+  return {
+    track,
+    stop: () => {
+      cancelAnimationFrame(rafId)
+      track.stop()
+    },
+  }
+}
+
+export class SelectedCandidateCheck extends Checker {
+  private result: IceCandidateReport | null = null
+
+  get description() {
+    const selected = this.result?.selected
+    if (!selected) return 'Selected ICE candidate pair'
+
+    const transport =
+      selected.local.relayProtocol ?? selected.local.protocol ?? 'unknown'
+    const rtt =
+      selected.rttMs === undefined ? '' : ` · RTT ${selected.rttMs} ms`
+    return `${selected.local.type ?? 'unknown'} over ${transport}${rtt}`
+  }
+
+  protected async perform() {
+    await this.connect()
+
+    const probe = createProbeTrack()
+    try {
+      let publication
+      try {
+        publication = await this.room.localParticipant.publishTrack(
+          probe.track,
+          {
+            // The token restricts `can_publish_sources`, so a raw
+            // MediaStreamTrack published as `unknown` is rejected server side.
+            source: Track.Source.Camera,
+            simulcast: false,
+            videoEncoding: { maxBitrate: 300_000, maxFramerate: PROBE_FPS },
+          }
+        )
+      } catch (error) {
+        // A server-side grant problem is not a diagnosis of the user's network.
+        this.appendWarning(
+          `Could not publish the probe track: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`
+        )
+        this.skip()
+        return
+      }
+
+      // ICE keeps promoting pairs for a moment after the track goes up.
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_DELAY_MS))
+
+      // Stats come from the publisher peer connection: in an empty test room
+      // there is no subscriber transport to inspect.
+      const report = await publication.track?.getRTCStatsReport()
+      this.result = report ? parseCandidates(report) : null
+    } finally {
+      probe.stop()
+    }
+
+    const selected = this.result?.selected
+    const working = this.result?.working ?? []
+
+    if (!selected) {
+      this.appendWarning('No working candidate pair reported by the browser')
+      return
+    }
+
+    this.appendMessage(`selected: ${describeCandidate(selected.local)}`)
+    this.appendMessage(`server: ${describeCandidate(selected.remote)}`)
+    if (selected.rttMs !== undefined) {
+      this.appendMessage(`round trip time: ${selected.rttMs} ms`)
+    }
+
+    this.appendMessage(`working candidate pairs: ${working.length}`)
+    for (const pair of working.slice(0, MAX_LOGGED_PAIRS)) {
+      const rtt = pair.rttMs === undefined ? '' : ` · ${pair.rttMs} ms`
+      this.appendMessage(
+        `${pair.selected ? '→' : ' '} ${describeCandidate(pair.local)} → ${describeCandidate(pair.remote)}${rtt}`
+      )
+    }
+    if (working.length > MAX_LOGGED_PAIRS) {
+      this.appendMessage(
+        `… and ${working.length - MAX_LOGGED_PAIRS} more, see the report`
+      )
+    }
+
+    if (selected.local.type === 'relay') {
+      this.appendWarning(
+        'Media is relayed through TURN. Direct connections are likely blocked by a firewall.'
+      )
+    }
+    if ((selected.local.relayProtocol ?? selected.local.protocol) !== 'udp') {
+      this.appendWarning(
+        'Media is not using UDP, which usually means degraded quality under load.'
+      )
+    }
+  }
+
+  getInfo(): CheckInfo {
+    const info = super.getInfo()
+    info.data = this.result ?? undefined
+    return info
+  }
+}

--- a/src/frontend/src/features/diagnostics/components/ConnectionTestStepRow.tsx
+++ b/src/frontend/src/features/diagnostics/components/ConnectionTestStepRow.tsx
@@ -1,0 +1,186 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Disclosure,
+  DisclosurePanel,
+  Heading,
+  Button as RACButton,
+} from 'react-aria-components'
+import { RiArrowDownSFill } from '@remixicon/react'
+import { css, cx } from '@/styled-system/css'
+import type { ConnectionTestStepResult } from '../types'
+import { StepStatusIndicator } from './StepStatusIndicator'
+
+/** Each step is its own bounded card, collapsed or not. */
+const cardClass = css({
+  border: '1px solid {colors.greyscale.900}',
+  borderRadius: '5px',
+  backgroundColor: 'white',
+  overflow: 'hidden',
+})
+
+/**
+ * Fixed columns so the status labels line up across every row, whether or not
+ * the row is expandable.
+ */
+const rowClass = css({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) 7rem 1.5rem',
+  alignItems: 'center',
+  gap: '1rem',
+  width: '100%',
+  paddingX: '1rem',
+  paddingY: '0.75rem',
+  textAlign: 'left',
+})
+
+const identityClass = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.125rem',
+  minWidth: 0,
+})
+
+const triggerClass = css({
+  cursor: 'pointer',
+  transition: 'background-color 120ms',
+  _hover: { backgroundColor: 'greyscale.50' },
+  '&[data-focus-visible]': {
+    outline: '2px solid {colors.focusRing}',
+    outlineOffset: '-2px',
+  },
+})
+
+/** Expanded headers stay tinted so the open card reads as one block. */
+const triggerExpandedClass = css({
+  backgroundColor: 'greyscale.100',
+  _hover: { backgroundColor: 'greyscale.100' },
+})
+
+const labelClass = css({
+  textStyle: 'body',
+  color: 'greyscale.1000',
+  fontWeight: 'medium',
+})
+
+const valueClass = css({
+  fontFamily: 'mono',
+  textStyle: 'xs',
+  color: 'greyscale.500',
+  overflowWrap: 'anywhere',
+})
+
+const chevronClass = css({
+  color: 'primary.800',
+  justifySelf: 'end',
+  transition: 'transform 150ms',
+})
+
+const chevronExpandedClass = css({ transform: 'rotate(180deg)' })
+
+const headingResetClass = css({
+  margin: 0,
+  fontSize: 'inherit',
+  fontWeight: 'inherit',
+})
+
+const panelClass = css({
+  backgroundColor: 'white',
+})
+
+const logListClass = css({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+})
+
+const logItemClass = css({
+  fontFamily: 'mono',
+  textStyle: 'xs',
+  color: 'greyscale.700',
+  overflowWrap: 'anywhere',
+})
+
+const StepRowContent = ({ step }: { step: ConnectionTestStepResult }) => {
+  const { t } = useTranslation('connectionTest')
+
+  return (
+    <>
+      <span className={identityClass}>
+        <span className={labelClass}>{t(`steps.${step.id}`)}</span>
+        {step.summary && <span className={valueClass}>{step.summary}</span>}
+      </span>
+      <StepStatusIndicator
+        status={step.status}
+        label={t(`status.${step.status}`)}
+      />
+    </>
+  )
+}
+
+export const ConnectionTestStepRow = ({
+  step,
+}: {
+  step: ConnectionTestStepResult
+}) => {
+  const { t } = useTranslation('connectionTest')
+  const isSettled = step.status !== 'pending' && step.status !== 'running'
+  const hasLogs = isSettled && Boolean(step.logs?.length)
+
+  if (!hasLogs) {
+    return (
+      <div className={cx(cardClass, rowClass)}>
+        <StepRowContent step={step} />
+        {/* Empty chevron column keeps non-expandable rows aligned. */}
+        <span />
+      </div>
+    )
+  }
+
+  return (
+    <Disclosure className={cardClass}>
+      {({ isExpanded }) => (
+        <>
+          <Heading level={3} className={headingResetClass}>
+            <RACButton
+              slot="trigger"
+              className={cx(
+                rowClass,
+                triggerClass,
+                isExpanded ? triggerExpandedClass : undefined
+              )}
+            >
+              <StepRowContent step={step} />
+              <RiArrowDownSFill
+                aria-hidden="true"
+                className={cx(
+                  chevronClass,
+                  isExpanded ? chevronExpandedClass : undefined
+                )}
+              />
+            </RACButton>
+          </Heading>
+          <DisclosurePanel
+            className={panelClass}
+            aria-label={t('detailsFor', { step: t(`steps.${step.id}`) })}
+            style={{ padding: isExpanded ? '0.75rem 1rem' : '0  1rem' }}
+          >
+            {/* Collapsed panels stay in the DOM for aria-controls, but the log
+                lines themselves are only mounted when actually visible. */}
+            {isExpanded && (
+              <ul className={logListClass}>
+                {step.logs?.map((log, index) => (
+                  <li key={`${log.level}-${index}`} className={logItemClass}>
+                    {log.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </DisclosurePanel>
+        </>
+      )}
+    </Disclosure>
+  )
+}

--- a/src/frontend/src/features/diagnostics/components/ConnectionTestSummary.tsx
+++ b/src/frontend/src/features/diagnostics/components/ConnectionTestSummary.tsx
@@ -1,0 +1,257 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ProgressBar } from 'react-aria-components'
+import { css, cx } from '@/styled-system/css'
+import type { ConnectionTestStats } from '../types'
+import { statusSquareClass } from './stepAppearance'
+
+type SummaryState = 'idle' | 'running' | 'passed' | 'partial' | 'failed'
+
+/** Only a failure earns a colour: everything else stays near-black. */
+const stateColorClass: Record<SummaryState, string> = {
+  idle: css({ color: 'greyscale.1000' }),
+  running: css({ color: 'greyscale.1000' }),
+  passed: css({ color: 'greyscale.1000' }),
+  partial: css({ color: 'greyscale.1000' }),
+  failed: css({ color: 'danger.600' }),
+}
+
+const cardClass = css({
+  width: '100%',
+  borderRadius: '5px',
+  border: '1px solid {colors.greyscale.900}',
+  backgroundColor: 'white',
+  padding: { base: '1.25rem', xsm: '1.75rem' },
+  display: 'flex',
+  flexDirection: 'column',
+  // Blocks are spaced here; everything inside a block stays tight.
+  gap: '1.5rem',
+})
+
+const headerClass = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+})
+
+const eyebrowClass = css({
+  textStyle: 'sm',
+  fontWeight: 'medium',
+  color: 'greyscale.600',
+  margin: 0,
+})
+
+const headlineClass = css({
+  // Sized for the longest state string ("N vérifications en échec"), not for
+  // the shortest one.
+  fontSize: { base: '28', xsm: '40' },
+  lineHeight: '1.1',
+  fontWeight: 'bold',
+  letterSpacing: '-0.02em',
+  textWrap: 'balance',
+  margin: 0,
+})
+
+const hintClass = css({
+  textStyle: 'sm',
+  color: 'greyscale.600',
+  margin: 0,
+  maxWidth: '34rem',
+})
+
+const dividerClass = css({
+  // Lighter than the card border: an inner rule should never compete with it.
+  borderTop: '1px solid {colors.greyscale.100}',
+  paddingTop: '1.25rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.875rem',
+})
+
+const progressRowClass = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+})
+
+const trackClass = css({
+  height: '0.375rem',
+  width: '100%',
+  borderRadius: 'full',
+  backgroundColor: 'greyscale.200',
+  overflow: 'hidden',
+})
+
+const fillClass = css({
+  height: '100%',
+  borderRadius: 'full',
+  backgroundColor: 'primary.800',
+  transition: 'width 200ms ease-out',
+})
+
+const progressValueClass = css({
+  textStyle: 'sm',
+  fontVariantNumeric: 'tabular-nums',
+  color: 'greyscale.700',
+  whiteSpace: 'nowrap',
+  // Reserved width so the bar does not resize when the digits change.
+  minWidth: '3rem',
+  textAlign: 'right',
+})
+
+const countersClass = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.5rem 1.5rem',
+})
+
+const counterClass = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  textStyle: 'sm',
+  color: 'greyscale.600',
+})
+
+const counterSquareClass = css({
+  width: '0.5rem',
+  height: '0.5rem',
+  borderRadius: '2px',
+  flexShrink: 0,
+})
+
+const counterValueClass = css({
+  fontWeight: 'medium',
+  fontVariantNumeric: 'tabular-nums',
+  color: 'greyscale.1000',
+})
+
+/** A zero count is context, not a result: it recedes instead of shouting. */
+const emptyCounterClass = css({ color: 'greyscale.400' })
+const emptySquareClass = css({
+  backgroundColor: 'transparent!',
+  border: '1px solid {colors.greyscale.250}',
+})
+
+const actionsClass = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.75rem',
+})
+
+const Counter = ({
+  squareClass,
+  value,
+  label,
+}: {
+  squareClass: string
+  value: number
+  label: string
+}) => {
+  const isEmpty = value === 0
+
+  return (
+    <span className={cx(counterClass, isEmpty ? emptyCounterClass : undefined)}>
+      <span
+        aria-hidden="true"
+        className={cx(
+          counterSquareClass,
+          squareClass,
+          isEmpty ? emptySquareClass : undefined
+        )}
+      />
+      <span
+        className={cx(
+          counterValueClass,
+          isEmpty ? emptyCounterClass : undefined
+        )}
+      >
+        {value}
+      </span>
+      {label}
+    </span>
+  )
+}
+
+export const ConnectionTestSummary = ({
+  stats,
+  isRunning,
+  children,
+}: {
+  stats: ConnectionTestStats
+  isRunning: boolean
+  children?: ReactNode
+}) => {
+  const { t } = useTranslation('connectionTest')
+
+  const state: SummaryState = isRunning
+    ? 'running'
+    : !stats.hasStarted
+      ? 'idle'
+      : stats.failed > 0
+        ? 'failed'
+        : stats.skipped > 0
+          ? 'partial'
+          : 'passed'
+
+  return (
+    <section className={cardClass}>
+      <div className={headerClass}>
+        <h1 className={eyebrowClass}>{t('title')}</h1>
+
+        {/* Announced once per state change rather than on every step update. */}
+        <p className={cx(headlineClass, stateColorClass[state])} role="status">
+          {state === 'failed'
+            ? t('summary.failed', { count: stats.failed })
+            : t(`summary.${state}`)}
+        </p>
+
+        <p className={hintClass}>{t(`summary.${state}Hint`)}</p>
+      </div>
+
+      {stats.hasStarted && (
+        <div className={dividerClass}>
+          <div className={progressRowClass}>
+            <ProgressBar
+              aria-label={t('progressLabel')}
+              value={stats.progress}
+              className={css({ flex: 1 })}
+            >
+              {({ percentage }) => (
+                <div className={trackClass}>
+                  <div
+                    className={fillClass}
+                    style={{ width: `${percentage ?? 0}%` }}
+                  />
+                </div>
+              )}
+            </ProgressBar>
+            <span className={progressValueClass}>
+              {t('progress', { done: stats.settled, total: stats.total })}
+            </span>
+          </div>
+
+          <div className={countersClass}>
+            <Counter
+              squareClass={statusSquareClass.success}
+              value={stats.passed}
+              label={t('counts.passed')}
+            />
+            <Counter
+              squareClass={statusSquareClass.skipped}
+              value={stats.skipped}
+              label={t('counts.skipped')}
+            />
+            <Counter
+              squareClass={statusSquareClass.failed}
+              value={stats.failed}
+              label={t('counts.failed')}
+            />
+          </div>
+        </div>
+      )}
+
+      {children && <div className={actionsClass}>{children}</div>}
+    </section>
+  )
+}

--- a/src/frontend/src/features/diagnostics/components/StepStatusIndicator.tsx
+++ b/src/frontend/src/features/diagnostics/components/StepStatusIndicator.tsx
@@ -1,0 +1,40 @@
+import { css, cx } from '@/styled-system/css'
+import type { ConnectionTestStepStatus } from '../types'
+import { statusSquareClass, statusTextClass } from './stepAppearance'
+
+const wrapperClass = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  textStyle: 'sm',
+  whiteSpace: 'nowrap',
+})
+
+const squareClass = css({
+  width: '0.625rem',
+  height: '0.625rem',
+  borderRadius: '2px',
+  flexShrink: 0,
+})
+
+/**
+ * Status is carried by the label; the square is decorative so the meaning does
+ * not depend on colour alone.
+ */
+export const StepStatusIndicator = ({
+  status,
+  label,
+  className,
+}: {
+  status: ConnectionTestStepStatus
+  label: string
+  className?: string
+}) => (
+  <span className={cx(wrapperClass, className)}>
+    <span
+      aria-hidden="true"
+      className={cx(squareClass, statusSquareClass[status])}
+    />
+    <span className={statusTextClass[status]}>{label}</span>
+  </span>
+)

--- a/src/frontend/src/features/diagnostics/components/stepAppearance.ts
+++ b/src/frontend/src/features/diagnostics/components/stepAppearance.ts
@@ -1,0 +1,29 @@
+import { css } from '@/styled-system/css'
+import type { ConnectionTestStepStatus } from '../types'
+
+/**
+ * Panda extracts styles statically, so every status needs its own literal
+ * `css()` call: `css({ backgroundColor: someVariable })` would emit nothing.
+ */
+export const statusSquareClass: Record<ConnectionTestStepStatus, string> = {
+  pending: css({
+    backgroundColor: 'transparent',
+    border: '1px solid {colors.greyscale.300}',
+  }),
+  running: css({
+    backgroundColor: 'primary.800',
+    animation: 'pulse_background 1.2s ease-in-out infinite',
+  }),
+  success: css({ backgroundColor: 'success.600' }),
+  failed: css({ backgroundColor: 'danger.600' }),
+  skipped: css({ backgroundColor: 'greyscale.300' }),
+}
+
+/** Colour is carried by the square; the label stays near-black except on failure. */
+export const statusTextClass: Record<ConnectionTestStepStatus, string> = {
+  pending: css({ color: 'greyscale.500' }),
+  running: css({ color: 'greyscale.700' }),
+  success: css({ color: 'greyscale.1000' }),
+  failed: css({ color: 'danger.600', fontWeight: 'medium' }),
+  skipped: css({ color: 'greyscale.500' }),
+}

--- a/src/frontend/src/features/diagnostics/hooks/useConnectionTestRunner.ts
+++ b/src/frontend/src/features/diagnostics/hooks/useConnectionTestRunner.ts
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  CheckStatus,
+  ConnectionCheck,
+  createLocalAudioTrack,
+  createLocalVideoTrack,
+  getBrowser,
+  type CheckInfo,
+} from 'livekit-client'
+import { fetchConnectionTestDetails } from '../api/fetchConnectionTestDetails'
+import {
+  createInitialSteps,
+  type ConnectionTestLog,
+  type ConnectionTestStepId,
+  type ConnectionTestStepResult,
+  type ConnectionTestStepStatus,
+} from '../types'
+import { openPermissionsDialog } from '@/stores/permissions'
+
+const LIVEKIT_STEP_IDS: ConnectionTestStepId[] = [
+  'websocket',
+  'webrtc',
+  'turn',
+  'reconnect',
+  'publishAudio',
+  'publishVideo',
+]
+
+const CHECK_STATUS_TO_STEP: Record<CheckStatus, ConnectionTestStepStatus> = {
+  [CheckStatus.IDLE]: 'pending',
+  [CheckStatus.RUNNING]: 'running',
+  [CheckStatus.SUCCESS]: 'success',
+  [CheckStatus.FAILED]: 'failed',
+  [CheckStatus.SKIPPED]: 'skipped',
+}
+
+/** getUserMedia rejections that mean "the user said no", not "the device is broken". */
+const PERMISSION_ERROR_NAMES = new Set([
+  'NotAllowedError',
+  'PermissionDeniedError',
+  'SecurityError',
+])
+
+const getErrorMessage = (error: unknown, fallback = 'Unknown error') =>
+  error instanceof Error ? error.message : fallback
+
+const isPermissionError = (error: unknown) =>
+  error instanceof Error && PERMISSION_ERROR_NAMES.has(error.name)
+
+const fromCheckInfo = (info: CheckInfo): Partial<ConnectionTestStepResult> => ({
+  status: CHECK_STATUS_TO_STEP[info.status] ?? 'failed',
+  summary: info.description,
+  logs: info.logs,
+})
+
+const groupDevicesByKind = (devices: MediaDeviceInfo[]) => {
+  const grouped: Record<string, string[]> = {
+    audioinput: [],
+    audiooutput: [],
+    videoinput: [],
+  }
+  for (const device of devices) {
+    // Browsers are free to report kinds we don't know about yet.
+    const bucket = (grouped[device.kind] ??= [])
+    bucket.push(device.label || device.deviceId)
+  }
+  return grouped
+}
+
+/**
+ * Outcome of a single step. `aborted` is deliberately distinct from `failed`:
+ * a cancelled run must not be reported to the user as a broken device.
+ */
+type StepOutcome =
+  | { state: 'success' }
+  | { state: 'failed'; error: unknown }
+  | { state: 'aborted' }
+
+const ABORTED: StepOutcome = { state: 'aborted' }
+
+export const useConnectionTestRunner = () => {
+  const [steps, setSteps] = useState(createInitialSteps)
+  const [isRunning, setIsRunning] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const updateStep = useCallback(
+    (id: ConnectionTestStepId, patch: Partial<ConnectionTestStepResult>) => {
+      setSteps((current) =>
+        current.map((step) => (step.id === id ? { ...step, ...patch } : step))
+      )
+    },
+    []
+  )
+
+  const skipSteps = useCallback(
+    (
+      ids: ConnectionTestStepId[],
+      summary: string,
+      logs?: ConnectionTestLog[]
+    ) => {
+      // One state update for the whole batch instead of one per step.
+      const targets = new Set(ids)
+      setSteps((current) =>
+        current.map((step) =>
+          targets.has(step.id)
+            ? { ...step, status: 'skipped', summary, logs }
+            : step
+        )
+      )
+    },
+    []
+  )
+
+  const runStep = useCallback(
+    async (
+      id: ConnectionTestStepId,
+      signal: AbortSignal,
+      fn: () => Promise<Partial<ConnectionTestStepResult>>
+    ): Promise<StepOutcome> => {
+      if (signal.aborted) return ABORTED
+
+      updateStep(id, {
+        status: 'running',
+        summary: undefined,
+        logs: undefined,
+        data: undefined,
+      })
+
+      try {
+        const result = await fn()
+        if (signal.aborted) return ABORTED
+        // `result.status` overrides when set (LiveKit checks map their own status)
+        updateStep(id, { status: 'success', ...result })
+        return { state: 'success' }
+      } catch (error) {
+        if (signal.aborted) return ABORTED
+        updateStep(id, {
+          status: 'failed',
+          summary: getErrorMessage(error),
+        })
+        return { state: 'failed', error }
+      }
+    },
+    [updateStep]
+  )
+
+  const runTest = useCallback(async () => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const { signal } = controller
+
+    setIsRunning(true)
+    setSteps(createInitialSteps())
+
+    try {
+      await runStep('browser', signal, async () => {
+        const browser = getBrowser()
+        if (!browser) throw new Error('Browser not detected')
+        return {
+          summary: `${browser.name} ${browser.version}`,
+          data: {
+            name: browser.name,
+            version: browser.version,
+            os: browser.os,
+            osVersion: browser.osVersion,
+          },
+        }
+      })
+      if (signal.aborted) return
+
+      const microphone = await runStep('microphone', signal, async () => {
+        const track = await createLocalAudioTrack()
+        const label =
+          track.mediaStreamTrack.label ||
+          track.mediaStreamTrack.getSettings().deviceId ||
+          ''
+        track.stop()
+        return { summary: label, data: { label } }
+      })
+      if (signal.aborted) return
+      if (
+        microphone.state === 'failed' &&
+        isPermissionError(microphone.error)
+      ) {
+        openPermissionsDialog('audioinput')
+      }
+
+      const camera = await runStep('camera', signal, async () => {
+        const track = await createLocalVideoTrack()
+        const settings = track.mediaStreamTrack.getSettings()
+        const label = track.mediaStreamTrack.label || ''
+        // Released immediately, like the microphone probe: the capture
+        // indicator must not stay on between this check and publishVideo.
+        track.stop()
+        return {
+          summary: label,
+          data: {
+            label,
+            width: settings.width,
+            height: settings.height,
+          },
+        }
+      })
+      if (signal.aborted) return
+      if (camera.state === 'failed' && isPermissionError(camera.error)) {
+        openPermissionsDialog('videoinput')
+      }
+
+      await runStep('devices', signal, async () => {
+        const devices = await navigator.mediaDevices.enumerateDevices()
+        return {
+          summary: String(devices.length),
+          data: groupDevicesByKind(devices),
+        }
+      })
+      if (signal.aborted) return
+
+      let checker: ConnectionCheck
+      try {
+        const { livekit } = await fetchConnectionTestDetails()
+        if (signal.aborted) return
+        checker = new ConnectionCheck(livekit.url, livekit.token)
+      } catch (error) {
+        if (signal.aborted) return
+        skipSteps(
+          LIVEKIT_STEP_IDS,
+          getErrorMessage(error, 'Failed to fetch test token')
+        )
+        return
+      }
+
+      // LiveKit's ConnectionCheck exposes no cancellation: each check owns its
+      // own room and disconnects it when it settles. The best we can do is
+      // never start the next one once the run has been aborted (runStep
+      // short-circuits on `signal.aborted`).
+      await runStep('websocket', signal, async () =>
+        fromCheckInfo(await checker.checkWebsocket())
+      )
+      await runStep('webrtc', signal, async () =>
+        fromCheckInfo(await checker.checkWebRTC())
+      )
+      await runStep('turn', signal, async () =>
+        fromCheckInfo(await checker.checkTURN())
+      )
+      await runStep('reconnect', signal, async () =>
+        fromCheckInfo(await checker.checkReconnect())
+      )
+
+      if (microphone.state !== 'success') {
+        skipSteps(['publishAudio'], 'Microphone permission required')
+      } else {
+        await runStep('publishAudio', signal, async () =>
+          fromCheckInfo(await checker.checkPublishAudio())
+        )
+      }
+
+      if (camera.state !== 'success') {
+        skipSteps(['publishVideo'], 'Camera permission required')
+      } else {
+        await runStep('publishVideo', signal, async () =>
+          fromCheckInfo(await checker.checkPublishVideo())
+        )
+      }
+    } finally {
+      if (!signal.aborted) {
+        setIsRunning(false)
+      }
+    }
+  }, [runStep, skipSteps])
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort()
+    setSteps(createInitialSteps())
+    setIsRunning(false)
+  }, [])
+
+  // Leaving the page mid-run must stop the pending checks rather than let them
+  // keep a LiveKit session open behind an unmounted component.
+  useEffect(
+    () => () => {
+      abortRef.current?.abort()
+    },
+    []
+  )
+
+  return {
+    steps,
+    isRunning,
+    runTest,
+    reset,
+  }
+}

--- a/src/frontend/src/features/diagnostics/hooks/useConnectionTestRunner.ts
+++ b/src/frontend/src/features/diagnostics/hooks/useConnectionTestRunner.ts
@@ -8,6 +8,7 @@ import {
   type CheckInfo,
 } from 'livekit-client'
 import { fetchConnectionTestDetails } from '../api/fetchConnectionTestDetails'
+import { SelectedCandidateCheck } from '../checks/selectedCandidate'
 import {
   createInitialSteps,
   type ConnectionTestLog,
@@ -22,6 +23,7 @@ const LIVEKIT_STEP_IDS: ConnectionTestStepId[] = [
   'webrtc',
   'turn',
   'reconnect',
+  'selectedCandidate',
   'publishAudio',
   'publishVideo',
 ]
@@ -245,6 +247,9 @@ export const useConnectionTestRunner = () => {
       )
       await runStep('reconnect', signal, async () =>
         fromCheckInfo(await checker.checkReconnect())
+      )
+      await runStep('selectedCandidate', signal, async () =>
+        fromCheckInfo(await checker.createAndRunCheck(SelectedCandidateCheck))
       )
 
       if (microphone.state !== 'success') {

--- a/src/frontend/src/features/diagnostics/routes/ConnectionTest.tsx
+++ b/src/frontend/src/features/diagnostics/routes/ConnectionTest.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  RiCloseLine,
+  RiDownload2Line,
+  RiErrorWarningLine,
+  RiPlayLine,
+} from '@remixicon/react'
+import { CenteredContent } from '@/layout/CenteredContent'
+import { Screen } from '@/layout/Screen'
+import { Button } from '@/primitives'
+import { css } from '@/styled-system/css'
+import { Center, VStack } from '@/styled-system/jsx'
+import { Permissions } from '@/features/rooms/components/Permissions'
+import { useConnectionTestRunner } from '../hooks/useConnectionTestRunner'
+import { ConnectionTestStepRow } from '../components/ConnectionTestStepRow'
+import { ConnectionTestSummary } from '../components/ConnectionTestSummary'
+import { CONNECTION_TEST_GROUPS, summarizeSteps } from '../types'
+import { downloadConnectionTestReport } from '../utils/downloadConnectionTestReport'
+import { useConfig } from '@/api/useConfig'
+import { navigateTo } from '@/navigation/navigateTo'
+
+const HIDE_LIVEKIT_VIDEO_CLASS = 'connection-test-hide-livekit-video'
+
+const sectionClass = css({
+  width: '100%',
+  borderTop: '2px solid {colors.greyscale.900}',
+  paddingTop: '1rem',
+})
+
+const sectionTitleClass = css({
+  textStyle: 'h2',
+  color: 'greyscale.1000',
+  margin: 0,
+})
+
+const rowsClass = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  marginTop: '0.75rem',
+})
+
+const helpClass = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.5rem',
+  width: '100%',
+  borderRadius: 8,
+  border: '1px solid {colors.greyscale.200}',
+  backgroundColor: 'white',
+  padding: '0.75rem 1rem',
+  textStyle: 'sm',
+  color: 'greyscale.800',
+})
+
+const helpIconClass = css({
+  color: 'danger.600',
+  flexShrink: 0,
+  marginTop: '2px',
+})
+
+const ConnectionTest = () => {
+  const { data, isLoading } = useConfig()
+  const { t } = useTranslation('connectionTest')
+  const { steps, isRunning, runTest, reset } = useConnectionTestRunner()
+
+  const stats = useMemo(() => summarizeSteps(steps), [steps])
+  const stepsById = useMemo(
+    () => new Map(steps.map((step) => [step.id, step] as const)),
+    [steps]
+  )
+  const isPublishVideoRunning =
+    stepsById.get('publishVideo')?.status === 'running'
+
+  // LiveKit appends a bare <video> to document.body during publishVideo.
+  // Keep it in the DOM (so the frame check still works) but hide it visually.
+  useEffect(() => {
+    document.body.classList.toggle(
+      HIDE_LIVEKIT_VIDEO_CLASS,
+      isPublishVideoRunning
+    )
+    return () => {
+      document.body.classList.remove(HIDE_LIVEKIT_VIDEO_CLASS)
+    }
+  }, [isPublishVideoRunning])
+
+  useEffect(() => {
+    // Wait for config to load, otherwise we'd redirect off a page
+    // that's actually enabled.
+    if (!isLoading && !data?.diagnostics?.connection_test_enabled) {
+      navigateTo('home', undefined, { replace: true })
+    }
+  }, [isLoading, data])
+
+  return (
+    <Screen layout="centered">
+      <Permissions />
+      <CenteredContent withBackButton>
+        <Center>
+          <VStack gap="1.5rem" maxWidth="40rem" width="100%">
+            <ConnectionTestSummary stats={stats} isRunning={isRunning}>
+              {isRunning ? (
+                // A disabled "run" button while the test runs is dead weight:
+                // cancelling is the only thing left to do.
+                <Button
+                  variant="secondary"
+                  onPress={reset}
+                  icon={<RiCloseLine size={18} aria-hidden="true" />}
+                >
+                  {t('cancel')}
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  onPress={runTest}
+                  icon={<RiPlayLine size={18} aria-hidden="true" />}
+                >
+                  {stats.hasStarted ? t('runAgain') : t('runTest')}
+                </Button>
+              )}
+              {stats.hasStarted && !isRunning && (
+                <Button
+                  variant="secondary"
+                  onPress={() => downloadConnectionTestReport(steps)}
+                  icon={<RiDownload2Line size={18} aria-hidden="true" />}
+                >
+                  {t('downloadReport')}
+                </Button>
+              )}
+            </ConnectionTestSummary>
+
+            {stats.hasStarted &&
+              CONNECTION_TEST_GROUPS.map((group) => (
+                <section key={group.id} className={sectionClass}>
+                  <h2 className={sectionTitleClass}>
+                    {t(`groups.${group.id}`)}
+                  </h2>
+                  <div className={rowsClass}>
+                    {group.steps.map((id) => {
+                      const step = stepsById.get(id)
+                      return step ? (
+                        <ConnectionTestStepRow key={id} step={step} />
+                      ) : null
+                    })}
+                  </div>
+                </section>
+              ))}
+
+            {stats.failed > 0 && !isRunning && (
+              <p className={helpClass}>
+                <RiErrorWarningLine
+                  size={18}
+                  aria-hidden="true"
+                  className={helpIconClass}
+                />
+                {t('help.firewall')}
+              </p>
+            )}
+          </VStack>
+        </Center>
+      </CenteredContent>
+    </Screen>
+  )
+}
+
+export default ConnectionTest

--- a/src/frontend/src/features/diagnostics/types.ts
+++ b/src/frontend/src/features/diagnostics/types.ts
@@ -1,0 +1,101 @@
+export type ConnectionTestStepId =
+  | 'browser'
+  | 'microphone'
+  | 'camera'
+  | 'devices'
+  | 'websocket'
+  | 'webrtc'
+  | 'turn'
+  | 'reconnect'
+  | 'publishAudio'
+  | 'publishVideo'
+
+export type ConnectionTestStepStatus =
+  | 'pending'
+  | 'running'
+  | 'success'
+  | 'failed'
+  | 'skipped'
+
+export type ConnectionTestLog = {
+  level: 'info' | 'warning' | 'error'
+  message: string
+}
+
+export type ConnectionTestStepResult = {
+  id: ConnectionTestStepId
+  status: ConnectionTestStepStatus
+  summary?: string
+  logs?: ConnectionTestLog[]
+  data?: Record<string, unknown>
+}
+
+export type ConnectionTestGroupId = 'local' | 'network'
+
+/** Display order: everything local first, then everything that leaves the machine. */
+export const CONNECTION_TEST_GROUPS: ReadonlyArray<{
+  id: ConnectionTestGroupId
+  steps: ReadonlyArray<ConnectionTestStepId>
+}> = [
+  { id: 'local', steps: ['browser', 'microphone', 'camera', 'devices'] },
+  {
+    id: 'network',
+    steps: [
+      'websocket',
+      'webrtc',
+      'turn',
+      'reconnect',
+      'publishAudio',
+      'publishVideo',
+    ],
+  },
+]
+
+export const CONNECTION_TEST_STEP_IDS: ConnectionTestStepId[] =
+  CONNECTION_TEST_GROUPS.flatMap((group) => [...group.steps])
+
+export const createInitialSteps = (): ConnectionTestStepResult[] =>
+  CONNECTION_TEST_STEP_IDS.map((id) => ({ id, status: 'pending' }))
+
+export type ConnectionTestStats = {
+  total: number
+  settled: number
+  passed: number
+  failed: number
+  skipped: number
+  hasStarted: boolean
+  progress: number
+}
+
+/**
+ * Single pass over the steps: the page needs half a dozen derived booleans and
+ * counters, and scanning the array once per render beats one `.some()` per flag.
+ */
+export const summarizeSteps = (
+  steps: ConnectionTestStepResult[]
+): ConnectionTestStats => {
+  let passed = 0
+  let failed = 0
+  let skipped = 0
+  let pending = 0
+
+  for (const step of steps) {
+    if (step.status === 'success') passed += 1
+    else if (step.status === 'failed') failed += 1
+    else if (step.status === 'skipped') skipped += 1
+    else if (step.status === 'pending') pending += 1
+  }
+
+  const total = steps.length
+  const settled = passed + failed + skipped
+
+  return {
+    total,
+    settled,
+    passed,
+    failed,
+    skipped,
+    hasStarted: pending < total,
+    progress: total === 0 ? 0 : Math.round((settled / total) * 100),
+  }
+}

--- a/src/frontend/src/features/diagnostics/types.ts
+++ b/src/frontend/src/features/diagnostics/types.ts
@@ -7,6 +7,7 @@ export type ConnectionTestStepId =
   | 'webrtc'
   | 'turn'
   | 'reconnect'
+  | 'selectedCandidate'
   | 'publishAudio'
   | 'publishVideo'
 
@@ -45,6 +46,7 @@ export const CONNECTION_TEST_GROUPS: ReadonlyArray<{
       'webrtc',
       'turn',
       'reconnect',
+      'selectedCandidate',
       'publishAudio',
       'publishVideo',
     ],

--- a/src/frontend/src/features/diagnostics/utils/downloadConnectionTestReport.ts
+++ b/src/frontend/src/features/diagnostics/utils/downloadConnectionTestReport.ts
@@ -1,0 +1,53 @@
+import type { ConnectionTestStepResult } from '../types'
+
+export type ConnectionTestReport = {
+  generatedAt: string
+  userAgent: string
+  steps: Record<
+    string,
+    {
+      status: ConnectionTestStepResult['status']
+      summary?: string
+      logs?: ConnectionTestStepResult['logs']
+      data?: ConnectionTestStepResult['data']
+    }
+  >
+}
+
+export const buildConnectionTestReport = (
+  steps: ConnectionTestStepResult[]
+): ConnectionTestReport => ({
+  generatedAt: new Date().toISOString(),
+  userAgent: navigator.userAgent,
+  steps: Object.fromEntries(
+    steps.map(({ id, status, summary, logs, data }) => [
+      id,
+      {
+        status,
+        ...(summary !== undefined ? { summary } : {}),
+        ...(logs?.length ? { logs } : {}),
+        ...(data !== undefined ? { data } : {}),
+      },
+    ])
+  ),
+})
+
+export const downloadConnectionTestReport = (
+  steps: ConnectionTestStepResult[]
+) => {
+  const report = buildConnectionTestReport(steps)
+  const timestamp = report.generatedAt.slice(0, 19).replace(/:/g, '-')
+  const blob = new Blob([JSON.stringify(report, null, 2)], {
+    type: 'application/json',
+  })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `connection-test-${timestamp}.json`
+  // Firefox only follows the click when the anchor is in the document, and
+  // revoking the URL in the same tick cancels the download in some browsers.
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}

--- a/src/frontend/src/layout/Footer.tsx
+++ b/src/frontend/src/layout/Footer.tsx
@@ -266,6 +266,18 @@ export const Footer = () => {
               {t('links.accessibility')}
             </Link>
           </StyledLi>
+          {data?.diagnostics?.connection_test_enabled && (
+            <StyledLi divider>
+              <Link
+                underline={false}
+                footer="minor"
+                to="/test-connection"
+                aria-label={t('links.connectionTest')}
+              >
+                {t('links.connectionTest')}
+              </Link>
+            </StyledLi>
+          )}
           <StyledLi>
             <A
               externalIcon

--- a/src/frontend/src/locales/de/connectionTest.json
+++ b/src/frontend/src/locales/de/connectionTest.json
@@ -1,0 +1,56 @@
+{
+  "title": "Ihre Konfiguration testen",
+  "runTest": "Test starten",
+  "runAgain": "Erneut testen",
+  "cancel": "Abbrechen",
+  "detailsFor": "Details zu Schritt {{step}}",
+  "downloadReport": "Bericht herunterladen",
+  "homeLink": "Ihre Konfiguration testen",
+  "progress": "{{done}}/{{total}}",
+  "progressLabel": "Fortschritt des Verbindungstests",
+  "groups": {
+    "local": "Browser und Geräte",
+    "network": "Verbindung zum Server"
+  },
+  "steps": {
+    "browser": "Browser",
+    "microphone": "Mikrofon",
+    "camera": "Kamera",
+    "devices": "Mediengeräte",
+    "websocket": "WebSocket",
+    "webrtc": "WebRTC",
+    "turn": "TURN",
+    "reconnect": "Erneut verbinden",
+    "selectedCandidate": "Ausgewählte Route",
+    "publishAudio": "Audio veröffentlichen",
+    "publishVideo": "Video veröffentlichen"
+  },
+  "status": {
+    "pending": "Ausstehend",
+    "running": "Läuft…",
+    "success": "Erfolgreich",
+    "failed": "Fehlgeschlagen",
+    "skipped": "Übersprungen"
+  },
+  "counts": {
+    "passed": "erfolgreich",
+    "failed": "fehlgeschlagen",
+    "skipped": "übersprungen"
+  },
+  "summary": {
+    "idle": "Bereit zum Testen",
+    "idleHint": "Der Test dauert ungefähr eine Minute. Ihre Kamera und Ihr Mikrofon werden nur während des Tests verwendet.",
+    "running": "Test wird durchgeführt…",
+    "runningHint": "Lassen Sie diese Seite geöffnet, bis alle Prüfungen abgeschlossen sind.",
+    "passed": "Alles funktioniert",
+    "passedHint": "Ihr Browser, Ihre Geräte und Ihr Netzwerk sind für eine Besprechung bereit.",
+    "partial": "Teilweiser Test",
+    "partialHint": "Einige Prüfungen wurden übersprungen. Erlauben Sie den Zugriff auf Ihre Kamera und Ihr Mikrofon, um diese zu testen.",
+    "failed_one": "{{count}} Prüfung fehlgeschlagen",
+    "failed_other": "{{count}} Prüfungen fehlgeschlagen",
+    "failedHint": "Öffnen Sie die fehlgeschlagenen Prüfungen für weitere Details und senden Sie den Bericht an Ihre IT-Abteilung."
+  },
+  "help": {
+    "firewall": "Wenn Netzwerktests fehlschlagen, überprüfen Sie Ihre Browserberechtigungen und die Netzwerkfilterregeln (WebRTC, WebSocket, TURN) mit Ihrer IT-Abteilung."
+  }
+}

--- a/src/frontend/src/locales/de/global.json
+++ b/src/frontend/src/locales/de/global.json
@@ -36,6 +36,7 @@
       "legalsTerms": "Rechtliche Hinweise",
       "data": "Datenschutz und Cookies",
       "accessibility": "Barrierefreiheit: nicht konform",
+      "connectionTest": "Testen Sie Ihre Konfiguration",
       "ariaLabel": "neues Fenster",
       "codeAnnotation": "Unser Code ist offen und verfügbar in diesem",
       "code": "Open-Source-Repository",

--- a/src/frontend/src/locales/de/home.json
+++ b/src/frontend/src/locales/de/home.json
@@ -13,6 +13,7 @@
   "moreLinkLabel": "Mehr über {{appTitle}} erfahren – neuer Tab",
   "moreLink": "Mehr erfahren",
   "moreAbout": "über {{appTitle}}",
+  "connectionTestLink": "Testen Sie Ihre Konfiguration",
   "createMenu": {
     "laterOption": "Meeting für später planen",
     "instantOption": "Meeting sofort starten"

--- a/src/frontend/src/locales/en/connectionTest.json
+++ b/src/frontend/src/locales/en/connectionTest.json
@@ -21,6 +21,7 @@
     "webrtc": "WebRTC",
     "turn": "TURN",
     "reconnect": "Reconnect",
+    "selectedCandidate": "Selected route",
     "publishAudio": "Audio publishing",
     "publishVideo": "Video publishing"
   },

--- a/src/frontend/src/locales/en/connectionTest.json
+++ b/src/frontend/src/locales/en/connectionTest.json
@@ -1,0 +1,55 @@
+{
+  "title": "Test your configuration",
+  "runTest": "Run test",
+  "runAgain": "Run again",
+  "cancel": "Cancel",
+  "detailsFor": "Details for {{step}}",
+  "downloadReport": "Download report",
+  "homeLink": "Test your configuration",
+  "progress": "{{done}}/{{total}}",
+  "progressLabel": "Connection test progress",
+  "groups": {
+    "local": "Browser and devices",
+    "network": "Server connectivity"
+  },
+  "steps": {
+    "browser": "Browser",
+    "microphone": "Microphone",
+    "camera": "Camera",
+    "devices": "Media devices",
+    "websocket": "WebSocket",
+    "webrtc": "WebRTC",
+    "turn": "TURN",
+    "reconnect": "Reconnect",
+    "publishAudio": "Audio publishing",
+    "publishVideo": "Video publishing"
+  },
+  "status": {
+    "pending": "Pending",
+    "running": "Running…",
+    "success": "Passed",
+    "failed": "Failed",
+    "skipped": "Skipped"
+  },
+  "counts": {
+    "passed": "passed",
+    "failed": "failed",
+    "skipped": "skipped"
+  },
+  "summary": {
+    "idle": "Ready to test",
+    "idleHint": "The test takes about a minute. Your camera and microphone are only used while it runs.",
+    "running": "Testing…",
+    "runningHint": "Keep this page open until every check has finished.",
+    "passed": "Everything works",
+    "passedHint": "Your browser, your devices and your network are ready for a meeting.",
+    "partial": "Partially tested",
+    "partialHint": "Some checks were skipped. Allow access to your camera and microphone to test them.",
+    "failed_one": "{{count}} check failed",
+    "failed_other": "{{count}} checks failed",
+    "failedHint": "Open the failed checks below for details, then send the report to your IT department."
+  },
+  "help": {
+    "firewall": "If network tests fail, check your browser permissions and network filtering rules (WebRTC, WebSocket, TURN) with your IT department."
+  }
+}

--- a/src/frontend/src/locales/en/global.json
+++ b/src/frontend/src/locales/en/global.json
@@ -36,6 +36,7 @@
       "legalsTerms": "Legal Notice",
       "data": "Personal Data and Cookies",
       "accessibility": "Accessibility: non-compliant",
+      "connectionTest": "Test your configuration",
       "ariaLabel": "new window",
       "codeAnnotation": "Our code is open and available on this",
       "code": "Open Source Code Repository",

--- a/src/frontend/src/locales/en/home.json
+++ b/src/frontend/src/locales/en/home.json
@@ -13,6 +13,7 @@
   "moreLinkLabel": "Learn more about {{appTitle}} - new tab",
   "moreLink": "Learn more",
   "moreAbout": "about {{appTitle}}",
+  "connectionTestLink": "Test your configuration",
   "createMenu": {
     "laterOption": "Create a meeting for a later date",
     "instantOption": "Start an instant meeting"

--- a/src/frontend/src/locales/fr/connectionTest.json
+++ b/src/frontend/src/locales/fr/connectionTest.json
@@ -21,6 +21,7 @@
     "webrtc": "WebRTC",
     "turn": "TURN",
     "reconnect": "Reconnexion",
+    "selectedCandidate": "Route sélectionnée",
     "publishAudio": "Publication audio",
     "publishVideo": "Publication vidéo"
   },

--- a/src/frontend/src/locales/fr/connectionTest.json
+++ b/src/frontend/src/locales/fr/connectionTest.json
@@ -1,0 +1,55 @@
+{
+  "title": "Tester votre configuration",
+  "runTest": "Lancer le test",
+  "runAgain": "Relancer",
+  "cancel": "Annuler",
+  "detailsFor": "Détails de l'étape {{step}}",
+  "downloadReport": "Télécharger le rapport",
+  "homeLink": "Tester votre configuration",
+  "progress": "{{done}}/{{total}}",
+  "progressLabel": "Progression du test de connexion",
+  "groups": {
+    "local": "Navigateur et périphériques",
+    "network": "Connexion au serveur"
+  },
+  "steps": {
+    "browser": "Navigateur",
+    "microphone": "Microphone",
+    "camera": "Caméra",
+    "devices": "Périphériques médias",
+    "websocket": "WebSocket",
+    "webrtc": "WebRTC",
+    "turn": "TURN",
+    "reconnect": "Reconnexion",
+    "publishAudio": "Publication audio",
+    "publishVideo": "Publication vidéo"
+  },
+  "status": {
+    "pending": "En attente",
+    "running": "En cours…",
+    "success": "Réussi",
+    "failed": "Échec",
+    "skipped": "Ignoré"
+  },
+  "counts": {
+    "passed": "réussis",
+    "failed": "en échec",
+    "skipped": "ignorés"
+  },
+  "summary": {
+    "idle": "Prêt à tester",
+    "idleHint": "Le test dure environ une minute. Votre caméra et votre microphone ne sont utilisés que pendant le test.",
+    "running": "Test en cours…",
+    "runningHint": "Gardez cette page ouverte jusqu'à la fin des vérifications.",
+    "passed": "Tout fonctionne",
+    "passedHint": "Votre navigateur, vos périphériques et votre réseau sont prêts pour une réunion.",
+    "partial": "Test partiel",
+    "partialHint": "Certaines vérifications ont été ignorées. Autorisez l'accès à votre caméra et à votre microphone pour les tester.",
+    "failed_one": "{{count}} vérification en échec",
+    "failed_other": "{{count}} vérifications en échec",
+    "failedHint": "Ouvrez les vérifications en échec pour voir le détail, puis transmettez le rapport à votre service informatique."
+  },
+  "help": {
+    "firewall": "En cas d'échec des tests réseau, vérifiez vos permissions navigateur et les règles de filtrage réseau (WebRTC, WebSocket, TURN) auprès de votre service informatique."
+  }
+}

--- a/src/frontend/src/locales/fr/global.json
+++ b/src/frontend/src/locales/fr/global.json
@@ -36,6 +36,7 @@
       "legalsTerms": "Mentions légales",
       "data": "Données personnelles et cookie",
       "accessibility": "Accessibilité : non conforme",
+      "connectionTest": "Tester votre configuration",
       "ariaLabel": "nouvelle fenêtre",
       "codeAnnotation": "Notre code est ouvert et disponible sur ce",
       "code": "dépôt de code Open Source",

--- a/src/frontend/src/locales/fr/home.json
+++ b/src/frontend/src/locales/fr/home.json
@@ -13,6 +13,7 @@
   "moreLinkLabel": "En savoir plus sur {{appTitle}} - nouvelle fenêtre",
   "moreLink": "En savoir plus",
   "moreAbout": "sur {{appTitle}}",
+  "connectionTestLink": "Tester votre configuration",
   "createMenu": {
     "laterOption": "Créer une réunion pour une date ultérieure",
     "instantOption": "Démarrer une réunion instantanée"

--- a/src/frontend/src/locales/nl/connectionTest.json
+++ b/src/frontend/src/locales/nl/connectionTest.json
@@ -1,0 +1,56 @@
+{
+  "title": "Je configuratie testen",
+  "runTest": "Test starten",
+  "runAgain": "Opnieuw testen",
+  "cancel": "Annuleren",
+  "detailsFor": "Details van stap {{step}}",
+  "downloadReport": "Rapport downloaden",
+  "homeLink": "Je configuratie testen",
+  "progress": "{{done}}/{{total}}",
+  "progressLabel": "Voortgang van de verbindingstest",
+  "groups": {
+    "local": "Browser en apparaten",
+    "network": "Verbinding met de server"
+  },
+  "steps": {
+    "browser": "Browser",
+    "microphone": "Microfoon",
+    "camera": "Camera",
+    "devices": "Media-apparaten",
+    "websocket": "WebSocket",
+    "webrtc": "WebRTC",
+    "turn": "TURN",
+    "reconnect": "Opnieuw verbinden",
+    "selectedCandidate": "Geselecteerde route",
+    "publishAudio": "Audio publiceren",
+    "publishVideo": "Video publiceren"
+  },
+  "status": {
+    "pending": "In afwachting",
+    "running": "Bezig…",
+    "success": "Geslaagd",
+    "failed": "Mislukt",
+    "skipped": "Overgeslagen"
+  },
+  "counts": {
+    "passed": "geslaagd",
+    "failed": "mislukt",
+    "skipped": "overgeslagen"
+  },
+  "summary": {
+    "idle": "Klaar om te testen",
+    "idleHint": "De test duurt ongeveer één minuut. Je camera en microfoon worden alleen tijdens de test gebruikt.",
+    "running": "Test wordt uitgevoerd…",
+    "runningHint": "Houd deze pagina open totdat alle controles zijn voltooid.",
+    "passed": "Alles werkt",
+    "passedHint": "Je browser, apparaten en netwerk zijn klaar voor een vergadering.",
+    "partial": "Gedeeltelijke test",
+    "partialHint": "Sommige controles zijn overgeslagen. Geef toegang tot je camera en microfoon om deze te testen.",
+    "failed_one": "{{count}} controle mislukt",
+    "failed_other": "{{count}} controles mislukt",
+    "failedHint": "Open de mislukte controles voor meer details en stuur het rapport door naar je IT-afdeling."
+  },
+  "help": {
+    "firewall": "Bij mislukte netwerktests: controleer je browserrechten en netwerkfilterregels (WebRTC, WebSocket, TURN) met je IT-afdeling."
+  }
+}

--- a/src/frontend/src/locales/nl/global.json
+++ b/src/frontend/src/locales/nl/global.json
@@ -35,6 +35,7 @@
       "legalsTerms": "Wettelijke kennisgeving",
       "data": "Persoonlijke gegevens en cookies",
       "accessibility": "Toegankelijkheid: audit in uitvoering",
+      "connectionTest": "Test je configuratie",
       "ariaLabel": "nieuw venster",
       "codeAnnotation": "Onze code is open en beschikbaar op dit",
       "code": "Open Source Code Repository",

--- a/src/frontend/src/locales/nl/home.json
+++ b/src/frontend/src/locales/nl/home.json
@@ -13,6 +13,7 @@
   "moreLinkLabel": "Meer informatie over {{appTitle}} - nieuw tabblad",
   "moreLink": "Meer informatie",
   "moreAbout": "over {{appTitle}}",
+  "connectionTestLink": "Test je configuratie",
   "createMenu": {
     "laterOption": "Maak een vergadering voor een latere datum",
     "instantOption": "Begin direct een vergadering"

--- a/src/frontend/src/routes.ts
+++ b/src/frontend/src/routes.ts
@@ -20,6 +20,9 @@ const AccessibilityRoute = lazy(
 )
 const RoomRoute = lazy(() => import('@/features/rooms/routes/Room'))
 const FeedbackRoute = lazy(() => import('@/features/rooms/routes/Feedback'))
+const ConnectionTestRoute = lazy(
+  () => import('@/features/diagnostics/routes/ConnectionTest')
+)
 
 const roomIdRegex = new RegExp(`^[/](?<roomId>${flexibleRoomIdPattern})$`)
 
@@ -27,6 +30,7 @@ export const routes: Record<
   | 'home'
   | 'room'
   | 'feedback'
+  | 'connectionTest'
   | 'legalTerms'
   | 'accessibility'
   | 'termsOfService'
@@ -56,6 +60,11 @@ export const routes: Record<
     name: 'feedback',
     path: '/feedback',
     Component: FeedbackRoute,
+  },
+  connectionTest: {
+    name: 'connectionTest',
+    path: '/test-connection',
+    Component: ConnectionTestRoute,
   },
   legalTerms: {
     name: 'legalTerms',

--- a/src/frontend/src/styles/index.css
+++ b/src/frontend/src/styles/index.css
@@ -31,6 +31,19 @@ html.font-opendyslexic {
   border: 0;
 }
 
+/* LiveKit ConnectionCheck appends a temporary <video> to body during publishVideo.
+   Keep it decodable (not display:none) but invisible. */
+body.connection-test-hide-livekit-video > video {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  opacity: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+
 * {
   outline: 2px solid transparent;
 }


### PR DESCRIPTION
## Purpose

Users currently have no reliable way to check browser, media devices, and LiveKit connectivity before joining a room. Support also lacks a simple diagnostic report when people hit network issues (e.g. `could not establish pc connection`).

## Proposal

Add a connection test page that runs local device checks plus LiveKit `ConnectionCheck` (WebSocket, WebRTC, TURN, publish audio/video, etc.), backed by a throttled `GET /api/v1.0/connection-test/` endpoint that issues a short-lived token for an ephemeral room (including for anonymous users). When the run finishes, users can download a JSON report of the results.