### PR TITLE
🩹(all) clear the SonarCloud reliability finding and the lint debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to
 - 💄(frontend) render Avatar initials in uppercase
 - 💄(frontend) improve participant name rendering in the list
 
-## Fixed
+### Fixed
 
 - 🐛(transcription) fix silent bug in speaker assignment
 - 🐛(summary) extend tasks auto retry logic
@@ -36,6 +36,7 @@ and this project adheres to
 - 🐛(backend) allow any string as sub in the API serializer
 - 🐛(frontend) fall back to user.full_name on request-entry
 - 🚸(frontend) show two initials in the Avatar when possible
+- 🩹(all) clear the SonarCloud reliability finding and the lint debt
 
 ## [1.24.0] - 2026-07-21
 

--- a/src/backend/core/tasks/_task.py
+++ b/src/backend/core/tasks/_task.py
@@ -1,4 +1,11 @@
+"""
+Celery task decorator that degrades to a synchronous call when Celery is off.
+"""
+
+# The Celery app is imported lazily so that importing this module does not pull
+# in Celery when CELERY_ENABLED is false.
 # ruff: noqa: PLC0415
+# pylint: disable=import-outside-toplevel
 
 from django.conf import settings
 

--- a/src/frontend/src/features/sdk/utils/CallbackIdHandler.ts
+++ b/src/frontend/src/features/sdk/utils/CallbackIdHandler.ts
@@ -2,9 +2,12 @@ export class CallbackIdHandler {
   private readonly storageKey = 'popup_callback_id'
 
   private generateId(): string {
-    return (
-      Math.random().toString(36).substring(2, 15) +
-      Math.random().toString(36).substring(2, 15)
+    // The id is the only thing guarding /rooms/creation-callback/, which is
+    // unauthenticated, so it comes from the CSPRNG rather than Math.random.
+    const bytes = new Uint8Array(16)
+    crypto.getRandomValues(bytes)
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+      ''
     )
   }
 

--- a/src/summary/tests/unit/test_file_service.py
+++ b/src/summary/tests/unit/test_file_service.py
@@ -143,13 +143,9 @@ def test_media_info_ignores_empty_stream_entry(monkeypatch: pytest.MonkeyPatch) 
 
 def test_extract_audio_from_video():
     """Test that extract_audio_from_video can extract audio from a video file."""
-    path = None
+    path = extract_audio_from_media(MEDIA_INFO_SAMPLE_VISIO)
     # A bit of cleanup logic since this is not a generator
     try:
-        path = extract_audio_from_media(MEDIA_INFO_SAMPLE_VISIO)
         assert path.name.endswith(".m4a")
-    except Exception as e:
-        pytest.fail(f"Failed to extract audio from video: {e}")
     finally:
-        if path and path.exists():
-            path.unlink()
+        path.unlink(missing_ok=True)


### PR DESCRIPTION
The [SonarCloud gate](https://sonarcloud.io/project/overview?id=suitenumerique_meet&branch=main) fails on `main`, so every commit lands red. This clears one of its three failing conditions; the other two need a decision rather than a diff.

```
new code since 2025-07-25
reliability      D → needs A     1 bug              ← this PR
security         C → needs A    63 vulnerabilities
hotspots       27% → needs 100% 24 unreviewed
maintainability  A → passes    175 smells
```

The fourth passes already, and its smells are mostly [helm chart](https://sonarcloud.io/project/issues?id=suitenumerique_meet&branch=main&types=CODE_SMELL&resolved=false&rules=kubernetes%3AS1874) policy, so nothing here touches them.

Revisions come as a force-push, so the branch stays one commit.

---

### [`test_file_service.py`](https://sonarcloud.io/project/issues?id=suitenumerique_meet&branch=main&open=AZ9a08Vl5eIywXzCm_-B): the whole reliability condition

`python:S5779` is the only issue behind it, so removing it takes the rating from D to A.

[`test_extract_audio_from_video`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/summary/tests/unit/test_file_service.py#L144-L155) wrapped its assertion in `except Exception` and re-raised through [`pytest.fail`](https://docs.pytest.org/en/stable/reference/reference.html#pytest-fail), which anchors the failure on that line and blames extraction even when extraction succeeded. Breaking the assertion on purpose now reports `AssertionError` against the real filename.

---

### [`CallbackIdHandler`](https://sonarcloud.io/project/security_hotspots?id=suitenumerique_meet&branch=main&hotspots=AZfAnfWegxBfRvlrJS2b): `Math.random`

The id now comes from [`crypto.getRandomValues`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues), one fixed-length value the size of a UUID, in front of [a view that runs unauthenticated](https://github.com/suitenumerique/meet/blob/8cbcad76/src/backend/core/api/viewsets.py#L589-L612) and deletes the entry on read. Not [`randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), which needs a secure context the SDK cannot assume in an embedder.

---

### [`core/tasks`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/backend/core/tasks/_task.py#L1): a package pylint never walked

No `__init__.py`, so [`pylint meet demo core`](https://github.com/suitenumerique/meet/blob/8cbcad76/.github/workflows/meet.yml#L137) skipped the directory and `_task.py` accumulated violations nobody could see. Pylint really walks it now: a bogus statement there draws a violation.

Adding the package file alone turns `lint-back` red on that debt, so [#1533](https://github.com/suitenumerique/meet/pull/1533) is red today on three convention messages it did not write, and the fix ships with the package file here.

Refs #1545
