### PR TITLE
💄(frontend) show pointer cursor on interactive switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to
 - 🐛(frontend) stop the installed app reopening the room it came from
 - 🐛(backend) serialize lazy title in summary payload
 - 💄(frontend) show pointer cursor on interactive switches
+- 🐛(frontend) fix icon centering in the Switch primitive
 
 ## [1.24.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to
 - 🩹(all) clear the SonarCloud reliability finding and the lint debt
 - 🐛(frontend) stop the installed app reopening the room it came from
 - 🐛(backend) serialize lazy title in summary payload
+- 💄(frontend) show pointer cursor on interactive switches
 
 ## [1.24.0] - 2026-07-21
 

--- a/src/frontend/src/primitives/Switch.tsx
+++ b/src/frontend/src/primitives/Switch.tsx
@@ -12,6 +12,7 @@ const StyledSwitch = styled(RACSwitch, {
     alignItems: 'center',
     gap: '0.571rem',
     color: 'black',
+    cursor: 'pointer',
     forcedColorAdjust: 'none',
     '& .indicator': {
       position: 'relative',
@@ -79,6 +80,9 @@ const StyledSwitch = styled(RACSwitch, {
       opacity: 0,
       transition: 'opacity 10ms',
       transitionDelay: '0ms',
+    },
+    '&[data-disabled]': {
+      cursor: 'not-allowed',
     },
     '&[data-disabled] .indicator': {
       borderColor: 'primary.200',

--- a/src/frontend/src/primitives/Switch.tsx
+++ b/src/frontend/src/primitives/Switch.tsx
@@ -35,30 +35,29 @@ const StyledSwitch = styled(RACSwitch, {
         transitionDelay: '0ms',
       },
     },
-    '& .checkmark': {
+    '& .checkmark, & .cross': {
       position: 'absolute',
-      display: 'block',
-      top: '50%',
-      right: '0.1rem',
-      transform: 'translateY(-50%)',
-      color: 'primary.800',
-      fontSize: '0.75rem',
-      fontWeight: 'bold',
+      top: 0,
+      bottom: 0,
+      width: '1.313rem', // knob width + 2 × knob margin
+      display: 'grid',
+      placeItems: 'center',
       pointerEvents: 'none',
       zIndex: 1,
+      '& svg': {
+        display: 'block',
+        width: '0.875rem',
+        height: '0.875rem',
+      },
+    },
+    '& .checkmark': {
+      right: 0,
+      color: 'primary.800',
       opacity: 0,
     },
     '& .cross': {
-      position: 'absolute',
-      display: 'block',
-      top: '50%',
-      left: '0.13rem',
-      transform: 'translateY(-50%)',
+      left: 0,
       color: 'white',
-      fontSize: '0.70rem',
-      fontWeight: 'bold',
-      pointerEvents: 'none',
-      zIndex: 1,
       opacity: 1,
       transition: 'opacity 200ms',
       transitionDelay: '0ms',
@@ -115,10 +114,10 @@ export const Switch = ({ children, ...props }: SwitchProps) => (
       <>
         <div className="indicator">
           <span className="checkmark" aria-hidden="true">
-            <RiCheckLine size={16} />
+            <RiCheckLine />
           </span>
           <span className="cross" aria-hidden="true">
-            <RiCloseFill size={16} />
+            <RiCloseFill />
           </span>
         </div>
         {typeof children === 'function' ? children(renderProps) : children}


### PR DESCRIPTION
Set the cursor to a pointer on Switch components when they are actually interactive, so it is visually clear that they can be toggled.