### PR TITLE
🐛(frontend) stop the installed app reopening the room it came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to
 - 🐛(frontend) fall back to user.full_name on request-entry
 - 🚸(frontend) show two initials in the Avatar when possible
 - 🩹(all) clear the SonarCloud reliability finding and the lint debt
+- 🐛(frontend) stop the installed app reopening the room it came from
 
 ## [1.24.0] - 2026-07-21
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -36,6 +36,9 @@ WORKDIR /home/frontend
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 
+ARG VITE_APP_TITLE
+ENV VITE_APP_TITLE=${VITE_APP_TITLE}
+
 RUN npm run build
 
 # ---- Front-end image ----

--- a/src/frontend/public/site.webmanifest
+++ b/src/frontend/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/src/frontend/site.webmanifest
+++ b/src/frontend/site.webmanifest
@@ -1,0 +1,18 @@
+{
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -26,6 +26,20 @@ export default defineConfig(({ mode }) => {
             dest: 'assets/mediapipe/wasm',
             rename: { stripBase: 4 },
           },
+          {
+            // Kept out of public/ so the instance title reaches the manifest,
+            // the way index.html gets it through %VITE_APP_TITLE%.
+            src: 'site.webmanifest',
+            dest: '.',
+            transform: (content) => {
+              const title = env.VITE_APP_TITLE
+              return JSON.stringify({
+                ...JSON.parse(content),
+                name: title,
+                short_name: title,
+              })
+            },
+          },
         ],
       }),
       env.VITE_ANALYZE === 'true' &&


### PR DESCRIPTION
[`site.webmanifest`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/public/site.webmanifest#L1) declares no `start_url`, so [the page that linked the manifest becomes one](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/start_url). Rooms are top-level paths in [`routes.ts`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/src/routes.ts#L52), so installing from inside a room gives an app that reopens that room every time it is launched.

The same file ships `name` and `short_name` as empty strings. That is survivable today: Chromium falls back to the document title, which [`index.html`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/index.html#L10) fills from `VITE_APP_TITLE`, so an install on Android is labelled correctly. But [the manifest specification](https://www.w3.org/TR/appmanifest/#name-member) defines no such fallback, so the label rests on behaviour no browser owes us.

The title cannot be hardcoded: the DINUM build sets `VITE_APP_TITLE` to `Visio` in [`docker/dinum-frontend/Dockerfile`](https://github.com/suitenumerique/meet/blob/8cbcad76/docker/dinum-frontend/Dockerfile#L19). Vite substitutes `%VITE_APP_TITLE%` in `index.html` only, and copies `public/` verbatim.

So the manifest moves out of `public/`, declares `start_url`, and [`vite.config.ts`](https://github.com/davd-gzl/meet/blob/0303ec2f/src/frontend/vite.config.ts#L29-L44) writes the title in through the [`viteStaticCopy`](https://github.com/sapphi-red/vite-plugin-static-copy) target already used for the MediaPipe assets. The frontend [`Dockerfile`](https://github.com/suitenumerique/meet/blob/8cbcad76/src/frontend/Dockerfile#L36-L38) declares the `VITE_APP_TITLE` build argument as well, which it never did, so the value [`compose.yml`](https://github.com/suitenumerique/meet/blob/8cbcad76/compose.yml#L165) passes stops being dropped.

Built with the variable set, unset, and on the dev server: `dist/site.webmanifest` carries the right name each time.

Refs #615
