### PR TITLE
🎨(all) apply the SonarCloud nits that need no decision

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -20,7 +20,7 @@ COMPOSE_PROJECT="meet"
 # $UNSET_USER environment variable to 1.
 function _set_user() {
 
-    if [ $UNSET_USER -eq 1 ]; then
+    if [[ $UNSET_USER -eq 1 ]]; then
         USER_ID=""
         return
     fi
@@ -57,7 +57,7 @@ function _dc_run() {
     _set_user
 
     user_args="--user=$USER_ID"
-    if [ -z $USER_ID ]; then
+    if [[ -z $USER_ID ]]; then
         user_args=""
     fi
 
@@ -76,7 +76,7 @@ function _dc_exec() {
     echo "🐳(compose) exec command: '\$@'"
 
     user_args="--user=$USER_ID"
-    if [ -z $USER_ID ]; then
+    if [[ -z $USER_ID ]]; then
         user_args=""
     fi
 

--- a/bin/buildpack_postfrontend.sh
+++ b/bin/buildpack_postfrontend.sh
@@ -10,7 +10,7 @@ mkdir -p build/
 mv src/frontend/dist build/frontend-out
 
 ASSETS_DIR=build/frontend-out/assets
-if [ -n "$CUSTOM_LOGO_URL" ]; then
+if [[ -n "$CUSTOM_LOGO_URL" ]]; then
     # Ensure https
     [[ ! "$CUSTOM_LOGO_URL" =~ ^https:// ]] && echo "[custom-logo] ERROR: URL must use HTTPS" >&2 && exit 1
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -37,7 +37,7 @@ update_python_version() {
     print_info "Updating $component version..."
     cd "src/$component"
 
-    if [ ! -f "pyproject.toml" ]; then
+    if [[ ! -f "pyproject.toml" ]]; then
         print_error "pyproject.toml not found in src/$component!"
         exit 1
     fi
@@ -122,7 +122,7 @@ cd -
 # Update CHANGELOG
 print_info "Updating CHANGELOG..."
 
-if [ ! -f "CHANGELOG.md" ]; then
+if [[ ! -f "CHANGELOG.md" ]]; then
     print_error "CHANGELOG.md not found in project root!"
     exit 1
 fi

--- a/src/frontend/src/features/rooms/components/Rating.tsx
+++ b/src/frontend/src/features/rooms/components/Rating.tsx
@@ -176,7 +176,7 @@ const RateQuality = ({
     <Card>
       <H lvl={3}>{t('question')}</H>
       <Bar>
-        {[...Array(maxRating)].map((_, index) => (
+        {[...new Array(maxRating)].map((_, index) => (
           <RACButton
             key={index}
             onPress={() => handleRatingClick(index + 1)}

--- a/src/frontend/src/features/rooms/livekit/components/controls/StartMediaButton.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/StartMediaButton.tsx
@@ -44,7 +44,7 @@ export const StartMediaButton: (
   style.display = canPlayAudio && canPlayVideo ? 'none' : 'block'
 
   return (
-    <button ref={ref} style={style} {...restProps}>
+    <button ref={ref} type="button" style={style} {...restProps}>
       {label ?? `Start ${!canPlayAudio ? 'Audio' : 'Video'}`}
     </button>
   )

--- a/src/frontend/src/features/rooms/livekit/components/effects/EffectsConfiguration.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/effects/EffectsConfiguration.tsx
@@ -438,7 +438,7 @@ export const EffectsConfiguration = ({
           config,
         }
       }),
-      virtualBackgrounds: [...Array(8).keys()].map((index) => {
+      virtualBackgrounds: [...new Array(8).keys()].map((index) => {
         const imagePath = `/assets/backgrounds/${index + 1}.jpg`
         const thumbnailPath = `/assets/backgrounds/thumbnails/${index + 1}.jpg`
         const config: ProcessorConfig = {

--- a/src/frontend/src/features/rooms/utils/generateRoomId.ts
+++ b/src/frontend/src/features/rooms/utils/generateRoomId.ts
@@ -17,7 +17,7 @@ const getRandomChar = () => {
 }
 
 const generateSegment = (length: number): string =>
-  Array.from(Array(length), getRandomChar).join('')
+  Array.from(new Array(length), getRandomChar).join('')
 
 // Generates a unique room identifier following the Google Meet format
 export const generateRoomId = () =>

--- a/src/frontend/src/features/rooms/utils/isRoomValid.ts
+++ b/src/frontend/src/features/rooms/utils/isRoomValid.ts
@@ -11,7 +11,7 @@ export const isRoomValid = (roomIdOrUrl: string) =>
   new RegExp(`^${window.location.origin}/${roomIdPattern}$`).test(roomIdOrUrl)
 
 export const normalizeRoomId = (roomId: string) => {
-  const cleanId = roomId.toLowerCase().replace(/-/g, '')
+  const cleanId = roomId.toLowerCase().replaceAll('-', '')
   if (cleanId.length === 10) {
     return `${cleanId.slice(0, 3)}-${cleanId.slice(3, 7)}-${cleanId.slice(7, 10)}`
   }

--- a/src/frontend/src/utils/formatDate.ts
+++ b/src/frontend/src/utils/formatDate.ts
@@ -4,7 +4,7 @@ export function formatDate(
 ): string {
   const dateObj = date instanceof Date ? date : new Date(date)
 
-  if (isNaN(dateObj.getTime())) {
+  if (Number.isNaN(dateObj.getTime())) {
     return 'Invalid Date'
   }
 
@@ -18,12 +18,12 @@ export function formatDate(
   const pad = (num: number): string => String(num).padStart(2, '0')
 
   let result = format
-  result = result.replace(/YYYY/g, year.toString())
-  result = result.replace(/MM/g, pad(month))
-  result = result.replace(/DD/g, pad(day))
-  result = result.replace(/HH/g, pad(hours))
-  result = result.replace(/mm/g, pad(minutes))
-  result = result.replace(/ss/g, pad(seconds))
+  result = result.replaceAll('YYYY', year.toString())
+  result = result.replaceAll('MM', pad(month))
+  result = result.replaceAll('DD', pad(day))
+  result = result.replaceAll('HH', pad(hours))
+  result = result.replaceAll('mm', pad(minutes))
+  result = result.replaceAll('ss', pad(seconds))
 
   return result
 }

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(({ mode }) => {
       sourcemap: env.VITE_BUILD_SOURCEMAP === 'true',
     },
     server: {
-      port: parseInt(env.VITE_PORT) || 3000,
+      port: Number.parseInt(env.VITE_PORT) || 3000,
       host: env.VITE_HOST ?? 'localhost',
       allowedHosts: ['.nip.io'],
       // In a local dev setup, we proxy the media server ourselves to avoid CORS issues

--- a/src/helm/meet/generate-readme.sh
+++ b/src/helm/meet/generate-readme.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 docker image ls | grep readme-generator-for-helm
-if [ "$?" -ne "0" ]; then
+if [[ "$?" -ne "0" ]]; then
 	git clone https://github.com/bitnami/readme-generator-for-helm.git /tmp/readme-generator-for-helm
 	cd /tmp/readme-generator-for-helm
 	docker build -t readme-generator-for-helm:latest .

--- a/src/sdk/consumer/src/App.tsx
+++ b/src/sdk/consumer/src/App.tsx
@@ -12,12 +12,12 @@ function App() {
         <span>Visio demo app</span>
       </div>
       <div className="group">
-        <label>Subject</label>
-        <input type="text" />
+        <label htmlFor="subject">Subject</label>
+        <input id="subject" type="text" />
       </div>
       <div className="group">
-        <label>Place</label>
-        <input type="text" />
+        <label htmlFor="place">Place</label>
+        <input id="place" type="text" />
       </div>
       <div className="group">
         <label>Visioconference</label>
@@ -27,8 +27,8 @@ function App() {
         />
       </div>
       <div className="group">
-        <label>Description</label>
-        <textarea />
+        <label htmlFor="description">Description</label>
+        <textarea id="description" />
       </div>
       <button
         type="button"


### PR DESCRIPTION
[SonarCloud](https://sonarcloud.io/project/issues?impactSoftwareQualities=RELIABILITY&issueStatuses=OPEN%2CCONFIRMED&id=suitenumerique_meet) reports 31 reliability findings outside the helm templates. Twenty-three of them have exactly one sensible fix and no design call in it. This applies those twenty-three and leaves the rest.

`replaceAll` replaces a global `replace` in [`formatDate`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/utils/formatDate.ts#L21-L26) and [`normalizeRoomId`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/features/rooms/utils/isRoomValid.ts#L14). `[[` replaces `[` in the four scripts, all of which already declare bash, which also removes the word-splitting hazard on the two unquoted expansions in [`_config.sh`](https://github.com/suitenumerique/meet/blob/8cbcad76/bin/_config.sh#L60). `new Array` replaces bare `Array` in three spreads, [`Number.isNaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN) and `Number.parseInt` replace the globals. Three labels in the SDK consumer bind to their inputs, and [`StartMediaButton`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/features/rooms/livekit/components/controls/StartMediaButton.tsx#L47) gets an explicit `type`, which changes nothing today since the frontend contains no `<form>`.

None of this moves a rating. A rating takes the worst finding, and every one of these is LOW or MEDIUM, so the gate reads exactly the same afterwards. They are here because each has a single unambiguous answer, not because the gate asks for them.

Seven are deliberately left, each a decision rather than a fix: the `aria-hidden` on the self-view video, the two Outlook anchors filled from `data-i18n` at runtime, the fourth SDK consumer label, whose control renders an iframe and takes no `id`, the object-literal default in [`fetchUser`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/features/auth/api/fetchUser.ts#L13-L19), and two `charCodeAt` calls in [`mergeProps`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/utils/mergeProps.ts#L76-L77), where `codePointAt` is typed `number | undefined` and the fix costs a `?? 0` on each line, in a comparison the file's own comment says was written for speed. The 33 helm resource requests are a capacity decision and are left too.

eslint at `--max-warnings 0`, prettier and `tsc -b` pass on this revision, and `bash -n` passes on all four scripts.

No CHANGELOG entry: this is internal only, which is the class the repository already leaves out, so it wants the `noChangelog` label.
